### PR TITLE
feat(#2): plugin scaffold + authoring standard

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "claude-workflow",
+  "version": "0.1.0",
+  "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. Includes 16 skills, shared protocols, authoring tools, and a /new-skill scaffolder.",
+  "author": {
+    "name": "Michal Konopski",
+    "url": "https://github.com/misiekhardcore"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/misiekhardcore/claude-workflow",
+  "repository": "https://github.com/misiekhardcore/claude-workflow",
+  "keywords": [
+    "workflow",
+    "skills",
+    "lifecycle",
+    "feature-development",
+    "tdd",
+    "review",
+    "discovery",
+    "architecture",
+    "implementation",
+    "scaffolder"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.claude/NOTES.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md — claude-workflow plugin
+
+Guidance for Claude Code when the claude-workflow plugin is active.
+
+## Feature Workflow
+
+Pick the lightest path that fits the task:
+
+| Size | Path |
+|---|---|
+| Trivial fix | `/implement` directly |
+| Medium feature | `/discovery` → `/implement` |
+| Large feature / epic | `/discovery` → `/define` → `/implement` |
+
+For the full lifecycle walkthrough — prerequisites, outcomes, and handoffs for each step — see `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md`.
+
+### Canonical example — medium feature
+
+> User: "Add a CSV export button to the reports page."
+>
+> 1. `/discovery` — interview the user, write the issue with acceptance criteria, get explicit approval.
+> 2. `/implement` — `/build` codes against the issue with TDD, `/review` runs specialist reviewers, `/verify` checks each criterion, then PR.
+
+The building blocks: `/describe`, `/specify`, `/architecture`, `/design`, `/build`, `/review`, `/verify`, `/grill-me`, `/wrap-up`, `/prune`, `/compound`.
+
+## Implementation Rules
+
+- **Default to single-agent.** Use `TeamCreate` only for parallelizable work across 3+ independent files or sub-issues.
+- **Use the cheapest viable model.** Skills set their own `model:` and `effortLevel:` — trust them.
+- **Respond concisely.** No filler, no preamble.
+
+## Authoring New Skills
+
+To scaffold a new skill conforming to this standard, run `/new-skill`. It will interview you, generate a conformant `SKILL.md`, and write it to your chosen location.
+
+For the full authoring standard — template shape, `_shared/` file conventions, naming rules — see `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md`.
+
+## Note on `${CLAUDE_PLUGIN_ROOT}`
+
+Skills in this plugin reference shared protocols via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md`. If your Claude Code version does not expand this variable inline in skill body text, the fallback convention is: skills reference `_shared/<file>.md` and Claude resolves the path by globbing against the plugin cache at `~/.claude/plugins/cache/<marketplace>/claude-workflow/<version>/`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Michal Konopski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,77 @@
 # claude-workflow
 
-Workflow skills plugin for Claude Code — a standardized lifecycle for feature development: `/discovery` → `/define` → `/implement`.
+Workflow skills plugin for Claude Code — a standardized lifecycle for feature development.
 
-> **Status**: scaffolding. Not yet released. See [issue #1](https://github.com/misiekhardcore/claude-workflow/issues/1) for the v0.1.0 plan.
+```
+/discovery → /define → /implement
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+           /build  →   /review   →  /verify
+              ▲            │            │
+              └─ fix-brief ◄┴────────────┘
+                            │ (both clean)
+                            ▼
+                   draft PR + /compound
+```
+
+## Install
+
+```bash
+claude marketplace add misiekhardcore/claude-workflow
+```
+
+Then enable it in your project or globally in Claude Code settings.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `/discovery` | Explore a problem and produce a GitHub issue with acceptance criteria |
+| `/define` | Plan architecture and design; produces the implementation handoff |
+| `/implement` | Full build→review→verify cycle, ends with a draft PR |
+| `/build` | Code against an issue's acceptance criteria using TDD |
+| `/review` | Review an implementation; correctness, standards, and conditional specialists |
+| `/verify` | QA verification of every acceptance criterion |
+| `/describe` | Explore and understand a problem space interactively |
+| `/specify` | Turn a problem statement into testable acceptance criteria |
+| `/architecture` | Decide on technical architecture — components, data flow, trade-offs |
+| `/design` | Visual and UX design decisions — layouts, interaction flows |
+| `/grill-me` | Relentless interviewing to stress-test a plan or design |
+| `/compound` | Capture learnings into the Obsidian wiki vault |
+| `/wrap-up` | End-of-session audit; harvests NOTES.md into the issue body |
+| `/prune` | Audit CLAUDE.md and wiki notes for staleness |
+| `/find-skills` | Discover and install skills from the ecosystem |
+| `/resolve-pr-feedback` | Process PR review feedback in bulk |
+| `/new-skill` | Scaffold a new skill conforming to this authoring standard |
+
+## Workflow paths
+
+| Task size | Path |
+|-----------|------|
+| Trivial fix | `/implement` directly |
+| Medium feature | `/discovery` → `/implement` |
+| Large feature / epic | `/discovery` → `/define` → `/implement` |
+
+Full lifecycle walkthrough: [`docs/workflow.md`](docs/workflow.md)
+
+## Authoring standard
+
+This plugin ships an authoring standard for creating new skills:
+
+- **Template**: `_templates/SKILL.template.md` — loose skeleton with placeholders
+- **Convention doc**: `_templates/AUTHORING.md` — when and how to reference `_shared/` protocols
+- **Scaffolder**: `/new-skill` — interactive, generates a conformant `SKILL.md`
+
+Shared protocols live at `_shared/`:
+
+| File | Purpose |
+|------|---------|
+| `handoff-artifact.md` | Five-field structure for cross-phase GitHub issue handoffs |
+| `interviewing-rules.md` | One-question-at-a-time interview protocol |
+| `notes-md-protocol.md` | In-phase NOTES.md memory tier |
+| `compaction-protocol.md` | Context editing → delegation → /compact order |
+
+## License
+
+MIT

--- a/_shared/compaction-protocol.md
+++ b/_shared/compaction-protocol.md
@@ -1,0 +1,60 @@
+# In-Phase Compaction Protocol — Shared
+
+Used by `/build` (and any other long-running phase skill) to keep the working context focused on the current concept. The dominant problem this protocol addresses is **context rot** — attention dilution and stale-framing anchoring as a session accumulates unrelated tool outputs and reasoning paths — not running out of tokens.
+
+This file is reference material — read it on demand when the skill reaches a compaction step. Do not preload.
+
+## Tool order
+
+1. **Context editing first.** Clear stale tool results verbatim. This is rot-immune because nothing is paraphrased.
+2. **Sub-agent delegation second.** If the next bulk read can be delegated, the lead never accumulates the rot in the first place. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` rule 3.
+3. **Summarization-based `/compact` last.** Re-summarization compresses, but it also creates a new lower-fidelity anchor the model will over-attend to. Use only when conversation bulk (not tool output) is the source of pressure.
+
+## When to trigger
+
+Trigger on **concept shifts**, not on a percentage:
+
+- **The next planned action is unrelated to the last several tool results.** Stale results will distort the next decision — clear them.
+- **About to start a new sub-issue or task-list item.** Natural concept boundary.
+- **Just spawned a sub-agent.** The lead can drop the brief; the sub-agent's exploration is already isolated.
+- **About to read a large file or search wide paths.** Delegate to a sub-agent instead — don't compact, prevent.
+- **The auto-compact warning appears.** Stop immediately, run this protocol, then continue. Never let auto-compact run unattended.
+
+A percentage threshold is not used. Rot is a function of concept-mixing, not utilization. A session at 80% on one tight concept is healthier than a session at 30% spanning four.
+
+## Context editing — the default
+
+If the pressure is from tool outputs that have been superseded (file reads after edits, test runs from a previous attempt, doc lookups already internalized), use [context editing](https://platform.claude.com/docs/en/build-with-claude/context-editing) to clear them verbatim. Anthropic reports 84% token reduction in long-running workflows when context editing is used instead of summarization, and — more importantly — it doesn't introduce paraphrase artifacts.
+
+This is the default tool. Reach for `/compact` only when it can't fix the actual pressure source.
+
+## Summarization-based `/compact` — last resort
+
+When you must use it (conversation bulk, not tool output), always emit a preservation note and write the Keep list to `.claude/NOTES.md` *before* compacting. Format:
+
+```
+/compact
+
+Keep: <architectural decisions>; <current task and files in scope>;
+<unresolved bugs or failing tests>; <open questions from the issue>.
+
+Drop: <rejected alternatives>; <tool outputs already acted on>;
+<API docs already internalized>; <exploration that led nowhere>.
+```
+
+**Keep** what the model can't reconstruct from the issue or `.claude/NOTES.md`. **Drop** anything large and replayable.
+
+## Verification
+
+After compaction, run: `Summarize where we are and what the next step is.`
+
+Diff the summary against the Keep list **in `.claude/NOTES.md`**, not from memory — both the summary and the post-compact state draw from the same now-truncated context, so an in-context check has limited diagnostic power. If anything from the Keep list is missing, **restate it explicitly before the next tool call**. If the summary looks hollow, abort and re-read the issue + `./.claude/NOTES.md`.
+
+## Rules
+
+- **Compaction is a build-time responsibility.** Do not defer it to `/wrap-up` — by then it's too late.
+- **Each step in the tool order is more lossy than the previous.** Reach for `/compact` only after context editing and delegation have been ruled out.
+
+## Why
+
+In-place summarization can silently drop architectural decisions that only matter three steps later — and the resulting summary becomes the new "early context" the model over-anchors on, recreating the rot pattern at a smaller scale. Context editing avoids both failure modes by deleting rather than paraphrasing. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` for the full rationale.

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -1,0 +1,66 @@
+# Handoff Artifact — Shared Template
+
+Used by phase-boundary skills (`/discovery`, `/define`, `/implement`, `/wrap-up`) to hand off state to the next phase. The GitHub issue body is the artifact. Each phase updates the body in place with the five fields below, then the user resets and starts the next phase in a fresh session.
+
+This file is reference material — read it on demand when the skill reaches a handoff step. Do not preload.
+
+## The five fields
+
+Every handoff artifact contains:
+
+1. **Acceptance criteria** — testable scenarios, unchanged from `/discovery`. One line each.
+2. **Constraints** — files in scope, files out of scope, non-negotiable decisions from `/define`.
+3. **Prior decisions** — "we chose X over Y because Z" entries. One line each. Include links to the conversation or code that produced the decision.
+4. **Evidence** — links to commits, PRs, benchmark output, design reviews, or approvals that justify each decision.
+5. **Open questions** — things the next phase must resolve. Explicit — no "obvious, will figure out later".
+
+## Shape
+
+Always update the **issue body** in place. If a section for the current phase (e.g. `## /define`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids. Keep field order consistent across phases so the next session can scan-read the body top to bottom.
+
+```markdown
+## Handoff: /<prev> → /<next>
+
+**Acceptance criteria** (from /discovery, unchanged)
+- AC1: ...
+- AC2: ...
+
+**Constraints**
+- In scope: <paths>
+- Out of scope: <paths>
+- Must reuse: <existing module/util>
+
+**Prior decisions**
+- <one-line decision> (why: <rationale>)
+- ...
+
+**Evidence**
+- <link to commit | PR | benchmark | design review>
+- ...
+
+**Open questions**
+- <question the next phase must resolve>
+- ...
+```
+
+## Precedence
+
+Two persistent stores, no overlap:
+
+- **The issue body is authoritative for cross-phase state** — acceptance criteria, locked architectural decisions, the handoff fields above.
+- **`.claude/NOTES.md` is authoritative for in-flight state within a phase** — current task, intra-phase decisions not yet promoted, working open questions. See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`.
+
+When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase needs is **promoted** into the issue body (typically by `/wrap-up`). Until promotion, the issue does not know about it. After promotion, the issue body is the source of truth for that item.
+
+## Rules
+
+- **Update the body, not a comment.** Every phase edits the issue body in place — append a new section if one does not exist for the current phase, edit the existing section if it does. Comments are for discussion only.
+- **Reset after updating.** Once the body is updated, tell the user to start the next phase in a fresh session. Do not call the next skill from within the current one.
+- **For cross-phase state, the issue body wins.** If in-context recall disagrees with the body, trust the body.
+- **Never include secrets.** Evidence links should point to internal systems, not pasted API keys, credentials, or internal hostnames in log dumps.
+- **Never drop prior decisions to save space.** If the list is long, that's the workflow working — not a bug.
+- **Open questions are mandatory.** If there are none, say so explicitly ("No open questions") — never omit the section.
+
+## Why this shape
+
+The five fields map to Anthropic's "structured handoff artifact" and OpenAI's `input_type` handoff metadata pattern. Summarization in place loses detail that the next phase needs; a body-update-in-place with this exact shape preserves the surviving content exactly and keeps the handoff scan-readable in a single fetch. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` for the full rationale.

--- a/_shared/interviewing-rules.md
+++ b/_shared/interviewing-rules.md
@@ -1,0 +1,14 @@
+# Interviewing Rules — Shared Protocol
+
+Used by discovery and definition phase skills when interviewing the user to build shared understanding. Read this file when you reach any step that involves asking the user questions or seeking approval.
+
+## Rules
+
+- **Ask one question at a time.** Never bundle multiple questions — wait for a response before moving on.
+- **Grill until fully clear.** Do not accept vague or partial answers; ask follow-up questions until the understanding is concrete and unambiguous.
+- **Prefer multi-choice forms.** When exploring tradeoffs or surfacing constraints, present options as numbered/lettered choices rather than open-ended prompts.
+- **Prefer visual questions.** Use diagrams, tables, and structured visualizations to frame choices and confirm understanding — show, don't just describe.
+- **Require explicit approval before proceeding.** Partial feedback, "sounds good", or silence is NOT approval. Ask directly: "Does this capture it correctly? Can I proceed?"
+- **Never self-approve.** Do not infer approval from a non-objection or the absence of pushback. Wait for the user to explicitly confirm each step.
+- **Do not finish until explicitly approved.** The phase is not complete until the user says so — do not summarize and close on your own initiative.
+- **If a question can be answered by exploring the codebase, explore it instead of asking.** Use your tools to find concrete answers first, then confirm with the user

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -1,0 +1,103 @@
+# NOTES.md — In-Phase Memory Tier
+
+`.claude/NOTES.md` is the **rot-immune external memory** for in-phase state. Because in-context recall degrades as a session accumulates concepts, the model cannot trust its own memory of what it decided ten turns ago — `.claude/NOTES.md` is where that state lives durably, on disk, outside the rotting context.
+
+This file is reference material — read it on demand when a skill creates, updates, or harvests `.claude/NOTES.md`. Do not preload.
+
+## Where it sits in the memory hierarchy
+
+Four tiers, no overlap:
+
+| Tier | Where | Lifetime | Authoritative for |
+|------|-------|----------|-------------------|
+| `TodoWrite` | In-context | This session only | Throwaway working scratchpad |
+| `.claude/NOTES.md` | Worktree-local file (gitignored) | This phase, across sessions | In-flight decisions, current task, open questions |
+| GitHub issue | Remote | Cross-phase | Acceptance criteria, prior-phase decisions, handoff state |
+| Obsidian vault | `memory/wiki/` (git-tracked) | Durable, cross-feature | Compounded knowledge — patterns, bug-fix history, architectural insights |
+
+`TodoWrite` and `.claude/NOTES.md` are not mirrored — they serve different roles, and manual sync invites drift.
+
+## NOTES.md vs the vault's recency channels
+
+The `claude-obsidian` plugin ships its own running-memory mechanisms inside the vault. They look superficially similar to `.claude/NOTES.md` but serve a different purpose — keep the boundary sharp:
+
+| Artifact | Scope | Lifetime | Written by | Committed? |
+|---|---|---|---|---|
+| `.claude/NOTES.md` | One worktree, one feature | Ends when the worktree is removed | `/build` (scratch while coding) | No (gitignored) |
+| `memory/wiki/hot.md` | Whole repo, all work | Cross-session, curated recent context | `/save`, `/compound`, or manual edits | Yes |
+| `memory/wiki/meta/<session>.md` | One session's archive | Permanent | `/save` at session end (Karpathy-style session capture) | Yes |
+| `memory/wiki/log.md` | Whole repo | Permanent, append-only | Every `/save` or `/compound` emits a line | Yes |
+
+Rule of thumb:
+- **While working** — log to `.claude/NOTES.md`. It's phase-local scratch; nothing leaves the worktree.
+- **Between sessions on the same feature** — resume from `.claude/NOTES.md` (it's the authoritative in-flight state).
+- **Between features** — promote durable learnings to `memory/wiki/concepts/` via `/compound` (or the plugin's `/save`). That's what crosses the worktree boundary.
+- **Want a quick "what have I been working on lately" cache across the repo** — that's `memory/wiki/hot.md`, not NOTES.md. Hot cache is curated and committed; NOTES.md is raw and ephemeral.
+
+`/wrap-up` is the bridge: it harvests NOTES.md at clean exit and drafts a GitHub-issue comment, and it's the natural trigger point to ask whether anything in NOTES.md deserves promotion to the vault.
+
+## Location and lifecycle
+
+- **Path:** `<worktree-root>/.claude/NOTES.md`. Resolve the worktree root with `git rev-parse --show-toplevel` if CWD is uncertain. One per worktree, one per feature.
+- **Created by `/build`** at the start of the phase, immediately after `git worktree add`, with the initial task list harvested from the issue.
+- **Updated by `/build`** after each completed task, each significant decision, and before any summarization-based `/compact`.
+- **Read on resume by `/build`** — before re-reading the issue.
+- **Harvested by `/wrap-up`** into a GitHub issue comment on clean exit.
+- **Left in place** after the phase ends. Cleanup happens when the worktree is removed (`wt remove` deletes the worktree directory and `.claude/NOTES.md` goes with it). Do not delete it from within a running phase.
+- **Not committed to git.** Ensure `/.claude/NOTES.md` is gitignored at the repo root before creating it; add the entry if missing.
+
+## Required sections
+
+`.claude/NOTES.md` is a bullet list, not prose. Keep the whole file readable in one screen — it should cost <1k tokens to re-read.
+
+```markdown
+# NOTES — feat/<feature-slug>
+
+## Current task
+- <the one thing you are working on right now>
+
+## Task list
+- [x] <done task>
+- [ ] <pending or in-progress task — first unchecked item is the current one>
+- [!] <blocked task — with reason>
+
+## Decisions made this session
+- <one-line decision> (why: <rationale>)
+- ...
+
+## Open questions
+- <question that needs the user or next phase to resolve>
+
+## Next action on resume
+- <exact command or file to open if the session dies>
+```
+
+## Update cadence
+
+Update at these points (bullet-level only — fast):
+
+- **After each completed task** — flip the checkbox, log any decision that resulted from completing it.
+- **After each significant decision** — one line, with rationale.
+- **Before any summarization-based `/compact`** — write the Keep list into the file *first*, so the post-compaction summary can be diffed against an external record.
+- **Before ending the session normally** — `/wrap-up` will harvest it.
+
+Do not update for trivial moves (opening a file, running a test command). It is a checkpoint log, not a transcript.
+
+## Resume protocol
+
+On a fresh session in an existing worktree, `.claude/NOTES.md` exists ⇒ this is a resume:
+
+1. Read `./.claude/NOTES.md` first.
+2. Read the GitHub issue second (for cross-phase decisions and acceptance criteria).
+3. Resume from **Next action on resume** — or, if that field is stale, from the first unchecked item in the Task list.
+4. Before your first real action, update **Current task** and **Next action on resume** to reflect the new session.
+
+## Rules
+
+- **`.claude/NOTES.md` is authoritative for in-flight state.** In-context recall is rot-degraded by the time the file matters; trust the file.
+- **The issue is authoritative for cross-phase state.** Acceptance criteria, locked architectural decisions, prior-phase handoff content live in the issue, not the file.
+- **Never delete it automatically.** The owning session may archive it on clean exit; do not remove it from within a running phase.
+
+## Why
+
+Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` for the full rationale.

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -1,0 +1,80 @@
+# AUTHORING.md — Skill Authoring Standard
+
+This document defines the authoring conventions for workflow skills in this plugin. Read it when creating or editing a skill, or when `/new-skill` asks which `_shared/` files apply.
+
+## Skill structure
+
+See `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.template.md` for the canonical shape. The template is a loose skeleton — not every section is required for every skill. Use what fits.
+
+### Frontmatter fields
+
+| Field | Required | Values | Notes |
+|-------|----------|--------|-------|
+| `name` | yes | lowercase kebab-case | Matches the directory name under `skills/` |
+| `description` | yes | 1–2 sentences | Primary trigger mechanism — include both what it does and when to use it |
+| `model` | yes | `haiku` \| `sonnet` \| `opus` | See model guide below |
+| `effortLevel` | no | `high` | Only for long-form research/decision-making (discovery, define, architecture, describe) |
+| `allowed-tools` | no | comma-separated tool names | Restrict the skill to a subset of tools. Omit to allow all tools. |
+
+### Model guide
+
+| Model | Use for |
+|-------|---------|
+| `haiku` | Fast lookup, formatting, retrieval, light verification |
+| `sonnet` | Standard multi-step workflows, implementation, review |
+| `opus` | Deep research, architecture, high-stakes decisions with many branches |
+
+## `_shared/` files — when and how
+
+Shared protocols live at `${CLAUDE_PLUGIN_ROOT}/_shared/`. Reference them on-demand from the skill body; do not preload.
+
+### Decision table
+
+| `_shared/` file | Reference when the skill... |
+|---|---|
+| `handoff-artifact.md` | Writes or reads a GitHub issue handoff block (phase-boundary skills: `/discovery`, `/define`, `/implement`, `/wrap-up`) |
+| `interviewing-rules.md` | Interviews the user — asks questions, seeks approval, uses multi-choice forms (`/discovery`, `/define`, `/describe`, `/specify`, `/architecture`, `/design`, `/grill-me`, `/new-skill`) |
+| `notes-md-protocol.md` | Creates, updates, or resumes from `.claude/NOTES.md` (`/build`, `/wrap-up`) |
+| `compaction-protocol.md` | Manages in-phase context — clearing stale tool results, delegating bulk reads, using `/compact` (`/build`) |
+
+### Reference pattern
+
+Add a reference line at the end of the relevant section in the skill body. Use the full `${CLAUDE_PLUGIN_ROOT}` path:
+
+```markdown
+See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.
+```
+
+```markdown
+See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the five-field handoff shape.
+```
+
+```markdown
+See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`.
+```
+
+```markdown
+See `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md`. Context editing first, sub-agents second, `/compact` last.
+```
+
+## Naming conventions
+
+- **Skill directory**: `skills/<name>/` — lowercase kebab-case, matches the `name` frontmatter field.
+- **Entry point**: `skills/<name>/SKILL.md` — always `SKILL.md`, uppercase.
+- **Bundled resources** (optional): `skills/<name>/references/`, `skills/<name>/scripts/`, `skills/<name>/assets/` — same sub-structure as the skill-creator standard.
+
+## Length guidance
+
+- Keep `SKILL.md` under 500 lines. If you're approaching this limit, split domain content into `references/` sub-files and link to them with clear "read when X" guidance.
+- The body is loaded into context on every invocation — keep it focused on instructions, not background narrative.
+
+## Writing style
+
+- Use imperative form: "Read the issue", "Spawn a team", not "You should read" or "The skill reads".
+- Explain the *why* behind non-obvious constraints. A rule without rationale becomes cargo cult.
+- Avoid `ALWAYS` / `NEVER` in all-caps when a reasoned explanation works better — prefer "do X because Y" over "ALWAYS do X".
+- No multi-paragraph docstrings or comment blocks. One short comment line max.
+
+## Dogfooding this standard
+
+The `/new-skill` scaffolder is itself written to conform to this standard. When extending this plugin, run `/new-skill` rather than copying an existing skill by hand.

--- a/_templates/SKILL.template.md
+++ b/_templates/SKILL.template.md
@@ -1,0 +1,34 @@
+---
+name: {{skill-name}}
+description: {{one-to-two sentence description — the primary trigger mechanism. Include both WHAT the skill does AND WHEN to use it (contexts, trigger phrases). Be specific: "Does X. Use when Y." Avoid generic phrasing.}}
+model: {{haiku | sonnet | opus}}
+{{!-- include the line below only if this skill runs long-form multi-turn research or decision-making --}}
+{{!-- effortLevel: high --}}
+{{!-- include the line below only if the skill should be restricted to a subset of tools; omit entirely to allow all tools --}}
+{{!-- allowed-tools: Read, Grep, Glob, Bash --}}
+---
+
+{{!-- optional opening statement — use for phase-boundary skills. Example: "You are leading the X phase. Your job is to..." --}}
+
+## Input
+
+{{what the skill expects — issue number, problem statement, diff, conversation context, etc.}}
+
+## Process
+
+{{numbered steps. Be concrete: what to read first, what to spawn, what to output at each step.}}
+
+1. {{first step}}
+
+2. {{second step}}
+
+## Output
+
+{{what the skill produces — a file, a report, a PR, an updated issue body, etc.}}
+
+## Rules
+
+{{non-negotiable constraints — things that must always or never happen.}}
+
+- {{rule 1}}
+- {{rule 2}}

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,255 @@
+# Development Workflow
+
+A step-by-step walkthrough of the feature lifecycle in this repo: which skill runs when, what it expects as input, and what it leaves behind. The rules themselves live in `CLAUDE.md` and in each `skills/<name>/SKILL.md`; this doc stitches them into a single narrative so a newcomer doesn't have to grep 15 files.
+
+## Workflow paths
+
+Pick the lightest path that fits the task (from `CLAUDE.md`):
+
+| Size | Path |
+|---|---|
+| Trivial fix | `/implement` |
+| Medium feature | `/discovery` → `/implement` |
+| Large feature / epic | `/discovery` → `/define` → `/implement` |
+
+Handoff between phases uses the **GitHub issue body** as the durable artifact — see `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the five-field structure. Within a phase, `./.claude/NOTES.md` is authoritative for in-flight state — see `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`. When context pressure mounts, follow `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` (context editing first, sub-agent delegation second, `/compact` last).
+
+## Quick visual
+
+```
+/discovery ──► (issue w/ AC + handoff) ──► /define ──► (issue w/ arch+design) ──► /implement
+                                                                                       │
+                                                                        ┌──────────────┼──────────────┐
+                                                                        ▼              ▼              ▼
+                                                                     /build  ──►   /review    ─►  /verify
+                                                                        ▲              │              │
+                                                                        └── fix-brief ◄┴──────────────┘
+                                                                                       │ (both clean)
+                                                                                       ▼
+                                                                              draft PR + /compound
+                                                                                       │
+                                                                              [human reviews PR]
+                                                                                       │
+                                                                              /address-review
+```
+
+---
+
+## Step 1 — `/discovery` (Opus, high effort)
+
+- **File:** `skills/discovery/SKILL.md`
+- **When:** Start of any non-trivial feature or bug. Triggered by prompts like "add X" or "fix Y".
+- **Prerequisites:** A user-provided problem statement. Nothing else.
+- **What it does:** Creates or updates a GitHub epic issue, then classifies scope (Lightweight / Standard / Deep) and dispatches:
+  - `/describe` (`skills/describe/SKILL.md`) — a problem analyst + domain researcher interview the user and scan the codebase for existing patterns.
+  - `/specify` (`skills/specify/SKILL.md`) — happy-path + edge-case analysts turn the problem statement into testable GIVEN/WHEN/THEN acceptance criteria.
+  - On Deep scope, adds a flow analyst and adversarial questioner in parallel.
+- **Outcome:** A live GitHub issue containing a problem statement and the five-field handoff block. **User approval is required** before moving on.
+- **Hands off to:** `/define` (for large work) or `/implement` (for medium work).
+
+### Five-field handoff block
+
+Every issue body produced by `/discovery` contains exactly these five fields:
+
+1. **Problem statement** — what is broken or missing and why it matters.
+2. **Acceptance criteria** — a numbered list of verifiable conditions that define "done".
+3. **Out of scope** — explicit exclusions to prevent scope creep.
+4. **Open questions** — anything still unresolved that a downstream phase must not silently assume.
+5. **References** — links to relevant code, docs, or prior issues.
+
+### Re-run semantics
+
+When `/discovery` runs against an existing issue it **rewrites the five-field block wholesale**. No strikethroughs, no dated sub-headings, no `<details>` folds.
+
+- The preamble reads the full current state (issue body + all comments) before rewriting — this is the knowledge-migration step. Anything worth preserving must make it into the new block consciously.
+- If the problem framing has shifted, the problem statement is rewritten. If it has not shifted, it stays byte-identical (no cosmetic rewrites).
+- Acceptance criteria follow the same rule: the old list is overwritten.
+- **Audit trail:** GitHub's native issue edit history holds every prior version. `/discovery` does not try to replicate it.
+
+### Postamble reconciliation (on AC change)
+
+AC are the contract `/implement` verifies against, so silent changes have blast radius. After rewriting AC, `/discovery` checks for downstream artifacts:
+
+| Situation | Action |
+|-----------|--------|
+| A PR is already open | Post on the PR: "Acceptance criteria updated in #\<issue\>. Current AC: \<n/n\> still met, \<n\> changed, \<n\> new. Re-run /address-review or /implement to reconcile." Does **not** close the PR. |
+| Sub-issues exist (from a prior `/define`) | Re-derive each sub-issue's AC slice from the new parent AC. Slices that no longer map get a superseded comment + close. |
+| Neither applies | Pure overwrite, nothing to reconcile. |
+
+---
+
+## Step 2 — `/define` (Opus, high effort) — *skip for medium features*
+
+- **File:** `skills/define/SKILL.md`
+- **When:** After `/discovery`, for epics or architecturally significant work.
+- **Prerequisites:** An approved issue from `/discovery` with acceptance criteria.
+- **What it does:** Spawns research agents (codebase research + patterns/learnings scan against `memory/wiki/`, starting with `memory/wiki/hot.md` and `memory/wiki/index.md`), then dispatches:
+  - `/architecture` (`skills/architecture/SKILL.md`) — codebase analyst + solution architect + devil's advocate converge on a technical approach, producing component diagrams, trade-off tables, and a sub-task dependency graph. Uses `/grill-me` (`skills/grill-me/SKILL.md`) to pin down open decisions with the user.
+  - `/design` (`skills/design/SKILL.md`) — UX researcher + design proposer + a11y reviewer, only when the task has visual aspects. Produces prototypes, wireframes, and interaction flows.
+- **Outcome:** The issue body is updated in place with a `## Define Outcome` section (see below), plus any sub-issues created and linked. **User approval is required** before `/implement`.
+- **Hands off to:** `/implement`.
+
+### Sub-issue inheritance
+
+Each sub-issue receives the same five-field block inherited from the parent epic, pre-populated with the slice of acceptance criteria it covers.
+
+### `## Define Outcome` block
+
+`/define` writes a `## Define Outcome` section into the epic issue body containing:
+
+- The chosen architecture / decomposition rationale.
+- The sub-issue breakdown (list with links) and dependency graph.
+- Any decisions made during define that downstream phases must honour.
+
+### Re-run semantics
+
+Re-running `/define` **replaces the `## Define Outcome` block in place**. No collapsed history.
+
+- The preamble reads the existing block before replacing, so architecture decisions still valid are carried forward intentionally (not by accumulation).
+- If a sub-issue was linked to a specific architecture decision that no longer appears in the new block, the sub-issue link becomes the only remaining reference — this forces the re-run to confront whether the sub-issue is still valid.
+
+### Postamble reconciliation (stale sub-issues)
+
+When `/define` re-runs and the sub-issue breakdown changes, old sub-issues are reconciled explicitly:
+
+| Sub-issue state | Action |
+|-----------------|--------|
+| Still maps cleanly to a slice of the new breakdown | Keep it; update its body with the new AC slice. |
+| No longer maps | Post comment: "Superseded by re-defined scope in #\<epic\>. Closing unless there's work already in flight." Then close. |
+| Maps partially | Leave open; post a comment with the delta; flag in `## Define Outcome` as "needs manual review". |
+
+---
+
+## Step 3 — `/implement` (Sonnet)
+
+- **File:** `skills/implement/SKILL.md`
+- **When:** After `/discovery` (medium) or `/define` (large); directly for trivial fixes.
+- **Prerequisites:** An approved issue with acceptance criteria (plus architecture/design if it's a large feature).
+- **What it does:** Reads the issue and all comments, then orchestrates a `/build → /review → /verify` loop until both pass clean. Maximum 3 cycles before escalating to the user.
+  1. **`/build`** (`skills/build/SKILL.md`, Sonnet) — creates a git worktree, initializes `./.claude/NOTES.md`, spawns an implementation team (TeamCreate only for 3+ parallelizable files), writes code test-driven, commits incrementally with semantic messages, and runs lightweight simplification scans every 2–3 tasks.
+  2. **`/review`** (`skills/review/SKILL.md`, Sonnet high effort) — reviewers run in isolated context against the diff + AC only. Always-on: correctness + standards. Conditional: security / performance / migration based on diff content. Findings are merged, deduped, and confidence-scored. Reviewers report only — they do not fix.
+  3. **`/verify`** (`skills/verify/SKILL.md`, Haiku) — a QA team runs the full verification chain (type-check, lint, unit tests, build, e2e) and checks every acceptance criterion with evidence. Reports pass/fail only — it does not fix.
+  - If review or verify finds issues, a fix-brief (failing AC + file:line findings) is fed back to `/build`, then re-reviewed and re-verified.
+- **Outcome:** A draft PR linking the issue. All acceptance criteria met, review clean, verify clean. `/compound` runs automatically before the PR is opened.
+- **Follow-up:** After human review, use `/address-review`.
+
+### Preamble (read before doing anything)
+
+Before writing any code, `/implement` fetches the issue body **and all comments**. Any comment newer than the last `## Define Outcome` update is treated as material input. If conflicting information is found, `/implement` **halts and asks** — it never silently picks one interpretation.
+
+### Issue comments posted by `/implement`
+
+One comment per meaningful state change. Never more.
+
+| Checkpoint | Comment |
+|-----------|---------|
+| **Start** | `🤖 Starting implementation. Working from ## Define Outcome (last updated <date>). Branch: <branch>. Will post again when a draft PR is open or if the fix-cycle escalates to needs-human.` |
+| **Escalation** (only if max fix-cycle iterations hit or an AC cannot be met) | `🤖 Fix-cycle escalated after N iterations. Blocking issue: <one-line>. Details: <fold with reviewer findings and failing AC>. Need guidance before continuing.` |
+| **PR open** | `🤖 Draft PR opened: #<n>. AC status: <n/n met>. Review + verify clean. Ready for human review.` |
+| **Consolidation** (only if `/compound` wrote new memory notes) | `🤖 Captured learnings: memory/wiki/concepts/<Title Case Name>.md.` |
+
+Not posted: per-commit updates, per-fix-cycle-iteration noise, internal reviewer findings (those belong in the fix-brief, not the issue thread).
+
+### PR body wording
+
+| Situation | PR body contains |
+|-----------|-----------------|
+| PR delivers the full epic | `Closes #<epic>` |
+| PR delivers one sub-issue of many | `Part of #<epic>` |
+
+---
+
+## Step 4 — `/compound` (Sonnet)
+
+- **File:** `skills/compound/SKILL.md`
+- **When:** Automatically after a successful `/implement`. Not a separate user invocation — it is part of `/implement`'s postamble.
+- **What it does:** Files the learning into the Obsidian vault at `memory/wiki/` (Karpathy LLM Wiki pattern, via the `claude-obsidian` plugin). Ensures `memory/wiki/concepts/` exists, searches the vault for overlap (starting at `index.md` and `hot.md`, then drilling into `concepts/`, `entities/`, `sources/`), and either updates an existing note or writes a new one using **Bug Track** (Problem / Symptoms / What Didn't Work / Solution / Why It Works / Prevention) or **Knowledge Track** (Context / Guidance / Why / When / Examples) format. Appends an entry to `memory/wiki/log.md`. When the `claude-obsidian` plugin is active, prefers the plugin's `/save` flow — the plugin keeps frontmatter, cross-links, and the index in sync automatically.
+- **Outcome:** A durable wiki note at `memory/wiki/concepts/<Title Case Name>.md` with frontmatter matching `memory/WIKI.md` (type, domain, tags, related wikilinks, sources). Never auto-deletes or overwrites without flagging.
+
+---
+
+## Step 5 — `/address-review` (Sonnet)
+
+- **File:** `skills/address-review/SKILL.md`
+- **When:** After a PR receives human review comments.
+- **What it does:** Fetches all review threads, triages them, spawns a fix team (one agent per disjoint file group), runs up to 2 fix-verify cycles per review round, then posts a verdict reply on every thread and resolves threads where appropriate.
+- **Outcome:** PR feedback processed in bulk with verdict replies posted, and resolved threads marked resolved. Safe to re-run for subsequent review rounds.
+
+### Verdict table
+
+| Verdict | Reply posted? | Thread resolved? | Rationale |
+|---------|--------------|-----------------|-----------|
+| `fixed` | Yes — with commit SHA | Yes — auto-resolve | Acted on the request exactly as asked. |
+| `fixed-differently` | Yes — with rationale + commit SHA | Yes — auto-resolve | Addressed the underlying concern; reviewer can re-open if unhappy. |
+| `replied` | Yes — discussion only, no code change | No — leave open | Asking or disagreeing; reviewer owns the next move. |
+| `not-addressing` | Yes — with rationale | No — leave open | Declining is a human-to-human decision; reviewer resolves it (or insists). |
+| `needs-human` | Yes — escalation context | No — leave open | Could not act confidently; leaving open keeps it visible on the unresolved count. |
+
+### Verdict tag in reply
+
+Every reply ends with a machine-readable tag so future runs can skip already-handled threads:
+
+```
+Fixed in abc1234 — replaced the N+1 loop with a single JOIN (benchmarks in commit body).
+<!-- verdict: fixed -->
+```
+
+### Idempotency and re-opened threads
+
+`/address-review` fetches the current state of each thread before acting. If it sees its own previous verdict tag and no new comments since, it skips that thread. If a reviewer unresolves a thread `/address-review` previously resolved, the next run treats it as a fresh triage entry (up to the 2-cycle cap per round).
+
+---
+
+## Step 6 — `/wrap-up` (Sonnet) — *optional, end of session*
+
+- **File:** `skills/wrap-up/SKILL.md`
+- **When:** End of a long or complex session, or when transitioning between phases mid-work.
+- **What it does:** Reads `./.claude/NOTES.md`, identifies assumptions, uncertain decisions, scope changes, and follow-ups, then drafts an update to the active issue body (never auto-applies).
+- **Outcome:** An audit block the user can paste into the issue — Assumptions Made / Uncertain Decisions / Scope Notes / Follow-ups.
+
+---
+
+## Consistency rule: replace in place
+
+The following three regions are always rewritten in place on re-run. None accumulate history inline.
+
+| Region | Written by |
+|--------|-----------|
+| Problem statement | `/discovery` |
+| Acceptance criteria | `/discovery` |
+| `## Define Outcome` block | `/define` |
+
+Each re-running phase reads the existing region before overwriting so carry-forwards are deliberate. Stale downstream artifacts (sub-issues, open PRs) get a reconciliation pass in the phase's postamble.
+
+---
+
+## Audit surface
+
+No phase contract tries to be its own audit log. The canonical audit sources are:
+
+1. **GitHub edit history** — every prior version of issue/PR bodies.
+2. **Issue comments from `/implement` checkpoints** — a permanent timeline (comments are not edited, only added).
+3. **`memory/wiki/`** (Obsidian vault) — when a re-run captures a new note via `/compound` or `/save`, that note (plus its entry in `memory/wiki/log.md`) is the permanent record of "the second attempt shipped this way".
+
+All three are read-only from the perspective of downstream phases.
+
+---
+
+## Memory hierarchy
+
+Four tiers, no overlap:
+
+| Tier | Location | Lifetime | Authoritative for |
+|---|---|---|---|
+| `TodoWrite` | In-context | This session only | Throwaway working scratchpad |
+| `./.claude/NOTES.md` | Worktree-local | This phase, across sessions | In-flight decisions, current task, open questions |
+| GitHub issue body | Remote | Cross-phase | Acceptance criteria, prior-phase decisions, handoff state |
+| Obsidian vault | `memory/wiki/` (git-tracked) | Durable, cross-feature | Compounded knowledge — bug-fix history, patterns, architectural insights (written by `/compound` or the plugin's `/save`) |
+
+---
+
+## Maintenance — `/prune` (Haiku)
+
+- **File:** `skills/prune/SKILL.md`
+- **When:** Monthly, or after major refactors.
+- **What it does:** Audits `CLAUDE.md`, memory files, and `memory/wiki/**/*.md` for stale / superseded / unclear entries (semantic staleness; `wiki-lint` complements this for vault-structural health — orphans, broken wikilinks, missing frontmatter). Never auto-deletes — produces recommendations for user approval.


### PR DESCRIPTION
## Summary

Delivers sub-issue #2 [1a] — plugin skeleton and authoring standard for `claude-workflow`. Skill migration lands in #3; personal config cleanup in #4.

## What's in the diff

| Path | What |
|------|------|
| `.claude-plugin/plugin.json` | Manifest (v0.1.0, MIT, 10 keywords) |
| `CLAUDE.md` | Workflow guidance migrated from personal config; documents `${CLAUDE_PLUGIN_ROOT}/_shared/` convention + fallback |
| `README.md` | Install, 17-skill index, authoring standard summary, lifecycle walkthrough link |
| `LICENSE` | MIT |
| `.gitignore` | `.claude/NOTES.md` |
| `_shared/<4 files>` | Verbatim copies (handoff-artifact.md has one intentional path rewrite on line 51) |
| `_templates/SKILL.template.md` | Loose skeleton, placeholders for name/description/model/effortLevel/allowed-tools |
| `_templates/AUTHORING.md` | Decision table for `_shared/` refs, frontmatter guide, naming, style |
| `docs/workflow.md` | Migrated; line 15 `skills/_shared/` refs rewritten to `${CLAUDE_PLUGIN_ROOT}/_shared/` |
| `skills/.gitkeep` | Tree present but empty (populated in #3) |

## Verification

Ran a scoped review + verify (full diff + AC only, isolated context) against all 14 ACs:
- **Review**: CLEAN (0 findings)
- **Verify**: 14/14 PASS
- Verbatim copies byte-identical to source (3 files)
- `handoff-artifact.md` differs from source ONLY at line 51 (intentional `${CLAUDE_PLUGIN_ROOT}` rewrite)
- `docs/workflow.md` differs from source ONLY at line 15 (3 intentional `${CLAUDE_PLUGIN_ROOT}` rewrites)
- No `/home/michal/` or `~/.claude/` paths in shipped files
- `plugin.json` valid per `jq`

## Manual testing

To reproduce locally from this branch:

```bash
# 1. Clone and check out this branch
git clone git@github.com:misiekhardcore/claude-workflow.git
cd claude-workflow
git checkout feat/1a-plugin-scaffold

# 2. Validate structure
jq . .claude-plugin/plugin.json         # valid JSON
ls _shared/                              # 4 files
ls _templates/                           # SKILL.template.md, AUTHORING.md
ls skills/                               # just .gitkeep
cat .gitignore                           # .claude/NOTES.md

# 3. Confirm self-containment
grep -rn '/home/michal\|~/.claude/skills' --include='*.md' --include='*.json' .
# expected: empty (the single '~/.claude/plugins/cache/' in CLAUDE.md is a
# documented fallback example, not a path the plugin depends on)

# 4. Verify verbatim copy
diff _shared/interviewing-rules.md \
     ../claude-config/skills/_shared/interviewing-rules.md        # empty
diff _shared/compaction-protocol.md \
     ../claude-config/skills/_shared/compaction-protocol.md       # empty
diff _shared/notes-md-protocol.md \
     ../claude-config/skills/_shared/notes-md-protocol.md         # empty

# 5. Verify intentional single-line rewrites
diff _shared/handoff-artifact.md \
     ../claude-config/skills/_shared/handoff-artifact.md
# expected: one hunk at line 51 — skills/_shared/ → ${CLAUDE_PLUGIN_ROOT}/_shared/

diff docs/workflow.md \
     ../claude-config/docs/workflow.md
# expected: one hunk at line 15 — three skills/_shared/ → ${CLAUDE_PLUGIN_ROOT}/_shared/ rewrites
```

## Downstream

- **#3** (skill migration) is unblocked once this merges.
- **Open questions carried into #3**: verify `${CLAUDE_PLUGIN_ROOT}` expansion inline in skill body text. Fallback path (glob plugin cache) already documented in `CLAUDE.md`.

Closes #2
Part of #1