### PR TITLE
feat(#4): marketplace manifest + README publication docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,30 @@
+{
+  "name": "claude-workflow",
+  "owner": {
+    "name": "Michal Konopski",
+    "url": "https://github.com/misiekhardcore"
+  },
+  "metadata": {
+    "description": "claude-workflow: standardized /discovery → /define → /implement lifecycle for Claude Code",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "claude-workflow",
+      "source": {
+        "source": "github",
+        "repo": "misiekhardcore/claude-workflow",
+        "ref": "main"
+      },
+      "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. 17 skills, shared protocols, authoring standard, /new-skill scaffolder.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Michal Konopski",
+        "url": "https://github.com/misiekhardcore"
+      },
+      "homepage": "https://github.com/misiekhardcore/claude-workflow",
+      "repository": "https://github.com/misiekhardcore/claude-workflow",
+      "license": "MIT"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Workflow skills plugin for Claude Code — a standardized lifecycle for feature 
 
 ## Install
 
+This repo is its own marketplace — the plugin and marketplace manifests both live in `.claude-plugin/`, so a single `marketplace add` points Claude Code at both.
+
 ```bash
-claude marketplace add misiekhardcore/claude-workflow
+claude plugin marketplace add misiekhardcore/claude-workflow
+claude plugin install claude-workflow@claude-workflow
 ```
 
 Then enable it in your project or globally in Claude Code settings.


### PR DESCRIPTION
## Summary

relates #4

- Adds `.claude-plugin/marketplace.json` so the repo acts as its own marketplace (self-marketplace pattern, same as `claude-obsidian`). This is what makes `claude plugin marketplace add misiekhardcore/claude-workflow` work.
- Updates the README install section with the explicit two-command flow (`marketplace add` → `plugin install claude-workflow@claude-workflow`) and a one-line note explaining that the plugin and marketplace manifests both live in `.claude-plugin/`.

Resolves the "marketplace publication path" open question from #1 in favor of a personal marketplace repo.

This PR covers the claude-workflow-side work for #4. The remaining AC items — personal `~/.claude/CLAUDE.md` cleanup, `claude-config/docs/workflow.md` removal, and the `v0.1.0` tag — are personal-config / release operations that happen after this merges and after the end-to-end smoke test passes.

## Manual testing

Verified locally before opening the PR:

1. `claude plugin validate /home/michal/Projects/claude-workflow` → ✓ Validation passed.
2. `claude plugin marketplace add /home/michal/Projects/claude-workflow` → marketplace registered as `claude-workflow`.
3. `claude plugin install claude-workflow@claude-workflow` → installed at `~/.claude/plugins/cache/claude-workflow/claude-workflow/0.1.0/`.
4. Confirmed all 17 skills (incl. `new-skill`) present under `skills/` and the 4 shared protocols present under `_shared/` — so `${CLAUDE_PLUGIN_ROOT}/_shared/*` references resolve.
5. `claude plugin list` → `claude-workflow@claude-workflow` visible.

End-to-end `/discovery` → `/define` → `/implement` on a trivial test issue is still pending and is the reviewer's responsibility before tagging `v0.1.0`.

## Reviewer checklist to reproduce

```bash
git fetch && git checkout feat/marketplace-and-readme
claude plugin validate .
claude plugin marketplace add "$(pwd)"
claude plugin install claude-workflow@claude-workflow
claude plugin list | grep workflow
```

Closes portion of #4 — marketplace + README ACs. The remaining ACs (CLAUDE.md cleanup, workflow.md delete, v0.1.0 tag) will be handled in a follow-up commit/tag after the smoke test passes.