### PR TITLE
feat: decouple claude-workflow from vault path (#9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "claude-workflow: standardized /discovery → /define → /implement lifecycle for Claude Code",
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. 17 skills, shared protocols, authoring standard, /new-skill scaffolder.",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "author": {
         "name": "Michal Konopski",
         "url": "https://github.com/misiekhardcore"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-workflow",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. Includes 16 skills, shared protocols, authoring tools, and a /new-skill scaffolder.",
   "author": {
     "name": "Michal Konopski",

--- a/README.md
+++ b/README.md
@@ -41,12 +41,22 @@ Then enable it in your project or globally in Claude Code settings.
 | `/architecture` | Decide on technical architecture — components, data flow, trade-offs |
 | `/design` | Visual and UX design decisions — layouts, interaction flows |
 | `/grill-me` | Relentless interviewing to stress-test a plan or design |
-| `/compound` | Capture learnings into the Obsidian wiki vault |
+| `/compound` | Capture learnings as structured wiki notes; files via `claude-obsidian` when installed, otherwise reports inline |
 | `/wrap-up` | End-of-session audit; harvests NOTES.md into the issue body |
-| `/prune` | Audit CLAUDE.md and wiki notes for staleness |
+| `/prune` | Audit CLAUDE.md for staleness; delegates vault audit to `wiki-lint` when `claude-obsidian` is installed |
 | `/find-skills` | Discover and install skills from the ecosystem |
 | `/resolve-pr-feedback` | Process PR review feedback in bulk |
 | `/new-skill` | Scaffold a new skill conforming to this authoring standard |
+
+## Optional: claude-obsidian integration
+
+claude-workflow doesn't ship its own knowledge store. When the [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) plugin is installed and a vault has been bootstrapped (`/wiki`), several skills light up vault-aware paths automatically:
+
+- `/compound` files captures via `/save` instead of reporting the note inline.
+- `/prune` delegates vault audit to `wiki-lint` and folds its findings into the report.
+- `/architecture` and `/define` query the vault for prior patterns/decisions via `wiki-query`.
+
+Without `claude-obsidian` every skill still runs; vault operations are skipped with a one-line note, and `/compound` emits a structured Markdown block the user can capture wherever they like. No hard dependency — install it if it's useful, skip it otherwise.
 
 ## Workflow paths
 

--- a/_shared/compaction-protocol.md
+++ b/_shared/compaction-protocol.md
@@ -7,7 +7,7 @@ This file is reference material — read it on demand when the skill reaches a c
 ## Tool order
 
 1. **Context editing first.** Clear stale tool results verbatim. This is rot-immune because nothing is paraphrased.
-2. **Sub-agent delegation second.** If the next bulk read can be delegated, the lead never accumulates the rot in the first place. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` rule 3.
+2. **Sub-agent delegation second.** If the next bulk read can be delegated, the lead never accumulates the rot in the first place. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` (rule 3).
 3. **Summarization-based `/compact` last.** Re-summarization compresses, but it also creates a new lower-fidelity anchor the model will over-attend to. Use only when conversation bulk (not tool output) is the source of pressure.
 
 ## When to trigger
@@ -57,4 +57,4 @@ Diff the summary against the Keep list **in `.claude/NOTES.md`**, not from memor
 
 ## Why
 
-In-place summarization can silently drop architectural decisions that only matter three steps later — and the resulting summary becomes the new "early context" the model over-anchors on, recreating the rot pattern at a smaller scale. Context editing avoids both failure modes by deleting rather than paraphrasing. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` for the full rationale.
+In-place summarization can silently drop architectural decisions that only matter three steps later — and the resulting summary becomes the new "early context" the model over-anchors on, recreating the rot pattern at a smaller scale. Context editing avoids both failure modes by deleting rather than paraphrasing. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale.

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -63,4 +63,4 @@ When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase
 
 ## Why this shape
 
-The five fields map to Anthropic's "structured handoff artifact" and OpenAI's `input_type` handoff metadata pattern. Summarization in place loses detail that the next phase needs; a body-update-in-place with this exact shape preserves the surviving content exactly and keeps the handoff scan-readable in a single fetch. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` for the full rationale.
+The five fields map to Anthropic's "structured handoff artifact" and OpenAI's `input_type` handoff metadata pattern. Summarization in place loses detail that the next phase needs; a body-update-in-place with this exact shape preserves the surviving content exactly and keeps the handoff scan-readable in a single fetch. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -13,9 +13,9 @@ Four tiers, no overlap:
 | `TodoWrite` | In-context | This session only | Throwaway working scratchpad |
 | `.claude/NOTES.md` | Worktree-local file (gitignored) | This phase, across sessions | In-flight decisions, current task, open questions |
 | GitHub issue | Remote | Cross-phase | Acceptance criteria, prior-phase decisions, handoff state |
-| Obsidian vault | `memory/wiki/` (git-tracked) | Durable, cross-feature | Compounded knowledge — patterns, bug-fix history, architectural insights |
+| Durable vault (optional) | The claude-obsidian vault (git-tracked) | Durable, cross-feature | Compounded knowledge — patterns, bug-fix history, architectural insights |
 
-`TodoWrite` and `.claude/NOTES.md` are not mirrored — they serve different roles, and manual sync invites drift.
+`TodoWrite` and `.claude/NOTES.md` are not mirrored — they serve different roles, and manual sync invites drift. The durable vault tier only materializes when the `claude-obsidian` plugin is installed and a vault has been bootstrapped (`/wiki`); without it, the tier is absent and skills that would write to it degrade gracefully.
 
 ## NOTES.md vs the vault's recency channels
 
@@ -24,15 +24,15 @@ The `claude-obsidian` plugin ships its own running-memory mechanisms inside the 
 | Artifact | Scope | Lifetime | Written by | Committed? |
 |---|---|---|---|---|
 | `.claude/NOTES.md` | One worktree, one feature | Ends when the worktree is removed | `/build` (scratch while coding) | No (gitignored) |
-| `memory/wiki/hot.md` | Whole repo, all work | Cross-session, curated recent context | `/save`, `/compound`, or manual edits | Yes |
-| `memory/wiki/meta/<session>.md` | One session's archive | Permanent | `/save` at session end (Karpathy-style session capture) | Yes |
-| `memory/wiki/log.md` | Whole repo | Permanent, append-only | Every `/save` or `/compound` emits a line | Yes |
+| Vault hot cache | Whole repo, all work | Cross-session, curated recent context | `/save`, `/compound`, or manual vault edits | Yes |
+| Session archive | One session's archive | Permanent | `/save` at session end (Karpathy-style session capture) | Yes |
+| Vault log | Whole repo | Permanent, append-only | Every `/save` or `/compound` emits a line | Yes |
 
 Rule of thumb:
 - **While working** — log to `.claude/NOTES.md`. It's phase-local scratch; nothing leaves the worktree.
 - **Between sessions on the same feature** — resume from `.claude/NOTES.md` (it's the authoritative in-flight state).
-- **Between features** — promote durable learnings to `memory/wiki/concepts/` via `/compound` (or the plugin's `/save`). That's what crosses the worktree boundary.
-- **Want a quick "what have I been working on lately" cache across the repo** — that's `memory/wiki/hot.md`, not NOTES.md. Hot cache is curated and committed; NOTES.md is raw and ephemeral.
+- **Between features** — promote durable learnings to the vault's concept notes via `/compound` (which delegates to `claude-obsidian`'s `/save` when available). That's what crosses the worktree boundary.
+- **Want a quick "what have I been working on lately" cache across the repo** — that's the vault's hot cache, not NOTES.md. Hot cache is curated and committed; NOTES.md is raw and ephemeral.
 
 `/wrap-up` is the bridge: it harvests NOTES.md at clean exit and drafts a GitHub-issue comment, and it's the natural trigger point to ask whether anything in NOTES.md deserves promotion to the vault.
 
@@ -100,4 +100,4 @@ On a fresh session in an existing worktree, `.claude/NOTES.md` exists ⇒ this i
 
 ## Why
 
-Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `memory/wiki/concepts/Context Hygiene Between Workflow Phases.md` for the full rationale.
+Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale.

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -1,0 +1,169 @@
+# Context Hygiene Between Workflow Phases
+
+Why this plugin treats phase boundaries as context resets, and what the four rules below actually do.
+
+## The problem
+
+The lifecycle — `/discovery` → `/define` → `/implement` (build → review → verify) → `/wrap-up` → `/compound` — is multi-phase on purpose. The problem is not that the context window fills up; even with large windows, that is rarely the binding constraint. The problem is **context rot**: the well-documented degradation in retrieval, reasoning, and instruction-following as unrelated concepts accumulate in a single session, even nominally well within the window.
+
+Two failure modes:
+
+1. **Within a phase** — a long `/build` session accumulates stale tool outputs (rejected approaches, replayed test runs, file reads that were superseded). The model starts anchoring on early framings instead of the current task.
+2. **Between phases** — `/discovery` is interview-shaped reasoning, `/define` is architectural tradeoffs, `/implement` is code edits. Carrying one phase's context into the next dilutes attention with the wrong reasoning patterns. The model keeps re-litigating user-interview framings while it should be writing code.
+
+The fix in both cases is the same: **keep the working context focused on the current concept**. The rules below are how.
+
+## Guidance
+
+Four rules. Apply them in order.
+
+### 1. Reset between phases — phases are concept boundaries
+
+Anthropic's harness team describes the tradeoff explicitly:
+
+> "A reset provides a clean slate, at the cost of the handoff artifact having enough state for the next agent to pick up the work cleanly. This differs from compaction, where earlier parts of the conversation are summarized in place so the same agent can keep going on a shortened history."
+> — [Harness design for long-running apps, Anthropic Engineering](https://www.anthropic.com/engineering/harness-design-long-running-apps)
+
+Phases in this workflow are not just organizational — they are **concept boundaries**. Each phase has a different reasoning shape, and carrying one shape into the next is the dominant rot vector at this workflow's scale. The GitHub issue **body** is the handoff artifact — always updated in place, never posted as a comment. End each phase by editing the issue body with the decisions and state the next phase needs, then start the next phase in a fresh session. Do not carry conversation history across `/discovery → /define`, `/define → /implement`, or `/build → /review`.
+
+The artifact has a fixed shape (Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions) defined canonically in `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. That shape mirrors Anthropic's "structured handoff artifact" and OpenAI's [`input_type` handoff metadata](https://openai.github.io/openai-agents-python/handoffs/) — small, structured, summary-shaped, not a transcript.
+
+### 2. Within a phase, prefer context editing over summarization, and trigger on concept shifts
+
+Inside a phase, the dominant rot source is stale tool output: file reads that were superseded, test runs from a previous attempt, doc lookups already internalized. **Context editing** — clearing those tool results verbatim — removes the rot at its source without paraphrasing anything.
+
+> "Context editing enabled agents to complete workflows that would otherwise fail due to context exhaustion — while reducing token consumption by 84%."
+> — [Managing context on the Claude Developer Platform, Anthropic](https://www.anthropic.com/news/context-management)
+
+Summarization-based `/compact` is a **last resort**, not the headline tool. Re-summarization forces the model to paraphrase its own reasoning, and the resulting summary becomes the new "early context" the model will over-anchor on — same rot pattern, slightly compressed. When you must use it, follow Anthropic's preservation guidance:
+
+> "Context compaction is implemented by passing the message history to the model to summarize and compress the most critical details, preserving architectural decisions, unresolved bugs, and implementation details while discarding redundant tool outputs or messages."
+> — [Effective context engineering for AI agents, Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+
+> "Overly aggressive compaction can result in the loss of subtle but critical context whose importance only becomes apparent later."
+> — same source
+
+Trigger compaction on **concept shifts**, not on a percentage. `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` enumerates the trigger conditions and the tool order (context editing → sub-agent delegation → summarization-based `/compact` last). The summary: never let auto-compact run unattended, always emit a preservation note when you do reach `/compact`, and write the Keep list to `.claude/NOTES.md` *before* compacting so the post-compaction state can be diffed against an external record. The model's own "summarize where we are" is a sanity check, not a verification — both the summary and the post-compact state draw from the same now-truncated context.
+
+### 3. Delegate bulk tool output to sub-agents, not just exploration
+
+Sub-agent isolation is **structurally rot-proof**: the lead session never sees the rotted context in the first place. This is the strongest tool in the kit and it should be used aggressively.
+
+> "Each subagent might explore extensively, using tens of thousands of tokens or more, but returns only a condensed, distilled summary of its work (often 1,000–2,000 tokens), achieving a clear separation of concerns where the detailed search context remains isolated within sub-agents, while the lead agent focuses on synthesizing and analyzing the results."
+> — [Effective context engineering for AI agents, Anthropic](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+
+The general rule: **anything that produces bulk tool output should run in a sub-agent that returns a distilled report**. The lead session stays on synthesis, where rot hurts most. Use Glob/Grep for narrow, directed lookups, and use sub-agents for broader exploration or any task likely to generate large volumes of output.
+
+In this workflow:
+
+- `/review` already follows this pattern: fresh-context reviewers receive the diff, not the build history. Keep it that way.
+- `/verify` is invoked with only the acceptance criteria plus the running code, never the build session history.
+- `/build` should delegate to an Explore sub-agent for any of: understanding an unfamiliar area of the codebase, parsing a long log, reading API docs, grepping wide paths. Ask for a focused report bounded by what the lead actually needs to make the next decision — not a fixed word limit.
+- Pass briefs, not session history. Sub-agents need objective + constraint + "what to report on" — not the conversation that led you to spawn them.
+
+### 4. Write `/wrap-up` output into the issue body before the session ends
+
+`/wrap-up` surfaces assumptions, uncertainties, and follow-ups — but without persistence, that output stays in the conversation and is lost when the session ends. That defeats rule (1). Fix: whenever `/wrap-up` runs at a phase boundary, edit the GitHub issue **body** in place to append a `## Wrap-up — session handoff` section. The captured content then survives the reset and lives in the same scan-readable artifact as the rest of the phase state.
+
+## Why
+
+Three convergent reasons, all from first-party sources:
+
+1. **Context rot is the binding constraint, not window size.** Retrieval, reasoning, and instruction-following degrade as unrelated concepts accumulate in a single session, well before the window fills. Bigger windows let you fit more — they don't help you attend better. Compaction exists as a feature precisely because token budget is not the only failure mode.
+
+2. **Context editing strictly dominates summarization for tool-output bulk.** Clearing stale tool results verbatim removes the rot at its source without paraphrasing anything. Summarization both compresses AND introduces a new lower-fidelity anchor for the model to over-attend to — it's a partial fix that adds its own failure mode. Anthropic's 84% token-reduction figure for context editing measures the right thing.
+
+3. **Sub-agent isolation is empirically effective.** Anthropic quantifies it: tens of thousands of tokens of exploration compressed into a 1–2k token report, with the lead agent reasoning over the distilled results. The lead never sees the rotted context — that's why it's the strongest tool in the kit. `/review` and `/verify` already work for this reason.
+
+A note on Opus 4.5/4.6 and "context anxiety": Anthropic reports they dropped context resets from their harness for long-running **single-concept** agents ([Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)). That is not the failure mode this doc addresses. Multi-concept session bloat across `/discovery`, `/define`, and `/implement` is a different problem and rot still applies.
+
+## When to Use
+
+- **Rule 1 (reset + artifact)** applies at every phase boundary, always. No exceptions.
+- **Rules 2 and 3** apply within a phase whenever a concept shift occurs. See `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` for the full trigger list and the tool-order decision (context editing → sub-agent → `/compact`).
+- **Rule 4** applies whenever `/wrap-up` runs at a phase boundary — its output is written into the issue body before the session ends.
+
+## Examples
+
+### Structured handoff artifact — filled example
+
+A worked instance of the canonical template from `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`, paste-ready into the issue body before resetting the session:
+
+```markdown
+## Handoff: /define → /implement
+
+**Acceptance criteria** (from /discovery, unchanged)
+- AC1: CSV export button appears on /reports for users with `reports.read`
+- AC2: Export respects current filters
+- AC3: File downloads within 5s for ≤50k rows
+
+**Constraints**
+- In scope: app/reports/**, app/lib/csv.ts (new)
+- Out of scope: server-side streaming, S3 upload path
+- Must reuse existing filter state from ReportsContext
+
+**Prior decisions**
+- Client-side generation via Papa Parse (chose over server endpoint: no infra change needed for ≤50k rows)
+- Button lives in ReportsToolbar, not inside the table (consistency with Print button)
+- No progress indicator in v1 (UX confirmed acceptable at 50k)
+
+**Evidence**
+- Benchmark: 50k rows → 1.4s in Chrome (see thread with @alex, 2026-04-12)
+- Design review: figma.com/... (approved)
+
+**Open questions**
+- Should empty result sets download an empty file or show a toast? (defer to /build, pick one and note it)
+```
+
+### Summarization-based `/compact` with preservation note
+
+Use only when context editing won't address the pressure (e.g., the bulk is conversation, not tool output). Never blind:
+
+```
+/compact
+
+Keep: issue #482 acceptance criteria; the ReportsToolbar component layout
+decision (client-side Papa Parse); files currently in scope
+(app/reports/ReportsToolbar.tsx, app/lib/csv.ts); the open question about
+empty result sets.
+
+Drop: the earlier exploration of server-side streaming (rejected); Papa
+Parse API reading; the tsc output from the first failing compile.
+```
+
+Before issuing `/compact`, write the Keep list to `.claude/NOTES.md`. After compacting, follow up with: `Summarize where we are and what the next step is.` Diff the summary against the Keep list **in NOTES.md**, not from memory — if anything is missing, restate it before the next tool call. If the summary looks hollow, abort and re-read the issue + NOTES.md.
+
+### Sub-agent brief (for `/review`)
+
+Do not pass the build transcript. Pass the brief:
+
+```
+Review the diff on branch feat/csv-export against issue #482.
+
+Criteria: AC1–AC3 in the issue body. Architectural decisions already locked
+(client-side Papa Parse, button in ReportsToolbar) — do not re-litigate.
+
+Report: correctness, standards, and any AC the diff fails to satisfy.
+Bound the report to what the lead needs to decide whether to merge.
+```
+
+This matches Anthropic's sub-agent pattern: the reviewer runs in isolation, returns a distilled report, and the lead session never sees the reviewer's internal exploration.
+
+## See Also
+
+- `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` — canonical handoff shape.
+- `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` — trigger list and tool order for in-phase context pressure.
+- `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` — NOTES.md as an external ledger the model can diff against after `/compact`.
+- `${CLAUDE_PLUGIN_ROOT}/skills/compound/SKILL.md` — how learnings from a completed phase become durable wiki notes.
+- `${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/SKILL.md` — end-of-session assumption audit; remember to persist its output per rule (4).
+
+## Sources
+
+- Anthropic — [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+- Anthropic — [Harness design for long-running application development](https://www.anthropic.com/engineering/harness-design-long-running-apps)
+- Anthropic — [Effective harnesses for long-running agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents)
+- Anthropic — [Managing context on the Claude Developer Platform](https://www.anthropic.com/news/context-management)
+- Anthropic — [Context editing (API docs)](https://platform.claude.com/docs/en/build-with-claude/context-editing)
+- Anthropic — [Compaction (API docs)](https://platform.claude.com/docs/en/build-with-claude/compaction)
+- OpenAI — [Agents SDK: Handoffs](https://openai.github.io/openai-agents-python/handoffs/)
+- OpenAI — [Orchestrating Agents: Routines and Handoffs (Cookbook)](https://cookbook.openai.com/examples/orchestrating_agents)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -83,7 +83,7 @@ AC are the contract `/implement` verifies against, so silent changes have blast 
 - **File:** `skills/define/SKILL.md`
 - **When:** After `/discovery`, for epics or architecturally significant work.
 - **Prerequisites:** An approved issue from `/discovery` with acceptance criteria.
-- **What it does:** Spawns research agents (codebase research + patterns/learnings scan against `memory/wiki/`, starting with `memory/wiki/hot.md` and `memory/wiki/index.md`), then dispatches:
+- **What it does:** Spawns research agents (codebase research + patterns/learnings scan against the claude-obsidian vault via `wiki-query` when available, else skipped with a note), then dispatches:
   - `/architecture` (`skills/architecture/SKILL.md`) — codebase analyst + solution architect + devil's advocate converge on a technical approach, producing component diagrams, trade-off tables, and a sub-task dependency graph. Uses `/grill-me` (`skills/grill-me/SKILL.md`) to pin down open decisions with the user.
   - `/design` (`skills/design/SKILL.md`) — UX researcher + design proposer + a11y reviewer, only when the task has visual aspects. Produces prototypes, wireframes, and interaction flows.
 - **Outcome:** The issue body is updated in place with a `## Define Outcome` section (see below), plus any sub-issues created and linked. **User approval is required** before `/implement`.
@@ -146,7 +146,7 @@ One comment per meaningful state change. Never more.
 | **Start** | `🤖 Starting implementation. Working from ## Define Outcome (last updated <date>). Branch: <branch>. Will post again when a draft PR is open or if the fix-cycle escalates to needs-human.` |
 | **Escalation** (only if max fix-cycle iterations hit or an AC cannot be met) | `🤖 Fix-cycle escalated after N iterations. Blocking issue: <one-line>. Details: <fold with reviewer findings and failing AC>. Need guidance before continuing.` |
 | **PR open** | `🤖 Draft PR opened: #<n>. AC status: <n/n met>. Review + verify clean. Ready for human review.` |
-| **Consolidation** (only if `/compound` wrote new memory notes) | `🤖 Captured learnings: memory/wiki/concepts/<Title Case Name>.md.` |
+| **Consolidation** (only if `/compound` filed new wiki notes) | `🤖 Captured learnings: <note title>` (or `inline` when claude-obsidian is not installed). |
 
 Not posted: per-commit updates, per-fix-cycle-iteration noise, internal reviewer findings (those belong in the fix-brief, not the issue thread).
 
@@ -163,8 +163,8 @@ Not posted: per-commit updates, per-fix-cycle-iteration noise, internal reviewer
 
 - **File:** `skills/compound/SKILL.md`
 - **When:** Automatically after a successful `/implement`. Not a separate user invocation — it is part of `/implement`'s postamble.
-- **What it does:** Files the learning into the Obsidian vault at `memory/wiki/` (Karpathy LLM Wiki pattern, via the `claude-obsidian` plugin). Ensures `memory/wiki/concepts/` exists, searches the vault for overlap (starting at `index.md` and `hot.md`, then drilling into `concepts/`, `entities/`, `sources/`), and either updates an existing note or writes a new one using **Bug Track** (Problem / Symptoms / What Didn't Work / Solution / Why It Works / Prevention) or **Knowledge Track** (Context / Guidance / Why / When / Examples) format. Appends an entry to `memory/wiki/log.md`. When the `claude-obsidian` plugin is active, prefers the plugin's `/save` flow — the plugin keeps frontmatter, cross-links, and the index in sync automatically.
-- **Outcome:** A durable wiki note at `memory/wiki/concepts/<Title Case Name>.md` with frontmatter matching `memory/WIKI.md` (type, domain, tags, related wikilinks, sources). Never auto-deletes or overwrites without flagging.
+- **What it does:** Extracts the learning and drafts it using **Bug Track** (Problem / Symptoms / What Didn't Work / Solution / Why It Works / Prevention) or **Knowledge Track** (Context / Guidance / Why / When / Examples) format, then checks for overlap with existing knowledge via `claude-obsidian:wiki-query` when available. Filing is delegated: if `claude-obsidian:save` is available, `/save` places the note in the vault, attaches frontmatter, cross-links, updates the hot cache, and appends a log entry. If `claude-obsidian` is not installed, the drafted note is emitted inline for the user to capture into whatever knowledge store they prefer.
+- **Outcome:** Either a durable vault note (when `claude-obsidian` is active) or a structured Markdown block in the response. Never auto-deletes or overwrites without flagging.
 
 ---
 
@@ -229,7 +229,7 @@ No phase contract tries to be its own audit log. The canonical audit sources are
 
 1. **GitHub edit history** — every prior version of issue/PR bodies.
 2. **Issue comments from `/implement` checkpoints** — a permanent timeline (comments are not edited, only added).
-3. **`memory/wiki/`** (Obsidian vault) — when a re-run captures a new note via `/compound` or `/save`, that note (plus its entry in `memory/wiki/log.md`) is the permanent record of "the second attempt shipped this way".
+3. **The claude-obsidian vault** (optional) — when installed, any note filed via `/compound` → `/save` plus the corresponding entry in the vault log is the permanent record of "the second attempt shipped this way". Without `claude-obsidian`, this tier is absent; the `/compound` inline output serves the same purpose but relies on the user to persist it.
 
 All three are read-only from the perspective of downstream phases.
 
@@ -244,7 +244,7 @@ Four tiers, no overlap:
 | `TodoWrite` | In-context | This session only | Throwaway working scratchpad |
 | `./.claude/NOTES.md` | Worktree-local | This phase, across sessions | In-flight decisions, current task, open questions |
 | GitHub issue body | Remote | Cross-phase | Acceptance criteria, prior-phase decisions, handoff state |
-| Obsidian vault | `memory/wiki/` (git-tracked) | Durable, cross-feature | Compounded knowledge — bug-fix history, patterns, architectural insights (written by `/compound` or the plugin's `/save`) |
+| Durable vault (optional) | The claude-obsidian vault (git-tracked) | Durable, cross-feature | Compounded knowledge — bug-fix history, patterns, architectural insights (written by `/compound` via `/save` when the plugin is installed) |
 
 ---
 
@@ -252,4 +252,4 @@ Four tiers, no overlap:
 
 - **File:** `skills/prune/SKILL.md`
 - **When:** Monthly, or after major refactors.
-- **What it does:** Audits `CLAUDE.md`, memory files, and `memory/wiki/**/*.md` for stale / superseded / unclear entries (semantic staleness; `wiki-lint` complements this for vault-structural health — orphans, broken wikilinks, missing frontmatter). Never auto-deletes — produces recommendations for user approval.
+- **What it does:** Audits `CLAUDE.md` and auto-memory files for stale / superseded / unclear entries (semantic staleness). When `claude-obsidian` is installed, delegates the vault audit to `wiki-lint` (structural health — orphans, broken wikilinks, missing frontmatter) and folds the findings in. Without `claude-obsidian`, the vault lane is skipped with a one-line note. Never auto-deletes — produces recommendations for user approval.

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -17,9 +17,14 @@ A GitHub issue with problem statement and acceptance criteria (from /discovery).
 
 2. **Dispatch parallel research agents** using TeamCreate before the architecture team begins:
    - **Codebase research agent** — systematic scan of relevant code: technology stack, module structure, related implementations, naming conventions, existing patterns. Outputs a structured context brief.
-   - **Patterns/learnings agent** — searches `memory/wiki/` (start with `memory/wiki/hot.md` and `memory/wiki/index.md`, then concepts/entities/sources), project documentation, past decision records, and — when local patterns are thin — external documentation via Context7 or web search for relevant prior art and lessons learned.
+   - **Patterns/learnings agent** — gathers prior art from, in order:
+     1. **The claude-obsidian vault, if available.** If `claude-obsidian:wiki-query` is usable, ask it for concepts/entities/sources/meta relevant to the feature (prior decisions, patterns, bug-fix history). Use whatever vocabulary the plugin expects — the agent does not know or need a filesystem path.
+     2. **Project documentation** under the repo (READMEs, ADRs, `docs/**`).
+     3. **External documentation** via Context7 or web search, when local patterns are thin.
 
-   **Gate rule**: skip external/web research when codebase research finds 3+ direct pattern examples. Always run full research for security, payments, privacy topics, or when local patterns are thin (fewer than 3 examples).
+     If `claude-obsidian` is not installed, skip step 1 and record a one-line note in the research brief: `Vault query skipped — claude-obsidian not installed.`
+
+   **Gate rule**: skip external/web research when internal sources (vault + project docs) yield 3+ direct pattern examples. Always run full research for security, payments, privacy topics, or when local patterns are thin (fewer than 3 examples).
 
    Research results feed into the architecture team's context before they begin proposing approaches.
 

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: compound
-description: Capture learnings from completed work into durable, searchable wiki notes. Invoke when the user says "it's fixed", "that worked", "working now", or explicitly via /compound — also after a non-trivial debugging session or implementation concludes successfully. Turns ephemeral knowledge into reusable artifacts in the Obsidian vault at memory/wiki/.
+description: Capture learnings from completed work into durable, searchable wiki notes. Invoke when the user says "it's fixed", "that worked", "working now", or explicitly via /compound — also after a non-trivial debugging session or implementation concludes successfully. When the claude-obsidian plugin is installed, filing is delegated to its /save flow; otherwise the structured note is emitted inline for the user to capture.
 model: sonnet
 ---
 
-You are leading the knowledge compounding phase. Your job is to capture what was just learned — the fix, the insight, the pattern — into a durable artifact that future agents and developers can discover and reuse.
+You are leading the knowledge compounding phase. Your job is to capture what was just learned — the fix, the insight, the pattern — into a structured, reusable artifact that future agents and developers can discover and reuse.
 
-The target is the Obsidian vault at `memory/wiki/`, powered by the `claude-obsidian` plugin (Karpathy's LLM Wiki pattern). The vault's schema is in `memory/WIKI.md` and vault-scoped instructions are in `memory/CLAUDE.md`. If the `claude-obsidian` plugin is enabled, prefer its `/save` flow — it handles frontmatter, cross-links, and the operation log automatically. This skill describes the same workflow for the direct-file case and adds dedupe/discoverability checks on top.
+This skill extracts the learning and drafts it. **Filing is delegated** to the `claude-obsidian` plugin when available: its `/save` command handles vault placement, frontmatter, cross-links, hot-cache updates, and the operation log automatically. If `claude-obsidian` is not installed, the drafted note is emitted inline for the user to copy into whatever knowledge store they prefer.
 
 ## Input
 
@@ -31,44 +31,40 @@ Decision tree:
 
 Single-pass extraction. Work through these steps yourself:
 
-1. Ensure `memory/wiki/concepts/` exists — create it if missing. (The `/wiki` command scaffolds the full vault if anything else is missing.)
-2. Identify the problem and solution from the conversation history.
-3. Search `memory/wiki/` for existing notes with overlapping content (same module, component, or symptoms). Start with `memory/wiki/index.md` and `memory/wiki/hot.md`; grep `memory/wiki/concepts/`, `memory/wiki/entities/`, and `memory/wiki/sources/` for related material.
-   - **High overlap** (same root cause or very similar symptoms) → update the existing note instead of creating a new one. Bump `updated:` in the frontmatter.
-   - **Partial overlap** (related but distinct) → create a new note, add the related note to the `related:` list and a wikilink in "See Also".
-   - **No overlap** → create a new note.
-4. Write the wiki note (see Knowledge Tracks and Output Format below).
-5. Append a one-line entry to `memory/wiki/log.md` describing what was filed.
-6. Verify discoverability: check whether `CLAUDE.md` or project-level instructions point at `memory/wiki/`. If not, suggest adding a line like: `Check memory/wiki/ (start with hot.md, then index.md) for known issues and patterns before debugging.` Do not modify CLAUDE.md automatically — present the suggestion to the user.
-7. **Staleness check** — scan `memory/wiki/` for notes the new learning contradicts or supersedes. If conflict exists, flag it for consolidation (do not auto-delete — present the conflict to the user). `wiki-lint` can help.
+1. Identify the problem and solution from the conversation history.
+2. Check for overlap with existing knowledge:
+   - If the `claude-obsidian:wiki-query` command is available, ask it for notes overlapping on module, symptoms, or root cause. Use its verdict.
+   - Otherwise, skip the overlap check and note in the output that it was skipped.
+3. Draft the note using the appropriate Knowledge Track (see below).
+4. File the note:
+   - If `claude-obsidian:save` is available → invoke `/save` with the drafted content as input. Let `claude-obsidian` place it, add frontmatter, cross-link, and update its hot cache + log.
+   - Otherwise → emit the drafted note inline in the response as a fenced Markdown block the user can copy, and add a one-line suggestion: `Install claude-obsidian (claude plugin marketplace add AgriciDaniel/claude-obsidian) and run /wiki to bootstrap a vault; future /compound invocations will file automatically.`
+5. **Staleness check** — if the overlap check found an existing note that the new learning contradicts or supersedes, flag it to the user for consolidation. Do not auto-edit other notes. The `wiki-lint` command (from `claude-obsidian`) is the complementary audit.
 
 ### Full
 
-1. Ensure `memory/wiki/concepts/` exists — create it if missing.
-
-2. **Spawn a compounding team** using TeamCreate with three specialists:
+1. **Spawn a compounding team** using TeamCreate with three specialists:
    - **Context analyst** — reviews the full conversation history and git diff to extract: what broke, what was tried, what worked, and why.
    - **Solution extractor** — distills the fix into a reusable pattern: root cause, solution steps, prevention guidance.
-   - **Overlap scanner** — searches `memory/wiki/` (concepts/entities/sources + index + hot cache) and project docs for existing coverage. Reports whether to create new or update existing:
-     - **High overlap** (same root cause or very similar symptoms) → update the existing note with new findings.
-     - **Partial overlap** (related but distinct) → create new note, add a wikilink to the related note in `related:` and "See Also".
-     - **No overlap** → create new note.
+   - **Overlap scanner** — if `claude-obsidian:wiki-query` is available, asks it for existing coverage of the module, symptoms, or root cause. Reports:
+     - **High overlap** (same root cause or very similar symptoms) → recommend updating the existing note. Include the target note's identifier in the report.
+     - **Partial overlap** (related but distinct) → recommend creating new; include the related note's identifier for cross-linking.
+     - **No overlap** → recommend creating new.
+     - If `wiki-query` is not available, report `"skipped: no vault query tool available"`.
 
-3. Teammates share findings via messages. The overlap scanner's verdict determines whether we create or update.
+2. Teammates share findings via messages. Synthesize into a single drafted note.
 
-4. Synthesize team findings into a wiki note.
+3. File the note:
+   - If `claude-obsidian:save` is available → invoke `/save` with the drafted content and, if the overlap scanner recommended an update, pass the target note identifier so `/save` updates in place rather than creating a new note.
+   - Otherwise → emit the drafted note inline, plus the overlap scanner's verdict so the user knows whether to file as new or merge into an existing note.
 
-5. Append an entry to `memory/wiki/log.md`.
-
-6. Verify discoverability: check whether `CLAUDE.md` or project-level instructions point at `memory/wiki/`. If not, suggest adding a line like: `Check memory/wiki/ (start with hot.md, then index.md) for known issues and patterns before debugging.` Do not modify CLAUDE.md automatically — present the suggestion to the user.
-
-7. **Staleness check** — scan `memory/wiki/` for notes the new learning contradicts or supersedes. If the new note contradicts or replaces an existing one, flag it for consolidation (do not auto-delete — present the conflict to the user). `wiki-lint` is the plugin's complementary audit.
+4. **Staleness check** — if the overlap scanner flagged a contradicting or superseded note, present the conflict to the user. Do not auto-delete. Recommend running `wiki-lint` (from `claude-obsidian`) for a broader audit if conflicts are recurrent.
 
 ## Output
 
 ### Knowledge Tracks
 
-Choose the track that fits what was learned. Both end up under `memory/wiki/concepts/` — they differ in frontmatter tags and body shape.
+Choose the track that fits what was learned. Both produce a structured Markdown note — `claude-obsidian`'s `/save` will slot it into the correct vault location (concept/entity/source) and attach frontmatter based on content.
 
 #### Bug Track
 Use when the learning came from fixing a bug or unexpected behavior. Tag with `bug-fix`.
@@ -113,50 +109,29 @@ Use when the learning is a pattern, technique, or architectural insight. Tag wit
 <!-- Concrete code examples or references -->
 ```
 
-### Output Format
+### Note shape (inline fallback)
 
-Create (or update) a Markdown file under `memory/wiki/concepts/` with this frontmatter shape (matches the vault schema in `memory/WIKI.md`):
+When `claude-obsidian` is not available and the note is emitted inline, include a minimal frontmatter block so the user can drop it straight into any vault:
 
 ```markdown
 ---
-type: concept
 title: "<Descriptive Title>"
-complexity: basic | intermediate | advanced
-domain: <module or area — e.g. workflow, auth, payments>
-aliases:
-  - "<alternate phrasing>"
+tags: [<track tag>, <domain tag>, <specific tag>]
 created: <YYYY-MM-DD>
-updated: <YYYY-MM-DD>
-tags:
-  - <track tag — bug-fix | pattern | technique | architecture>
-  - <domain tag>
-  - <specific tag>
-status: draft | mature | deprecated
-related:
-  - "[[<related wiki note title>]]"
-  - "[[concepts/_index]]"
-sources:
-  - "<url or internal ref>"
 ---
 
 # <Descriptive Title>
 
-<!-- Knowledge track content here (Bug Track or Knowledge Track) -->
-
-## See Also
-
-- `[[<related note>]]`
-- `<path/to/skill>` when relevant
+<!-- Bug Track or Knowledge Track body -->
 ```
 
-File naming: `memory/wiki/concepts/<Descriptive Title>.md` (Title Case with spaces, matching the existing vault convention — e.g. `Compounding Knowledge.md`). Do not kebab-case; Obsidian wikilinks match the file title.
+When `claude-obsidian` is active, pass only the body + a suggested title to `/save`; the plugin owns the frontmatter schema.
 
 ## Rules
 
 - Capture knowledge while it's fresh — don't defer.
-- Prefer updating existing notes over creating duplicates.
-- Keep notes concise — future readers want answers, not narratives.
 - Include actual error messages and stack traces in symptoms — these are what people search for.
-- Never include secrets, tokens, or credentials in wiki notes.
-- Always add at least one wikilink in `related:` and one in "See Also" so the graph stays connected — orphans are surfaced by `wiki-lint`.
-- If the `claude-obsidian` plugin is active and a `/save` invocation would produce the same artifact, prefer `/save` — the plugin's schema, index, and log updates stay in sync automatically.
+- Never include secrets, tokens, or credentials in notes.
+- Prefer updating an existing note over creating a duplicate (the overlap scanner's job).
+- Do not file directly to any filesystem path. Delegation to `/save` is the only vault-write path; the inline fallback hands responsibility to the user.
+- If `claude-obsidian` is installed but `/save` invocation fails, report the error inline with the drafted note — never silently drop the capture.

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -17,7 +17,7 @@ A GitHub issue number from /discovery (or provided by the user).
 
 2. **Dispatch a research team** (TeamCreate) before the definition team:
    - **Codebase research agent** — scans tech stack, modules, related implementations, naming, existing patterns. Outputs a structured brief.
-   - **Patterns/learnings agent** — searches `memory/wiki/` (start with `hot.md` and `index.md`, then concepts/entities/sources), project docs, past decisions, and (when local patterns are thin) external sources via Context7. Skip external research when 3+ direct pattern examples exist; always run full research for security/payments/privacy.
+   - **Patterns/learnings agent** — gathers prior art from, in order: (1) the claude-obsidian vault via `claude-obsidian:wiki-query` if available (concepts/entities/sources/meta); (2) project docs (READMEs, ADRs, `docs/**`); (3) external sources via Context7 when local patterns are thin. If `claude-obsidian` is not installed, step 1 is skipped with a note. Skip external research when internal sources yield 3+ direct pattern examples; always run full research for security/payments/privacy.
 
    The brief feeds both the architecture and design specialists as seed context.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -39,7 +39,7 @@ When /review and /verify both pass with no issues:
 
 ### Compound (after PR is open)
 
-6. **Run /compound** — capture learnings from the implementation cycle. If the build involved non-trivial debugging, unexpected edge cases, or architectural surprises, /compound writes them into the Obsidian vault at `memory/wiki/` (concepts/, entities/, or sources/ depending on the shape) so future `/architecture` research can find them.
+6. **Run /compound** — capture learnings from the implementation cycle. If the build involved non-trivial debugging, unexpected edge cases, or architectural surprises, `/compound` drafts a structured note and files it via `claude-obsidian:save` when that plugin is installed (otherwise it returns the note inline for the user to capture). Filed notes become available to future `/architecture` and `/define` research via `claude-obsidian:wiki-query`.
 
 ## Rules
 

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: prune
-description: Audit CLAUDE.md rules, memory files, and wiki notes for staleness. Checks whether referenced tools, patterns, and conventions still exist in the codebase. Use monthly or after major refactors. Complements the claude-obsidian plugin's wiki-lint (which handles vault-internal health — orphans, broken links, frontmatter gaps).
+description: Audit CLAUDE.md rules, memory files, and (optionally) the claude-obsidian vault for staleness. Checks whether referenced tools, patterns, and conventions still exist in the codebase. Use monthly or after major refactors. Vault-internal health (orphans, broken links, frontmatter gaps) is delegated to claude-obsidian's wiki-lint when available.
 model: haiku
 ---
 
 You are auditing the project's Claude Code rules and documentation for staleness.
 
+This skill has two lanes:
+
+- **Rules lane** — always runs. Audits `CLAUDE.md`, imported files, and the harness's auto-memory.
+- **Vault lane** — optional. If the `claude-obsidian` plugin is installed, delegates the vault audit to its `wiki-lint` command and folds the findings in. If not, the vault lane is skipped with a one-line note.
+
 ## Process
+
+### Rules lane (always)
 
 1. **Gather all rule sources:**
    - `~/.claude/CLAUDE.md` (global)
    - Any `@imported` files referenced in CLAUDE.md
    - Project-level `CLAUDE.md` (if exists in cwd)
-   - `memory/wiki/**/*.md` — Obsidian vault notes (written by `/compound` or `/save`, per the Karpathy LLM Wiki pattern). Scan `memory/wiki/concepts/`, `memory/wiki/entities/`, `memory/wiki/sources/`, and `memory/wiki/meta/`; use `memory/wiki/index.md` as the map.
    - `~/.claude/projects/<project>/memory/MEMORY.md` + topic files — Claude Code's built-in auto memory (per-user, harness-managed). Group these together when reporting; do not propose edits inside `MEMORY.md` itself unless it is clearly stale, since the harness rewrites it.
 
 2. **For each rule or guidance item, assess:**
@@ -21,17 +27,24 @@ You are auditing the project's Claude Code rules and documentation for staleness
    - Has it been superseded by a newer rule or convention?
    - Is it redundant with built-in Claude Code behavior?
 
-3. **For each wiki note:**
-   - Is the problem or pattern it describes still possible / applicable? (check if the root cause or usage context still exists)
-   - Has the codebase changed enough that the solution steps or guidance are invalid?
-   - Is there a newer wiki note that supersedes it?
-   - Defer vault-structural checks (orphaned pages, broken `[[wikilinks]]`, missing frontmatter fields) to `wiki-lint` — this skill is about semantic staleness, not schema hygiene.
-
-4. **For each memory file:**
+3. **For each auto-memory file:**
    - Is the information still accurate? (check against current state)
    - Is it redundant with what's already in CLAUDE.md or the codebase?
 
-5. **Classify each item:**
+### Vault lane (optional — claude-obsidian)
+
+4. **If `claude-obsidian:wiki-lint` is available:**
+   - Invoke it. It handles vault-structural checks (orphans, broken wikilinks, missing frontmatter fields, stale claims) — don't duplicate that work here.
+   - Additionally ask it (or use `claude-obsidian:wiki-query`) to flag concept/entity/source notes whose described problem, pattern, or root cause may no longer apply given recent code changes. That semantic check is the piece unique to `/prune`.
+   - Fold the returned findings into the audit report as a separate section titled "Vault (via wiki-lint)".
+
+5. **If `claude-obsidian` is not installed:**
+   - Skip step 4.
+   - Add a single line to the report: `Vault audit skipped — install claude-obsidian (claude plugin marketplace add AgriciDaniel/claude-obsidian) to enable.`
+
+### Classification
+
+6. **Classify each item:**
    - **Current** — still relevant, keep as-is
    - **Stale** — references things that no longer exist, recommend removal
    - **Superseded** — replaced by a newer rule/doc, recommend consolidation
@@ -40,13 +53,16 @@ You are auditing the project's Claude Code rules and documentation for staleness
 ## Output
 
 An audit report with:
+
 - Total rules/docs audited
-- Items by classification (current / stale / superseded / unclear)
+- Items by classification (current / stale / superseded / unclear) for the rules lane
+- The vault lane's findings (or the "skipped" line) as a separate section
 - Specific recommendations for each non-current item
 - Suggested edits (but do NOT apply them without user approval)
 
 ## Rules
 
-- Never delete rules or docs automatically — present recommendations and wait for approval
-- When in doubt, classify as "unclear" rather than "stale"
-- Check the actual codebase, not just the rule text — a rule might reference an outdated name but the intent is still valid
+- Never delete rules or docs automatically — present recommendations and wait for approval.
+- When in doubt, classify as "unclear" rather than "stale".
+- Check the actual codebase, not just the rule text — a rule might reference an outdated name but the intent is still valid.
+- Do not scan vault files directly. The vault's structure is the `claude-obsidian` plugin's responsibility; this skill calls into it rather than walking paths.


### PR DESCRIPTION
## Summary

- Removes 36 hardcoded `memory/wiki/` references across 9 files; skills now speak the `claude-obsidian` vocabulary (vault, hot cache, log, concept/entity/source notes, session archive) instead of filesystem paths.
- Delegates all vault I/O to `claude-obsidian` commands (`/save`, `wiki-lint`, `wiki-query`) when the plugin is installed; each skill degrades gracefully with a one-line note when it isn't.
- Moves the `Context Hygiene Between Workflow Phases` note from the author's personal vault into the plugin as `docs/context-hygiene.md`; the three `_shared/` protocols retarget their cites to the new in-plugin location.
- Adds an "Optional: claude-obsidian integration" section to the README.
- Bumps the plugin + marketplace manifests to v0.2.0.

## Manual testing

1. `claude plugin validate .` → passes (already run).
2. `grep -rn 'memory/wiki\|memory/WIKI' . --include='*.md' --include='*.json'` → only hit is the title of `docs/context-hygiene.md`.
3. **No-vault smoke test:** in a fresh directory without `claude-obsidian` installed, invoke `/prune` — expect the "Vault audit skipped — install claude-obsidian…" line, no errors.
4. **Vault-present smoke test:** from `claude-config` (which has both plugins), simulate a fix and invoke `/compound` — expect the agent to call `/save` rather than write any filesystem path directly.
5. After merge: tag `v0.2.0`, cut GitHub release, update local installs with `claude plugin update claude-workflow`.

Closes #9