### PR TITLE
feat(#3): migrate 16 skills + /new-skill scaffolder

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: architecture
+description: Explore and decide on technical architecture for a feature. Targeted grill-me wrapper for making structural decisions — components, data flow, APIs, dependencies.
+model: opus
+effortLevel: high
+---
+
+You are leading an architecture team. Your job is to explore technical approaches with the user and converge on the right architecture for the feature.
+
+## Input
+
+A GitHub issue with problem statement and acceptance criteria (from /discovery).
+
+## Process
+
+1. Read the issue and understand the requirements
+
+2. **Dispatch parallel research agents** using TeamCreate before the architecture team begins:
+   - **Codebase research agent** — systematic scan of relevant code: technology stack, module structure, related implementations, naming conventions, existing patterns. Outputs a structured context brief.
+   - **Patterns/learnings agent** — searches `memory/wiki/` (start with `memory/wiki/hot.md` and `memory/wiki/index.md`, then concepts/entities/sources), project documentation, past decision records, and — when local patterns are thin — external documentation via Context7 or web search for relevant prior art and lessons learned.
+
+   **Gate rule**: skip external/web research when codebase research finds 3+ direct pattern examples. Always run full research for security, payments, privacy topics, or when local patterns are thin (fewer than 3 examples).
+
+   Research results feed into the architecture team's context before they begin proposing approaches.
+
+3. **Spawn an architecture team** using TeamCreate, providing them with the research output:
+   - **Codebase analyst** — reviews the research brief and explores specific architectural constraints: module boundaries, deployment topology, and integration points NOT covered by the research scan
+   - **Solution architect** — uses /grill-me to explore approaches with the user, informed by both research and analyst findings
+   - **Devil's advocate** — challenges proposed approaches, identifies risks, edge cases, and scaling concerns
+
+4. Teammates share findings via messages. The analyst feeds context to the architect; the devil's advocate critiques proposals.
+
+5. For each major decision, present **2-3 approaches** with:
+   - Architecture diagram (Mermaid component/sequence diagram)
+   - Trade-off table (pros, cons, complexity, risk)
+   - Code structure preview (directory layout, key interfaces)
+   - Recommended approach with rationale
+
+6. After each decision is resolved, move to the next
+
+7. Define the dependency graph between sub-tasks — what can be parallelized
+
+8. **Auto-deepen thin sections** — scan output for vague language ("appropriate", "as needed", "standard approach"), fewer than 3 concrete decisions, or missing file references. If found, dispatch focused deepening agents (cap 2 rounds). Ask the user first when invoked by another skill.
+
+## Output
+
+Architecture decisions formatted as issue comments:
+
+- Component diagram showing the overall structure
+- Key interfaces and data flow
+- Sub-issues with GitHub relationships if the work decomposes
+- Dependency graph identifying parallelizable work
+- Research summary (what was found, what patterns informed the decisions)
+
+## Rules
+
+- Never propose architecture without reading the existing code first
+- Respect existing patterns unless there's a strong reason to deviate
+- Never leave vague placeholders — every section must have concrete decisions or be explicitly marked as needing user input
+- Research agents run first; architecture team builds on their findings
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: build
+description: Build a feature from a GitHub issue. Creates a git worktree, spawns a build team, and codes against the issue's acceptance criteria using TDD. Use after /define has produced approved architecture decisions.
+model: sonnet
+---
+
+You are leading the build phase. Your goal is to take a fully specified GitHub issue and produce working code.
+
+## Input
+
+A GitHub issue number (with architecture/design decisions from /define) and any additional resources.
+
+## Process
+
+1. Read the issue, all comments, and linked sub-issues to understand the full scope.
+
+2. **Create a git worktree** for the feature (`git worktree add`). Worktrees keep the main workspace clean and let teammates operate in isolation.
+
+   Before creating `./.claude/NOTES.md`, verify `/.claude/NOTES.md` is listed in the repo root `.gitignore`; add it there if missing. Then create `./.claude/NOTES.md` with the initial task list harvested from the issue. This is the living worklog for the phase — it survives unexpected session close and is the resume point if this session dies before `/wrap-up`. See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`.
+
+   **On resume in an existing worktree**, read `./.claude/NOTES.md` *before* re-reading the issue — it has the latest in-flight state. Resume from its **Next action on resume** field.
+
+3. **Spawn an implementation team** using TeamCreate:
+   - Assign each teammate a separate sub-issue or file group to avoid conflicts
+   - Teammates communicate peer-to-peer, share discoveries, and flag potential conflicts
+   - The lead coordinates via the shared task list and merges results
+
+4. Each teammate follows **test-driven development (TDD)** for logic-heavy code:
+   - Write a failing test first — derive test cases from the acceptance criteria
+   - Implement until the test passes — minimal code to satisfy the test
+   - Refactor — clean up while tests stay green
+   - Skip TDD for pure boilerplate/wiring
+
+5. **Verify before marking done** — run `superpowers:verification-before-completion` after each task. Mandatory, no user approval needed; fix any gaps before committing.
+
+6. **Simplify as you go** — after every 2-3 task completions from the task list, do a quick consolidation scan:
+   - Review files you just touched for obvious duplication, dead code, or consolidation opportunities
+   - This is NOT a full refactor — just a fast scan for low-hanging improvements
+   - If found, create a micro-task to consolidate before proceeding to the next implementation task
+   - Keep it lightweight: "scan for obvious duplication in files you just touched"
+
+7. **Keep context focused.** Trigger on **concept shifts**, not on a percentage:
+   - Stale tool results in context after the work has moved on → clear them with **context editing** (verbatim — the default tool).
+   - About to read a large file or grep wide paths → delegate to a sub-agent that returns a focused report (the lead never accumulates the bulk).
+   - About to start a new sub-issue, or just spawned a sub-agent → natural reset point.
+   - If summarization-based `/compact` is unavoidable: flush the working set into `./.claude/NOTES.md` first, emit a `Keep: / Drop:` note, run `/compact`, then diff the post-compaction summary against the Keep list **in `.claude/NOTES.md`** before the next tool call.
+
+   See `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md`. Context editing first, sub-agents second, `/compact` last.
+
+8. Commit changes incrementally using semantic commit messages (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`). Update `./.claude/NOTES.md` after each completed task — it is the resume point if the session dies unexpectedly.
+
+## Output
+
+A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for /review.
+
+## Rules
+
+- Use superpowers:test-driven-development for the TDD workflow
+- Use worktrunk (`wt`) for worktree management
+- Use TeamCreate for team coordination
+- Do not ask the user whether to use teams — just use them
+- Do not open a PR — that happens after /implement completes the full cycle
+- Always run the 5-question verification check before marking a task done
+- Consolidation scans are lightweight — spend seconds, not minutes
+- Context hygiene is a build-time responsibility, not a wrap-up afterthought — trigger on concept shifts, not percentages, and never let auto-compact run unattended
+- `./.claude/NOTES.md` is authoritative for in-flight state; if your recall disagrees with the file, trust the file

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: compound
+description: Capture learnings from completed work into durable, searchable wiki notes. Invoke when the user says "it's fixed", "that worked", "working now", or explicitly via /compound — also after a non-trivial debugging session or implementation concludes successfully. Turns ephemeral knowledge into reusable artifacts in the Obsidian vault at memory/wiki/.
+model: sonnet
+---
+
+You are leading the knowledge compounding phase. Your job is to capture what was just learned — the fix, the insight, the pattern — into a durable artifact that future agents and developers can discover and reuse.
+
+The target is the Obsidian vault at `memory/wiki/`, powered by the `claude-obsidian` plugin (Karpathy's LLM Wiki pattern). The vault's schema is in `memory/WIKI.md` and vault-scoped instructions are in `memory/CLAUDE.md`. If the `claude-obsidian` plugin is enabled, prefer its `/save` flow — it handles frontmatter, cross-links, and the operation log automatically. This skill describes the same workflow for the direct-file case and adds dedupe/discoverability checks on top.
+
+## Input
+
+The current conversation context — a completed debugging session, feature implementation, or fix.
+
+## Process
+
+### Mode Selection
+
+Assess the complexity of what was just learned:
+
+- **Lightweight** — simple fix, single root cause, no cross-cutting concerns. Single-pass extraction, no sub-agents.
+- **Full** — multi-step debugging, non-obvious root cause, or pattern that applies broadly. Parallel sub-agents for thorough extraction.
+
+Decision tree:
+1. Is this a pattern others will hit? → Full
+2. Did debugging involve multiple hypotheses or files? → Full
+3. Was the fix a one-liner or config change with obvious cause AND unlikely to recur? → Lightweight
+4. Is the user explicitly asking for a quick capture? → Lightweight
+
+### Lightweight
+
+Single-pass extraction. Work through these steps yourself:
+
+1. Ensure `memory/wiki/concepts/` exists — create it if missing. (The `/wiki` command scaffolds the full vault if anything else is missing.)
+2. Identify the problem and solution from the conversation history.
+3. Search `memory/wiki/` for existing notes with overlapping content (same module, component, or symptoms). Start with `memory/wiki/index.md` and `memory/wiki/hot.md`; grep `memory/wiki/concepts/`, `memory/wiki/entities/`, and `memory/wiki/sources/` for related material.
+   - **High overlap** (same root cause or very similar symptoms) → update the existing note instead of creating a new one. Bump `updated:` in the frontmatter.
+   - **Partial overlap** (related but distinct) → create a new note, add the related note to the `related:` list and a wikilink in "See Also".
+   - **No overlap** → create a new note.
+4. Write the wiki note (see Knowledge Tracks and Output Format below).
+5. Append a one-line entry to `memory/wiki/log.md` describing what was filed.
+6. Verify discoverability: check whether `CLAUDE.md` or project-level instructions point at `memory/wiki/`. If not, suggest adding a line like: `Check memory/wiki/ (start with hot.md, then index.md) for known issues and patterns before debugging.` Do not modify CLAUDE.md automatically — present the suggestion to the user.
+7. **Staleness check** — scan `memory/wiki/` for notes the new learning contradicts or supersedes. If conflict exists, flag it for consolidation (do not auto-delete — present the conflict to the user). `wiki-lint` can help.
+
+### Full
+
+1. Ensure `memory/wiki/concepts/` exists — create it if missing.
+
+2. **Spawn a compounding team** using TeamCreate with three specialists:
+   - **Context analyst** — reviews the full conversation history and git diff to extract: what broke, what was tried, what worked, and why.
+   - **Solution extractor** — distills the fix into a reusable pattern: root cause, solution steps, prevention guidance.
+   - **Overlap scanner** — searches `memory/wiki/` (concepts/entities/sources + index + hot cache) and project docs for existing coverage. Reports whether to create new or update existing:
+     - **High overlap** (same root cause or very similar symptoms) → update the existing note with new findings.
+     - **Partial overlap** (related but distinct) → create new note, add a wikilink to the related note in `related:` and "See Also".
+     - **No overlap** → create new note.
+
+3. Teammates share findings via messages. The overlap scanner's verdict determines whether we create or update.
+
+4. Synthesize team findings into a wiki note.
+
+5. Append an entry to `memory/wiki/log.md`.
+
+6. Verify discoverability: check whether `CLAUDE.md` or project-level instructions point at `memory/wiki/`. If not, suggest adding a line like: `Check memory/wiki/ (start with hot.md, then index.md) for known issues and patterns before debugging.` Do not modify CLAUDE.md automatically — present the suggestion to the user.
+
+7. **Staleness check** — scan `memory/wiki/` for notes the new learning contradicts or supersedes. If the new note contradicts or replaces an existing one, flag it for consolidation (do not auto-delete — present the conflict to the user). `wiki-lint` is the plugin's complementary audit.
+
+## Output
+
+### Knowledge Tracks
+
+Choose the track that fits what was learned. Both end up under `memory/wiki/concepts/` — they differ in frontmatter tags and body shape.
+
+#### Bug Track
+Use when the learning came from fixing a bug or unexpected behavior. Tag with `bug-fix`.
+
+```markdown
+## Problem
+<!-- What went wrong — observable symptoms -->
+
+## Symptoms
+<!-- How it manifested — error messages, failing tests, user reports -->
+
+## What Didn't Work
+<!-- Approaches tried that failed — saves future debuggers time -->
+
+## Solution
+<!-- The actual fix — code changes, config changes, commands -->
+
+## Why It Works
+<!-- Root cause explanation — why the fix addresses the underlying issue -->
+
+## Prevention
+<!-- How to avoid this in the future — tests, linting rules, patterns -->
+```
+
+#### Knowledge Track
+Use when the learning is a pattern, technique, or architectural insight. Tag with `pattern`, `technique`, or `architecture`.
+
+```markdown
+## Context
+<!-- When this knowledge applies — project area, tech stack, situation -->
+
+## Guidance
+<!-- The insight or pattern — what to do -->
+
+## Why
+<!-- Rationale — why this approach over alternatives -->
+
+## When to Use
+<!-- Conditions that make this the right choice -->
+
+## Examples
+<!-- Concrete code examples or references -->
+```
+
+### Output Format
+
+Create (or update) a Markdown file under `memory/wiki/concepts/` with this frontmatter shape (matches the vault schema in `memory/WIKI.md`):
+
+```markdown
+---
+type: concept
+title: "<Descriptive Title>"
+complexity: basic | intermediate | advanced
+domain: <module or area — e.g. workflow, auth, payments>
+aliases:
+  - "<alternate phrasing>"
+created: <YYYY-MM-DD>
+updated: <YYYY-MM-DD>
+tags:
+  - <track tag — bug-fix | pattern | technique | architecture>
+  - <domain tag>
+  - <specific tag>
+status: draft | mature | deprecated
+related:
+  - "[[<related wiki note title>]]"
+  - "[[concepts/_index]]"
+sources:
+  - "<url or internal ref>"
+---
+
+# <Descriptive Title>
+
+<!-- Knowledge track content here (Bug Track or Knowledge Track) -->
+
+## See Also
+
+- `[[<related note>]]`
+- `<path/to/skill>` when relevant
+```
+
+File naming: `memory/wiki/concepts/<Descriptive Title>.md` (Title Case with spaces, matching the existing vault convention — e.g. `Compounding Knowledge.md`). Do not kebab-case; Obsidian wikilinks match the file title.
+
+## Rules
+
+- Capture knowledge while it's fresh — don't defer.
+- Prefer updating existing notes over creating duplicates.
+- Keep notes concise — future readers want answers, not narratives.
+- Include actual error messages and stack traces in symptoms — these are what people search for.
+- Never include secrets, tokens, or credentials in wiki notes.
+- Always add at least one wikilink in `related:` and one in "See Also" so the graph stays connected — orphans are surfaced by `wiki-lint`.
+- If the `claude-obsidian` plugin is active and a `/save` invocation would produce the same artifact, prefer `/save` — the plugin's schema, index, and log updates stay in sync automatically.

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: define
+description: Full definition phase — plan architecture and design for a feature. Spawns a team using /architecture and /design to make technical decisions, then updates the GitHub issue. Use after /discovery has produced an approved issue.
+model: opus
+effortLevel: high
+---
+
+You are leading the definition phase. Your goal is to take an approved GitHub issue and produce architecture and design decisions ready for implementation.
+
+## Input
+
+A GitHub issue number from /discovery (or provided by the user).
+
+## Process
+
+1. Read the issue to understand the problem statement and acceptance criteria.
+
+2. **Dispatch a research team** (TeamCreate) before the definition team:
+   - **Codebase research agent** — scans tech stack, modules, related implementations, naming, existing patterns. Outputs a structured brief.
+   - **Patterns/learnings agent** — searches `memory/wiki/` (start with `hot.md` and `index.md`, then concepts/entities/sources), project docs, past decisions, and (when local patterns are thin) external sources via Context7. Skip external research when 3+ direct pattern examples exist; always run full research for security/payments/privacy.
+
+   The brief feeds both the architecture and design specialists as seed context.
+
+3. **Spawn a definition team** using TeamCreate with specialists:
+   - **Architecture specialist** — runs /architecture to explore technical approaches, seeded with research output. Pass the research brief as input — the Architecture specialist skips its own research phase when a research brief is provided. Produces component diagrams, data flow, API design, dependency graphs.
+   - **Design specialist** (if the feature has visual aspects) — runs /design to explore UI/UX approaches, seeded with research output. Produces mockups, interaction flows, component hierarchies.
+
+4. The architecture specialist goes first. Once technical decisions are approved by the user, the design specialist (if applicable) works within those constraints.
+
+5. **Update the GitHub issue body** with decisions. The body is the handoff artifact, single source of truth — always update it in place, never post handoff state as a comment:
+   - If the body already has a `## /define` section, edit it. If not, append one.
+   - Record architecture decisions and design decisions (with visuals) inside that section.
+   - Create sub-issues with GitHub relationships if the work decomposes.
+   - Define the dependency graph — identify what can be parallelized.
+   - The updated body is the sole input to `/implement` — a fresh session will read it, not this conversation. Include all five handoff fields (Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions). See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
+
+6. Present all decisions to the user for approval. Do not proceed until sign-off.
+
+7. After sign-off, instruct the user: "Start `/implement` in a fresh session; this one is closed." Do not call `/implement` from within `/define`.
+
+## Rules
+
+- **Require explicit full approval** before finalizing. Partial feedback is NOT approval.
+- For complex tasks, spawn a second team to critique the plan before finalizing
+- Respect existing codebase patterns unless there's a strong reason to deviate
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: describe
+description: Explore and understand a problem space interactively. Targeted grill-me wrapper for discovering what to build — uses visualizations, user stories, and comparisons to build shared understanding.
+model: opus
+effortLevel: high
+---
+
+You are leading a product discovery team. Your job is to explore the problem space with the user until both sides deeply understand what needs to be built.
+
+## Phase 0 — Scope Assessment
+
+Before starting, classify the task scope:
+
+1. **Lightweight** — trivial fix, clear requirements, single file or well-understood change
+   - Skip sub-agents. Single-pass problem statement.
+   - Skip the Product Pressure Test.
+   - Go directly to Output.
+2. **Standard** — typical feature or fix with some unknowns
+   - Current behavior: spawn team, visuals, grill-me.
+   - Run the Product Pressure Test.
+3. **Deep** — complex cross-cutting change, security/auth/payments, architecture change, or multi-team impact
+   - Full team plus extra research sub-agents for prior art, competitive analysis, and failure mode exploration.
+   - Run the Product Pressure Test.
+
+Decision tree:
+
+1. Can the user describe the full change in one sentence AND it touches one file? → Lightweight
+2. Does it cross module boundaries, touch auth/security/payments, or require architecture decisions? → Deep
+3. Otherwise → Standard
+
+## Process
+
+### Standard / Deep
+
+1. Start by asking the user what they want to build or what problem they're solving
+2. **Spawn a discovery team** using TeamCreate:
+   - **Problem analyst** — uses /grill-me to interview the user: who is this for, what problem does it solve, what does success look like, what's out of scope
+   - **Domain researcher** — explores the codebase and external context in parallel: existing patterns, related features, prior art, constraints
+   - _(Deep only)_ **Prior art researcher** — searches for how similar problems have been solved in this codebase, adjacent projects, and industry. Reports patterns, anti-patterns, and failure modes.
+3. Teammates share findings via messages. The domain researcher surfaces codebase context that informs the analyst's questions.
+4. **Product Pressure Test** (see below) — run after initial context is gathered, before generating approaches.
+5. For each major concept or decision point, **produce a visual**:
+   - User journey → flowchart or sequence diagram (Mermaid)
+   - Feature comparison → table
+   - System boundaries → ASCII or Mermaid diagram
+   - Data relationships → entity diagrams
+   - Alternatives → side-by-side comparison tables with trade-offs
+6. After each visual, confirm understanding before moving on
+7. Synthesize team findings into a structured problem statement
+
+### Lightweight
+
+1. Ask the user to confirm the problem and desired outcome
+2. Explore the codebase briefly to validate assumptions
+3. Produce the problem statement directly
+
+### Product Pressure Test
+
+Run this between context exploration and problem statement synthesis (Standard and Deep only). Work through these three questions with the user, one at a time, grill-me style — present your assessment and recommendation, then ask for the user's take:
+
+1. **"Is this the right problem?"** — Validate the problem statement isn't a symptom of something deeper. Look at the codebase and the user's description — is there an underlying cause that, if addressed, would eliminate this problem and others?
+
+2. **"What if we do nothing?"** — Assess the cost of inaction. Who is affected, how often, and how badly? If the cost is low, maybe this isn't worth building yet.
+
+3. **"What's the highest-leverage move?"** — Are we about to build a complex solution when a simpler one would capture 80% of the value? Is there a smaller change that unblocks the most users?
+
+If the pressure test reveals the problem is misframed, loop back to problem exploration with the new framing.
+
+## Output
+
+A clear problem statement with:
+
+- **What** we're building (1-2 sentences)
+- **Why** it matters (the problem it solves)
+- **Who** it's for
+- **Scope boundaries** (what's in, what's out)
+
+Hand this output to /specify for requirements extraction.
+
+## Rules
+
+- Always recommend an answer for each question
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: design
+description: Explore visual and UX design for a feature. Targeted grill-me wrapper for making design decisions — UI layouts, interaction flows, component structure.
+model: sonnet
+---
+
+You are leading a design team. Your job is to explore visual and interaction design approaches with the user and converge on the right design for the feature.
+
+## Input
+
+A GitHub issue with architecture decisions (from /define).
+
+## Process
+
+1. Read the issue and architecture decisions to understand constraints
+2. **Spawn a design team** using TeamCreate:
+   - **UX researcher** — explores existing UI patterns in the codebase, accessibility requirements, and design system constraints
+   - **Design proposer** — uses /grill-me to explore design options with the user, producing prototypes for each approach
+   - **Accessibility reviewer** — evaluates each proposal for a11y compliance, keyboard navigation, and screen reader support
+3. Teammates share findings via messages. The researcher feeds context to the proposer; the a11y reviewer critiques proposals.
+4. For each design decision, present **2-3 visual approaches**:
+   - Code prototypes with screenshots (HTML/React/etc.)
+   - Wireframe diagrams (ASCII or Mermaid)
+   - Interaction flow diagrams (state machines, sequence diagrams)
+   - Component hierarchy trees
+   - Side-by-side comparison of approaches
+5. User picks an approach (or asks for iterations)
+6. The chosen design becomes a constraint for implementation
+
+## Output
+
+Design decisions formatted as issue comments:
+
+- Visual mockups or prototypes
+- Component hierarchy
+- Interaction flow diagram
+- Key design constraints for implementation
+
+## Applicability
+
+This skill applies when the task has visual aspects (UI, webview, frontend). Skip for purely backend or infrastructure work — use /architecture alone for those.
+
+## Rules
+
+- Follow existing design system and component patterns unless explicitly diverging
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: discovery
+description: Full discovery phase — explore a problem and produce a GitHub issue with requirements. Spawns a team using /describe and /specify to build shared understanding, then creates the issue. Use at the start of any new feature.
+model: opus
+effortLevel: high
+---
+
+You are leading the discovery phase. Your goal is to take a vague idea and produce a well-specified GitHub issue ready for architecture and implementation.
+
+## Phase 0 — Scope Assessment
+
+Classify the task before dispatching:
+
+- **Lightweight** — clear repro + single area. Single agent runs /describe (Lightweight) → minimal /specify → issue. No team.
+- **Standard** — typical feature with some unknowns. Team with /describe + /specify specialists.
+- **Deep** — cross-module, auth/security/payments, architecture-changing, or multi-team. Full team + flow analyst + adversarial questioner.
+
+## Process
+
+### Standard
+
+1. **Spawn a discovery team** using TeamCreate with two specialists:
+   - **Describe specialist** — runs /describe to explore the problem space with the user. Produces visualizations, explores user stories, maps boundaries.
+   - **Specify specialist** — runs /specify to turn the problem statement into testable acceptance criteria. Produces concrete GIVEN/WHEN/THEN scenarios.
+
+2. The describe specialist goes first. Once the problem statement is clear and the user has explicitly approved it, hand findings to the specify specialist.
+
+3. The specify specialist drills into requirements. Once acceptance criteria are approved by the user, combine outputs.
+
+### Deep
+
+1. **Spawn an extended discovery team** using TeamCreate with four specialists:
+   - **Describe specialist** — runs /describe (Deep mode) to explore the problem space
+   - **Specify specialist** — runs /specify to produce acceptance criteria
+   - **Flow analyst** — maps the end-to-end flow of the change: what systems are touched, what data moves where, what can break. Produces sequence diagrams and dependency maps.
+   - **Adversarial questioner** — actively challenges assumptions: what if this fails, what's the migration path, what are the security implications, what happens at scale
+
+2. Describe and flow analyst work in parallel. Adversarial questioner waits for both describe and flow analyst to complete, then reviews their combined findings and challenges conclusions. Specify specialist works last, incorporating all concerns.
+
+### Lightweight
+
+1. Run /describe in Lightweight mode — quick problem confirmation
+2. Extract 3-5 core acceptance criteria directly (do not invoke /specify)
+3. Skip to issue creation
+
+### Issue Creation (all modes)
+
+1. **Create a GitHub issue** (`gh issue create`) as a self-contained brief for the next phase. The issue body has two parts:
+
+   **(a) Problem statement preamble** — `/discovery`-only, not part of the handoff field order. From /describe output: what the user is trying to do, why the current state is inadequate, who is affected. This is the framing the rest of the issue depends on. Subsequent phases do not update this section.
+
+   **(b) Handoff block** — the five fields below, in this order, matching `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. Field order is uniform across all phases so the next session can scan-read it.
+   - **Title** — concise feature description
+   - **Acceptance criteria** — from /specify output, as a numbered list of testable scenarios
+   - **Constraints** — explicit in/out scope boundaries, non-negotiable decisions surfaced during discovery
+   - **Prior decisions** — any decisions already made during discovery (one line each, with rationale)
+   - **Evidence** — links to design reviews, benchmarks, prior discussions
+   - **Open questions** — things `/define` must resolve, explicit (say "None" if there are none)
+
+2. Present the issue to the user for approval. Do not proceed until sign-off.
+
+3. After sign-off, tell the user to run `/define` in a fresh session. Do not call `/define` from within `/discovery` — the issue is the handoff artifact, and the next phase must start with clean context.
+
+## Rules
+
+- **Require explicit full approval** before creating the issue. Partial feedback is NOT approval.
+- Every feature has at least one issue and at least one PR closing it
+- Epics get sub-issues linked with GitHub issue relationships (parent/child)
+- The user must approve the issue
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+model: haiku
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+model: sonnet
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: implement
+description: Full implementation cycle — build, review, and verify a feature until ready, then open a PR. Orchestrates /build → /review → /verify in a loop. Use after /define has produced approved architecture decisions.
+model: sonnet
+---
+
+You are orchestrating the full implementation cycle. Your goal is to take a fully defined GitHub issue and produce a ready-to-merge PR.
+
+## Input
+
+A GitHub issue number (with architecture/design decisions from /define) and any additional resources (docs, API specs, etc.).
+
+## Process
+
+### Cycle: build → review → verify
+
+1. **Run /build** — spawns implementation team, codes against the issue
+2. **Run /review** — spawns review team, checks correctness and standards
+3. **Run /verify** — spawns QA team, verifies every acceptance criterion
+
+If /review or /verify report issues:
+- Feed findings back to /build for fixes — pass a **fix brief** (failing criteria + reviewer findings as `file:line` + prior architectural decisions). Do not forward the review/verify session history.
+- Re-run /review and /verify on the fixes
+- Repeat until both pass clean
+
+### PR creation (after cycle passes)
+
+When /review and /verify both pass with no issues:
+
+1. Push the branch to remote
+2. Open a draft PR (`gh pr create --draft`)
+3. Link to the issue:
+   - `Closes #<issue>` — if this is the only/final PR for the issue
+   - `Related to #<issue>` — if this is a partial implementation
+4. PR description must include:
+   - Summary of changes
+   - **Manual testing** section with concrete repro steps someone can follow
+5. Use superpowers:finishing-a-development-branch for PR finalization
+
+### Compound (after PR is open)
+
+6. **Run /compound** — capture learnings from the implementation cycle. If the build involved non-trivial debugging, unexpected edge cases, or architectural surprises, /compound writes them into the Obsidian vault at `memory/wiki/` (concepts/, entities/, or sources/ depending on the shape) so future `/architecture` research can find them.
+
+## Rules
+
+- Do not open a PR until both /review and /verify pass clean
+- Maximum 3 build→review→verify cycles before escalating to the user
+- Each cycle should address all findings from the previous cycle, not just some
+- Keep the user informed of cycle progress (which cycle, what was found, what was fixed)
+- The GitHub issue body is the handoff artifact across phases; every sub-skill reads from and updates it in place. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
+- In-phase state lives in `./.claude/NOTES.md` (read by `/build` on resume) and in the issue body (cross-phase). Do not re-issue instructions already captured in either.

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: new-skill
+description: Scaffold a new skill conforming to the claude-workflow authoring standard. Interviews the author, generates a conformant SKILL.md from the template, and writes it to the chosen location. Use when creating a new skill for personal use, a project, or this plugin.
+model: haiku
+---
+
+You are an interactive skill scaffolder. Your job is to help the author create a new skill that conforms to the claude-workflow authoring standard, without them having to read the standard end-to-end first.
+
+## Input
+
+A brief statement from the author of what the skill should do — or nothing, in which case start with question (a) below.
+
+## Process
+
+1. Read `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.template.md` — the skeleton you will fill in.
+2. Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — the decision table for `_shared/` files and the frontmatter guide. You will quote its guidance back to the author when they are unsure.
+
+3. **Interview the author** — ask ONE question at a time. Do not bundle. See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`.
+
+   a. **Name** — "What's the skill called?" Must be lowercase kebab-case (e.g. `deploy-to-vercel`). Matches the directory name under `skills/`.
+
+   b. **Description** — "In one or two sentences: what does this skill do, and when should it trigger?" Frame as "Does X. Use when Y." This is the primary trigger mechanism — specificity matters more than elegance. If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
+
+   c. **Model** — "Which model fits?" Offer a multi-choice:
+      1. `haiku` — fast lookup, formatting, retrieval, light verification
+      2. `sonnet` — standard multi-step workflows, implementation, review (default)
+      3. `opus` — deep research, architecture, high-stakes decisions
+      Recommend one based on the description. Confirm before moving on.
+
+   d. **effortLevel** — "Does this skill run long-form multi-turn research or decision-making? (y/n)" If yes, add `effortLevel: high`. Otherwise omit the field entirely. Default: no.
+
+   e. **allowed-tools** — "Should the skill be restricted to a subset of tools, or have access to everything? (restricted/all)" Most skills want `all` (omit the field). Only restrict when the skill is narrow and should not e.g. write files.
+
+   f. **Shared protocols** — "Does this skill do any of the following? (yes/no to each)". Walk through the AUTHORING.md decision table:
+      - Write or read a GitHub issue handoff block → include `handoff-artifact.md`
+      - Interview the user, ask questions, seek approval → include `interviewing-rules.md`
+      - Create or read `.claude/NOTES.md` → include `notes-md-protocol.md`
+      - Manage in-phase context (clearing stale results, delegating, `/compact`) → include `compaction-protocol.md`
+
+   g. **Target location** — "Where should the skill be written?" Offer:
+      1. **Personal** — `~/.claude/skills/<name>/SKILL.md` (default, recommended for individual use)
+      2. **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
+      3. **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
+
+4. **Generate the SKILL.md** by filling in `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.template.md`:
+   - Frontmatter: `name`, `description`, `model`; include `effortLevel: high` / `allowed-tools: ...` only when the author opted in
+   - Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
+   - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern").
+
+5. **Show the draft** to the author in a fenced code block. Ask: "Does this look right? Shall I write it to `<target-path>`? (y/n)". Do not write on silence or "looks good" — require an explicit yes.
+
+6. **On yes**: create the directory if needed, write the file. Report the absolute path and tell the author:
+   - "Fill in the Input / Process / Output / Rules sections. The skeleton has placeholders."
+   - "Test by invoking `/<name>` in a new session. Claude loads skills at session start."
+
+7. **On no**: ask which question they want to revise, loop back to that step, regenerate.
+
+## Output
+
+A single file written to the chosen target location, conforming to the authoring standard. Empty skeleton sections that the author fills in afterwards — this skill scaffolds the frame, not the domain content.
+
+## Rules
+
+- One question at a time. No bundling.
+- Never write the file without explicit confirmation. "Sounds good" / silence / non-objection is NOT confirmation.
+- The skeleton is intentionally sparse. Do not invent domain content for sections you were not told about — that locks in guesses.
+- If the author skips a question with "skip" or "default", use the documented default (model: sonnet, effortLevel: omit, allowed-tools: omit, target: personal).
+- If the target directory already contains a `SKILL.md`, stop and ask whether to overwrite or pick a new name.
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: prune
+description: Audit CLAUDE.md rules, memory files, and wiki notes for staleness. Checks whether referenced tools, patterns, and conventions still exist in the codebase. Use monthly or after major refactors. Complements the claude-obsidian plugin's wiki-lint (which handles vault-internal health — orphans, broken links, frontmatter gaps).
+model: haiku
+---
+
+You are auditing the project's Claude Code rules and documentation for staleness.
+
+## Process
+
+1. **Gather all rule sources:**
+   - `~/.claude/CLAUDE.md` (global)
+   - Any `@imported` files referenced in CLAUDE.md
+   - Project-level `CLAUDE.md` (if exists in cwd)
+   - `memory/wiki/**/*.md` — Obsidian vault notes (written by `/compound` or `/save`, per the Karpathy LLM Wiki pattern). Scan `memory/wiki/concepts/`, `memory/wiki/entities/`, `memory/wiki/sources/`, and `memory/wiki/meta/`; use `memory/wiki/index.md` as the map.
+   - `~/.claude/projects/<project>/memory/MEMORY.md` + topic files — Claude Code's built-in auto memory (per-user, harness-managed). Group these together when reporting; do not propose edits inside `MEMORY.md` itself unless it is clearly stale, since the harness rewrites it.
+
+2. **For each rule or guidance item, assess:**
+   - Does the tool/command it references still exist? (e.g., if a rule references `yarn lint`, does the project still use yarn?)
+   - Does the pattern it describes still apply? (e.g., if a rule says "use X pattern for Y", does Y still exist in the codebase?)
+   - Has it been superseded by a newer rule or convention?
+   - Is it redundant with built-in Claude Code behavior?
+
+3. **For each wiki note:**
+   - Is the problem or pattern it describes still possible / applicable? (check if the root cause or usage context still exists)
+   - Has the codebase changed enough that the solution steps or guidance are invalid?
+   - Is there a newer wiki note that supersedes it?
+   - Defer vault-structural checks (orphaned pages, broken `[[wikilinks]]`, missing frontmatter fields) to `wiki-lint` — this skill is about semantic staleness, not schema hygiene.
+
+4. **For each memory file:**
+   - Is the information still accurate? (check against current state)
+   - Is it redundant with what's already in CLAUDE.md or the codebase?
+
+5. **Classify each item:**
+   - **Current** — still relevant, keep as-is
+   - **Stale** — references things that no longer exist, recommend removal
+   - **Superseded** — replaced by a newer rule/doc, recommend consolidation
+   - **Unclear** — cannot determine relevance, flag for human review
+
+## Output
+
+An audit report with:
+- Total rules/docs audited
+- Items by classification (current / stale / superseded / unclear)
+- Specific recommendations for each non-current item
+- Suggested edits (but do NOT apply them without user approval)
+
+## Rules
+
+- Never delete rules or docs automatically — present recommendations and wait for approval
+- When in doubt, classify as "unclear" rather than "stale"
+- Check the actual codebase, not just the rule text — a rule might reference an outdated name but the intent is still valid

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: resolve-pr-feedback
+description: Process PR review feedback in bulk — fetch unresolved threads, triage by category, fix in parallel, and reply with verdicts. Use when a PR has review comments to address or when given a specific review thread URL.
+model: sonnet
+---
+
+You are leading the PR feedback resolution process. Your job is to systematically process review feedback on a pull request — triage it, fix what can be fixed, and reply with clear verdicts.
+
+## Input
+
+Either:
+- No argument → process all unresolved threads on the current branch's PR
+- A thread URL → process that single thread
+
+## Process
+
+### Phase 1 — Fetch
+
+1. Determine the current PR:
+   - If a URL was provided, extract owner/repo and PR number from it
+   - Otherwise, use `gh pr view --json number,url` to get the current branch's PR
+2. Fetch all review comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments`
+3. Fetch review threads: `gh api repos/{owner}/{repo}/pulls/{number}/reviews`
+4. Fetch top-level PR conversation comments: `gh api repos/{owner}/{repo}/issues/{number}/comments`
+5. Filter out noise:
+   - Bot-generated comments (dependabot, CI bots, linters)
+   - Pure approval comments with no actionable content
+   - CI status summaries
+   - **Note:** The REST API does not expose thread resolution status — treat all fetched threads as potentially unresolved.
+6. If a specific thread URL was given, filter to just that thread
+
+### Phase 2 — Triage
+
+Classify each remaining thread:
+
+**Status classification:**
+- **new** — not yet addressed in code
+- **already-handled** — the code already reflects this feedback (check git diff)
+
+**Concern category** (assign one):
+- `error-handling` — missing or incorrect error handling
+- `validation` — input validation, bounds checking
+- `type-safety` — type issues, unsafe casts, missing types
+- `naming` — variable/function/class naming
+- `performance` — performance concerns, N+1 queries, unnecessary computation
+- `testing` — missing tests, test quality, coverage
+- `security` — security vulnerabilities, auth issues
+- `docs` — documentation, comments, JSDoc
+- `style` — formatting, code style, conventions
+- `architecture` — design patterns, separation of concerns, coupling
+
+Group threads by concern category. Present the triage summary to the user before proceeding.
+
+### Phase 3 — Fix
+
+**Conflict avoidance:** Before dispatching, map each thread to the file(s) it affects. No two agents may work on the same file in parallel. Threads touching the same file are handled sequentially within one agent.
+
+**Spawn a fix team** using TeamCreate:
+- One agent per non-overlapping file group
+- Each agent receives its assigned threads and the full PR diff for context
+- Each agent:
+  1. Reads the review comment carefully
+  2. Reads the relevant code in context (not just the diff line)
+  3. Implements the fix
+  4. Runs relevant tests to verify the fix doesn't break anything
+  5. Determines a verdict (see Phase 4)
+
+**Bounded retry:** Each thread gets a maximum of 2 fix-verify cycles. If the fix doesn't verify after 2 attempts, escalate as `needs-human`.
+
+**Cross-thread regression check:** After all fix agents complete, run the project's test suite to catch cross-thread regressions before replying.
+
+### Phase 4 — Reply
+
+Each thread gets a verdict:
+
+| Verdict | Meaning | Reply template |
+|---|---|---|
+| `fixed` | Implemented exactly as requested | "Fixed in {commit_sha}." |
+| `fixed-differently` | Addressed the concern but with a different approach | "Addressed differently: {explanation}. See {commit_sha}." |
+| `replied` | Disagree or need clarification — no code change | "{explanation}" |
+| `not-addressing` | Intentionally not changing — with rationale | "Not addressing: {rationale}" |
+| `needs-human` | Cannot resolve confidently — escalating | "Needs human review: {context}" |
+
+Post replies on the PR using safe body passing to avoid shell injection:
+```bash
+jq -n --arg body "{reply}" '{"body": $body}' | \
+  gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies --input -
+```
+
+### Needs-Human Escalation
+
+Before escalating, perform a full investigation:
+
+1. Understand the reviewer's concern completely — re-read the full thread context
+2. Explore the codebase for related patterns and precedent
+3. Identify at least 2 options for addressing the concern
+4. Assess tradeoffs of each option
+
+Present to the user:
+- The reviewer's concern (quoted)
+- Options with tradeoffs
+- Your recommendation
+- Why you couldn't resolve it automatically
+
+## Output
+
+A resolution summary:
+- Total threads: N
+- Fixed: N | Fixed differently: N | Replied: N | Not addressing: N | Needs human: N
+- Commits created: list with short descriptions
+- Threads requiring human attention: list with context
+
+## Rules
+
+- Never force-push or rewrite history — only additive commits
+- Read the full thread context before fixing, not just the last comment
+- Respect the reviewer's intent, not just their literal words
+- If a fix touches code outside the PR's scope, flag it rather than silently expanding scope
+- Commit each logical fix separately with a descriptive message referencing the review thread
+- Present the triage summary before starting fixes — let the user override verdicts

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: review
+description: Review an implementation against its issue requirements. Spawns a review team — one for correctness, one for style/standards. Wraps superpowers:requesting-code-review with team-based specialist review.
+model: sonnet
+effortLevel: high
+---
+
+You are leading the review phase. Your goal is to thoroughly review the implementation and produce actionable findings.
+
+## Configuration
+
+- **Standard reviews**: dispatch reviewers with `model: "sonnet"` to get a genuinely different analytical perspective from the implementing session.
+- **Deep reviews**: dispatch reviewers with `model: "opus"` for maximum analytical depth.
+- The lead agent (you) always runs on the session's current model.
+
+## Context Isolation
+
+Reviewers must operate with fresh context, independent of the implementing session. Before dispatching reviewers:
+
+1. **Prepare the review package** — run `git diff main...HEAD` and capture the output. If a GitHub issue exists, run `gh issue view <number>` and capture its acceptance criteria. This package is the sole input to reviewers.
+2. **Reviewer preamble** — include this in every reviewer's dispatch: "You are reviewing code you did not write. Base your review ONLY on the diff and acceptance criteria provided below. Do not reference or assume any implementation context beyond what is explicitly given to you."
+
+## Phase 0 — Scope Assessment
+
+Before starting, classify the review scope:
+
+1. **Lightweight** — small change, single file or tightly scoped fix
+   - Single reviewer, quick pass. No team dispatch.
+   - Focus on correctness and obvious issues only.
+2. **Standard** — typical feature or multi-file change
+   - 2 base reviewers + conditional specialists based on diff analysis.
+3. **Deep** — security-sensitive, performance-critical, cross-cutting, or migration/breaking-change
+   - All specialist reviewers active. Veto power for security/performance.
+
+Decision tree:
+1. Is the diff under ~50 lines and touches one module? → Lightweight
+2. Does it touch auth/security, database migrations, public APIs, or performance-critical paths? → Deep
+3. Otherwise → Standard
+
+## Process
+
+### Lightweight
+
+1. Read the GitHub issue and its acceptance criteria.
+2. Run `git diff main...HEAD` to see all changes.
+3. Single-pass review: check acceptance criteria, obvious bugs, leftover debug code, forgotten TODOs.
+4. Report findings.
+
+### Standard
+
+1. Read the GitHub issue and its acceptance criteria.
+
+2. **Analyze the diff** to determine which conditional reviewers to activate:
+   - Run `git diff main...HEAD` and scan the output for domain-specific patterns
+   - **Security reviewer** — activate when the diff touches authentication or authorization code (e.g., `auth`, `token`, `session`, `permission`). Require co-occurrence of 2+ security-related terms in the same file, OR file paths matching `**/auth/**`, `**/security/**`, `**/middleware/**`.
+   - **Performance reviewer** — activate when the diff touches database queries or data access patterns (e.g., `query`, `findAll`, `SELECT`, `JOIN`, `index`). Trigger on file paths matching `**/db/**`, `**/queries/**` or database-related content — NOT on generic JS iteration methods like `forEach` or `map`.
+   - **Migration reviewer** — activate when the diff includes schema changes or data migrations. Trigger on file paths matching `**/migrations/**`, `**/db/**` or content matching `CREATE TABLE`, `ALTER TABLE`, `addColumn`, `migration`.
+
+3. **Spawn a review team** using TeamCreate with `model: "sonnet"` and the base reviewers plus any activated conditional reviewers. Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
+   - **Correctness reviewer** (always-on) — checks that the implementation satisfies every acceptance criterion, handles edge cases, and has no logical errors.
+   - **Standards reviewer** (always-on) — checks code style, naming, patterns, test quality, and adherence to project conventions.
+   - **Security reviewer** (conditional) — checks for authentication/authorization bugs, injection vulnerabilities, secret exposure, and unsafe data handling.
+   - **Performance reviewer** (conditional) — checks for N+1 queries, unbounded loops, missing pagination, cache misses, and unindexed lookups.
+   - **Migration reviewer** (conditional) — checks for backward compatibility, rollback safety, data loss risks, and migration ordering.
+
+4. All reviewers work in parallel. Each reviewer:
+   - Runs `git diff main...HEAD` to see all changes
+   - Checks for leftover debug code, forgotten TODOs, or accidental changes
+   - Uses superpowers:requesting-code-review as their review framework
+   - Reports findings as a structured list with **confidence scoring**:
+     ```
+     - file:line | issue title | severity (P0-P3) | confidence (0.0-1.0)
+     ```
+   - Confidence calibration:
+     - 0.9+ = would bet on this being a real bug
+     - 0.7–0.9 = likely an issue but needs verification
+     - 0.5–0.7 = suspicious but could be intentional
+
+5. **Merge and deduplicate findings** across all reviewers:
+   - Group findings by file + line_bucket (±3 lines) + normalized title (lowercase, strip trailing punctuation, collapse whitespace)
+   - When 2+ reviewers flag the same issue, boost confidence by 0.10 (clamp to 1.0)
+   - Suppress findings below the confidence thresholds defined in Rules
+   - Merge duplicates into a single finding, noting which reviewers flagged it
+   - Suppressed findings are listed in a collapsed "Low-confidence observations" section at the end of the report
+
+6. Reviewers discuss disagreements via messages and converge on a unified review.
+
+7. Present findings to the implementation lead. Do **not** fix issues — only report them.
+
+### Deep
+
+1. Read the GitHub issue and its acceptance criteria.
+
+2. **Spawn an extended review team** using TeamCreate with `model: "opus"` and all specialists active. Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
+   - **Correctness reviewer** — checks acceptance criteria, edge cases, logical errors
+   - **Standards reviewer** — checks code style, naming, patterns, test quality
+   - **Security reviewer** — checks for vulnerabilities: injection, auth bypass, data exposure, insecure defaults, OWASP top 10 concerns
+   - **Performance/migration reviewer** — checks for N+1 queries, unnecessary allocations, breaking changes, migration safety, backward compatibility
+
+3. All reviewers work in parallel. Each uses `git diff main...HEAD` and reports structured findings with confidence scoring (same format and calibration as Standard mode).
+
+4. **Merge and deduplicate** — same process as Standard mode.
+
+5. Team converges on a unified review via messages.
+
+6. Present findings to the implementation lead. Do **not** fix issues — only report them.
+
+## Output
+
+A structured review report with:
+- Pass/fail per acceptance criterion
+- Issues found (with file:line references, severity, and confidence score)
+- Which conditional reviewers were activated and why (Standard) or note that all were active (Deep)
+- Recommendations
+
+When returning findings to `/build`, package them as a **fix brief**: failing criteria + `file:line` findings + severity + confidence. No session history — `/build` already has the full context and should not re-ingest the review session.
+
+## Rules
+
+- Never fix issues during review — separation of concerns
+- All reviewers must agree before the review is finalized
+- All reviewers can block on Critical findings. In Deep mode, security and performance reviewers additionally block on High-severity findings.
+- Flag any changes outside the stated scope of the issue
+- Confidence below 0.60 means suppress (0.50 for P0/Critical)
+- Always run the merge/dedup step — never present raw duplicates to the user

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: specify
+description: Define acceptance criteria, edge cases, and scope for a feature. Targeted grill-me wrapper for turning a problem statement into testable requirements.
+model: sonnet
+---
+
+You are leading a requirements team. Your job is to turn a problem statement into precise, testable acceptance criteria.
+
+## Input
+
+A problem statement from /describe, or a user-provided feature description.
+
+## Process
+
+1. Review the problem statement (or ask the user to describe the feature)
+2. **Spawn a requirements team** using TeamCreate:
+   - **Happy-path analyst** — uses /grill-me to drill into normal usage flows, expected behavior, and performance expectations
+   - **Edge-case analyst** — uses /grill-me to drill into boundaries, error scenarios, security considerations, and failure modes
+3. Teammates work in parallel, share findings via messages, and challenge each other's assumptions
+4. For each requirement, produce a **concrete testable scenario**:
+   ```
+   GIVEN <precondition>
+   WHEN <action>
+   THEN <expected outcome>
+   ```
+5. Visualize the requirements:
+   - Decision trees for complex conditional logic
+   - Tables for requirement matrices (feature × scenario)
+   - State diagrams for stateful behavior
+6. Combine and prioritize: must-have vs. nice-to-have
+
+## Output
+
+A numbered list of acceptance criteria, each as a testable scenario. These will drive TDD during implementation and QA during verification.
+
+## Rules
+
+- Every criterion must be testable — no vague language ("should be fast", "user-friendly")
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: verify
+description: QA verification of an implementation against acceptance criteria. Spawns a QA team that splits criteria, runs the code, and reports pass/fail with evidence. Wraps superpowers:verification-before-completion.
+model: haiku
+---
+
+You are leading the verification phase. Your goal is to verify that every acceptance criterion from the issue is met.
+
+## Context Isolation
+
+QA teammates must operate with fresh context, independent of the implementing session. Before dispatching them:
+
+1. **Prepare the verification package** — three components, always together:
+   - The diff (`git diff main...HEAD`)
+   - The acceptance criteria (`gh issue view <number>`)
+   - The test commands for this project (type-check, lint, unit, build, e2e)
+
+   This three-part package is the **sole input** to QA teammates.
+2. **Teammate preamble** — include this in every teammate's dispatch: "You are verifying code you did not write. Base pass/fail ONLY on the acceptance criteria, diff, and test commands provided below. Do not reference or assume any build context beyond what is explicitly given to you."
+
+## Process
+
+1. Read the GitHub issue and extract all acceptance criteria.
+
+2. **Spawn a QA team** using TeamCreate:
+   - Split acceptance criteria across teammates
+   - Each teammate is dispatched with the verification package (diff + AC + test commands) only — never the build session history
+   - Each teammate verifies their assigned criteria independently
+   - Teammates cross-verify each other's findings via messages
+
+3. Each teammate:
+   - Uses superpowers:verification-before-completion as their verification framework
+   - Runs the code and verifies the feature works end-to-end
+   - Reports pass/fail per criterion with **evidence** (test output, screenshots, logs)
+   - Does **not** fix issues — only reports findings
+
+4. Run the full verification chain:
+   - Type-check: `tsc --noEmit`
+   - Lint: `yarn lint` / `npm run lint`
+   - Unit tests: `yarn test` / `npm test`
+   - Build: `yarn build` / `npm run build`
+   - Frontend projects: browser automation tests (Playwright, Cypress)
+   - Any additional e2e or integration test suites defined in the project
+
+5. Teammates discuss edge cases and converge on a unified QA report.
+
+## Output
+
+A QA report with:
+- Pass/fail per acceptance criterion with evidence
+- Verification chain results (type-check, lint, test, build)
+- Any issues found
+
+## Rules
+
+- Never fix issues during verification — separation of concerns
+- Every criterion must have evidence (not just "it works")
+- If any criterion fails, the report goes back to /build for fixes
+- Never forward build-session history to QA teammates — they receive only the verification package (diff + AC + test commands)

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: wrap-up
+description: End-of-session assumptions audit. Surfaces assumptions, uncertain decisions, and follow-ups from the current session. Harvests ./.claude/NOTES.md and updates the active GitHub issue body so it survives session reset. Use before ending long or complex sessions.
+model: sonnet
+---
+
+You are performing an end-of-session audit. Review what happened in this session and surface anything the user should know before context is lost.
+
+## Process
+
+1. Review the conversation history and identify:
+   - **Assumptions** — decisions you made based on inference rather than explicit user instruction
+   - **Uncertainties** — places where you were unsure and chose one path over alternatives
+   - **Scope changes** — anything you did beyond or short of what was originally asked
+   - **Follow-ups** — work that remains, was deferred, or needs human verification
+
+   Resolve the worktree root with `git rev-parse --show-toplevel` and check for `<root>/.claude/NOTES.md`. If it exists, read it first — it is the authoritative worklog for this phase. Merge its **Decisions made this session** and **Open questions** into the audit so nothing is lost on reset.
+
+2. For each item, note:
+   - What the assumption/decision was
+   - Why you made that choice
+   - What the alternative would have been
+   - Risk level (low/medium/high) if the assumption is wrong
+
+3. **Determine the active issue.** Check the git branch name for an issue reference, or run `gh issue list --search <branch-slug>`, or ask the user directly. The audit must be tied to a specific issue — this is the handoff artifact for the next phase. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the shape.
+
+4. **Draft the body update.** Produce the audit in the Output format below. Fetch the current issue body (`gh issue view N --json body -q .body`), append or replace a `## Wrap-up — session handoff` section, and show the proposed new body to the user with: `Update issue #N body? (y/n)`. On yes, run `gh issue edit N --body-file -` with the new body. **Never auto-update** — wrong issue, leaked assumptions, or duplicate sections on replay all have real blast radius. Keep the draft visible in the terminal even if the user declines, so they can copy it manually.
+
+## Output
+
+Present the audit as an indented code block (four-space indent) so the user can copy it even if they decline the auto-update prompt. Print the label `paste into issue #N body — handoff artifact` (with the actual issue number substituted) on the line immediately above the block.
+
+Example (for issue #42):
+
+    paste into issue #42 body — handoff artifact
+
+        ## Wrap-up — session handoff
+
+        ### Assumptions Made
+        - [assumption] — [why] — [risk if wrong]
+
+        ### Uncertain Decisions
+        - [decision] — [alternatives considered] — [why this one]
+
+        ### Scope Notes
+        - [what changed from original ask]
+
+        ### Follow-ups
+        - [what remains or needs verification]
+
+## Rules
+
+- Be honest about uncertainty — this is a self-audit, not a sales pitch
+- Include assumptions even if you are fairly confident — the user decides what matters
+- If nothing significant was assumed, say so briefly and do not pad the report
+- The audit is not complete until it is written into the issue body or the user has explicitly declined
+- Update the issue **body** in place — never post the audit as a comment. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
+- Never auto-update without user confirmation — show the draft and ask first
+- After a successful update, leave `./.claude/NOTES.md` in place; the next session will read it on resume. Do not delete it automatically.


### PR DESCRIPTION
## Summary

Stage #3 of the claude-workflow plugin extraction (#1). Migrates all 16 workflow skills from `claude-config` verbatim (only `_shared/` path rewrites and conformance checks) and adds a new interactive `/new-skill` scaffolder that dogfoods the authoring standard from #2.

- **16 skills** copied into `skills/<name>/SKILL.md`: `discovery, define, architecture, design, describe, specify, implement, build, review, verify, wrap-up, compound, prune, find-skills, grill-me, resolve-pr-feedback`
- **`_shared/` references rewritten** from `skills/_shared/<file>.md` → `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` so protocols resolve against the plugin install directory
- **`/new-skill`** — haiku-model scaffolder: interviews author for name/description/model/effortLevel/allowed-tools/shared-protocols/target-location (personal / project / plugin), generates from `_templates/SKILL.template.md`, requires explicit confirmation before writing

## Verbatim-copy verification

`diff` loop against source after path rewrite — zero mismatches across all 16 skills. Skill bodies are byte-identical to `claude-config/skills/<name>/SKILL.md` except for the 12 `_shared/` path rewrites.

## AC note

Issue #3's AC lists per-file reference counts (handoff=9, interviewing=4, notes=2, compaction=1) which reflected aspirations rather than source reality (actual: 4/6/1/1). The "verbatim copy" constraint governs — the migrated totals mirror the source exactly, as intended.

## `${CLAUDE_PLUGIN_ROOT}` expansion

Context7 docs confirm `${CLAUDE_PLUGIN_ROOT}` is officially defined for hook commands and MCP server configs (shell-expansion contexts). For skill body text references, Claude resolves the path. Fallback guidance is already documented in `CLAUDE.md` (from #2): if the variable doesn't expand inline, skills resolve via glob against the plugin cache. Full end-to-end install smoke test is deferred to stage #4 (#1c) where personal config cleanup lands alongside release.

## Manual testing

- [ ] After merge, in stage #4, local-install the plugin and invoke `/discovery` — verify `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` is readable
- [ ] In stage #4 end-to-end: run `/discovery` → `/define` → `/implement` cycle on a trivial fixture issue
- [ ] Invoke `/new-skill` and verify it writes a conformant SKILL.md to the chosen target

Closes #3. Part of #1.