### PR TITLE
fix: address PR review comments from #6 and #7

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-workflow",
   "version": "0.2.0",
-  "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. Includes 16 skills, shared protocols, authoring tools, and a /new-skill scaffolder.",
+  "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. Ships a family of lifecycle skills, shared protocols, an authoring standard, and the /new-skill scaffolder.",
   "author": {
     "name": "Michal Konopski",
     "url": "https://github.com/misiekhardcore"

--- a/_templates/SKILL.template.md
+++ b/_templates/SKILL.template.md
@@ -1,34 +1,38 @@
 ---
-name: {{skill-name}}
-description: {{one-to-two sentence description — the primary trigger mechanism. Include both WHAT the skill does AND WHEN to use it (contexts, trigger phrases). Be specific: "Does X. Use when Y." Avoid generic phrasing.}}
-model: {{haiku | sonnet | opus}}
-{{!-- include the line below only if this skill runs long-form multi-turn research or decision-making --}}
-{{!-- effortLevel: high --}}
-{{!-- include the line below only if the skill should be restricted to a subset of tools; omit entirely to allow all tools --}}
-{{!-- allowed-tools: Read, Grep, Glob, Bash --}}
+name: "<skill-name>"
+description: "<one-to-two sentence description — the primary trigger mechanism. Include both WHAT the skill does AND WHEN to use it (contexts, trigger phrases). Be specific: 'Does X. Use when Y.' Avoid generic phrasing.>"
+model: "<haiku | sonnet | opus>"
+# Uncomment the next line only if this skill runs long-form multi-turn research or decision-making:
+# effortLevel: high
+# Uncomment the next line only if the skill should be restricted to a subset of tools; omit entirely to allow all tools:
+# allowed-tools: Read, Grep, Glob, Bash
 ---
 
-{{!-- optional opening statement — use for phase-boundary skills. Example: "You are leading the X phase. Your job is to..." --}}
+<!--
+Author note: the frontmatter above uses YAML-valid placeholder strings and YAML comments. Replace the "<…>" strings with real values (keep the quotes, or drop them once the value is a simple identifier). Leave the commented `effortLevel` / `allowed-tools` lines commented out unless the skill needs them, then uncomment and fill in.
+
+Optional opening statement — use for phase-boundary skills. Example: "You are leading the X phase. Your job is to..."
+-->
 
 ## Input
 
-{{what the skill expects — issue number, problem statement, diff, conversation context, etc.}}
+<!-- What the skill expects — issue number, problem statement, diff, conversation context, etc. -->
 
 ## Process
 
-{{numbered steps. Be concrete: what to read first, what to spawn, what to output at each step.}}
+<!-- Numbered steps. Be concrete: what to read first, what to spawn, what to output at each step. -->
 
-1. {{first step}}
+1. <first step>
 
-2. {{second step}}
+2. <second step>
 
 ## Output
 
-{{what the skill produces — a file, a report, a PR, an updated issue body, etc.}}
+<!-- What the skill produces — a file, a report, a PR, an updated issue body, etc. -->
 
 ## Rules
 
-{{non-negotiable constraints — things that must always or never happen.}}
+<!-- Non-negotiable constraints — things that must always or never happen. -->
 
-- {{rule 1}}
-- {{rule 2}}
+- <rule 1>
+- <rule 2>

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,6 +1,6 @@
 # Development Workflow
 
-A step-by-step walkthrough of the feature lifecycle in this repo: which skill runs when, what it expects as input, and what it leaves behind. The rules themselves live in `CLAUDE.md` and in each `skills/<name>/SKILL.md`; this doc stitches them into a single narrative so a newcomer doesn't have to grep 15 files.
+A step-by-step walkthrough of the feature lifecycle in this repo: which skill runs when, what it expects as input, and what it leaves behind. The rules themselves live in `CLAUDE.md` and in each `skills/<name>/SKILL.md`; this doc stitches them into a single narrative so a newcomer doesn't have to read every `SKILL.md` to understand the flow.
 
 ## Workflow paths
 
@@ -30,7 +30,7 @@ Handoff between phases uses the **GitHub issue body** as the durable artifact �
                                                                                        │
                                                                               [human reviews PR]
                                                                                        │
-                                                                              /address-review
+                                                                              /resolve-pr-feedback
 ```
 
 ---
@@ -72,7 +72,7 @@ AC are the contract `/implement` verifies against, so silent changes have blast 
 
 | Situation | Action |
 |-----------|--------|
-| A PR is already open | Post on the PR: "Acceptance criteria updated in #\<issue\>. Current AC: \<n/n\> still met, \<n\> changed, \<n\> new. Re-run /address-review or /implement to reconcile." Does **not** close the PR. |
+| A PR is already open | Post on the PR: "Acceptance criteria updated in #\<issue\>. Current AC: \<n/n\> still met, \<n\> changed, \<n\> new. Re-run /resolve-pr-feedback or /implement to reconcile." Does **not** close the PR. |
 | Sub-issues exist (from a prior `/define`) | Re-derive each sub-issue's AC slice from the new parent AC. Slices that no longer map get a superseded comment + close. |
 | Neither applies | Pure overwrite, nothing to reconcile. |
 
@@ -131,7 +131,7 @@ When `/define` re-runs and the sub-issue breakdown changes, old sub-issues are r
   3. **`/verify`** (`skills/verify/SKILL.md`, Haiku) — a QA team runs the full verification chain (type-check, lint, unit tests, build, e2e) and checks every acceptance criterion with evidence. Reports pass/fail only — it does not fix.
   - If review or verify finds issues, a fix-brief (failing AC + file:line findings) is fed back to `/build`, then re-reviewed and re-verified.
 - **Outcome:** A draft PR linking the issue. All acceptance criteria met, review clean, verify clean. `/compound` runs automatically before the PR is opened.
-- **Follow-up:** After human review, use `/address-review`.
+- **Follow-up:** After human review, use `/resolve-pr-feedback`.
 
 ### Preamble (read before doing anything)
 
@@ -168,9 +168,9 @@ Not posted: per-commit updates, per-fix-cycle-iteration noise, internal reviewer
 
 ---
 
-## Step 5 — `/address-review` (Sonnet)
+## Step 5 — `/resolve-pr-feedback` (Sonnet)
 
-- **File:** `skills/address-review/SKILL.md`
+- **File:** `skills/resolve-pr-feedback/SKILL.md`
 - **When:** After a PR receives human review comments.
 - **What it does:** Fetches all review threads, triages them, spawns a fix team (one agent per disjoint file group), runs up to 2 fix-verify cycles per review round, then posts a verdict reply on every thread and resolves threads where appropriate.
 - **Outcome:** PR feedback processed in bulk with verdict replies posted, and resolved threads marked resolved. Safe to re-run for subsequent review rounds.
@@ -196,7 +196,7 @@ Fixed in abc1234 — replaced the N+1 loop with a single JOIN (benchmarks in com
 
 ### Idempotency and re-opened threads
 
-`/address-review` fetches the current state of each thread before acting. If it sees its own previous verdict tag and no new comments since, it skips that thread. If a reviewer unresolves a thread `/address-review` previously resolved, the next run treats it as a fresh triage entry (up to the 2-cycle cap per round).
+`/resolve-pr-feedback` fetches the current state of each thread before acting. If it sees its own previous verdict tag and no new comments since, it skips that thread. If a reviewer unresolves a thread `/resolve-pr-feedback` previously resolved, the next run treats it as a fresh triage entry (up to the 2-cycle cap per round).
 
 ---
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -56,7 +56,7 @@ A feature branch in a worktree with all acceptance criteria implemented, tests p
 ## Rules
 
 - Use superpowers:test-driven-development for the TDD workflow
-- Use worktrunk (`wt`) for worktree management
+- Use `git worktree add` / `git worktree remove` for worktree management. [worktrunk](https://github.com/max-sixty/worktrunk)'s `wt` wrapper is an optional convenience when installed; the skill assumes only the stock `git worktree` commands.
 - Use TeamCreate for team coordination
 - Do not ask the user whether to use teams — just use them
 - Do not open a PR — that happens after /implement completes the full cycle

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -49,8 +49,7 @@ Classify the task before dispatching:
 
    **(a) Problem statement preamble** — `/discovery`-only, not part of the handoff field order. From /describe output: what the user is trying to do, why the current state is inadequate, who is affected. This is the framing the rest of the issue depends on. Subsequent phases do not update this section.
 
-   **(b) Handoff block** — the five fields below, in this order, matching `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. Field order is uniform across all phases so the next session can scan-read it.
-   - **Title** — concise feature description
+   **(b) Handoff block** — the five fields below, in this order, matching `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. Field order is uniform across all phases so the next session can scan-read it. (The issue *title* is set via `gh issue create --title` and is not part of the body handoff block.)
    - **Acceptance criteria** — from /specify output, as a numbered list of testable scenarios
    - **Constraints** — explicit in/out scope boundaries, non-negotiable decisions surfaced during discovery
    - **Prior decisions** — any decisions already made during discovery (one line each, with rationale)

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -31,6 +31,8 @@ A brief statement from the author of what the skill should do — or nothing, in
 
    e. **allowed-tools** — "Should the skill be restricted to a subset of tools, or have access to everything? (restricted/all)" Most skills want `all` (omit the field). Only restrict when the skill is narrow and should not e.g. write files.
 
+      If the author picks **restricted**, ask one follow-up: "Which tools should it be allowed to use? (comma-separated — e.g. `Read, Grep, Glob, Bash`)". Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask). Use the answer verbatim as the value of `allowed-tools:` in the generated frontmatter. On `all`, omit the field entirely.
+
    f. **Shared protocols** — "Does this skill do any of the following? (yes/no to each)". Walk through the AUTHORING.md decision table:
       - Write or read a GitHub issue handoff block → include `handoff-artifact.md`
       - Interview the user, ask questions, seek approval → include `interviewing-rules.md`

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -19,15 +19,37 @@ Either:
 1. Determine the current PR:
    - If a URL was provided, extract owner/repo and PR number from it
    - Otherwise, use `gh pr view --json number,url` to get the current branch's PR
-2. Fetch all review comments: `gh api repos/{owner}/{repo}/pulls/{number}/comments`
-3. Fetch review threads: `gh api repos/{owner}/{repo}/pulls/{number}/reviews`
-4. Fetch top-level PR conversation comments: `gh api repos/{owner}/{repo}/issues/{number}/comments`
-5. Filter out noise:
-   - Bot-generated comments (dependabot, CI bots, linters)
+2. Fetch **review threads with resolution state** via GraphQL (REST's `pulls/{n}/reviews` returns top-level reviews, not threads, and never exposes `isResolved`):
+
+   ```bash
+   gh api graphql -F owner={owner} -F repo={repo} -F number={number} -f query='
+     query($owner:String!, $repo:String!, $number:Int!) {
+       repository(owner:$owner, name:$repo) {
+         pullRequest(number:$number) {
+           reviewThreads(first:100) {
+             nodes {
+               id
+               isResolved
+               isOutdated
+               path
+               line
+               comments(first:50) {
+                 nodes { id databaseId body author { login } createdAt url }
+               }
+             }
+           }
+         }
+       }
+     }'
+   ```
+
+3. Fetch top-level PR conversation comments (not attached to a thread): `gh api repos/{owner}/{repo}/issues/{number}/comments`
+4. Filter out noise:
+   - Threads where `isResolved: true` (skip unless the user explicitly asked to re-open)
+   - Bot-generated comments (dependabot, CI bots, linters) — match by `author.login`
    - Pure approval comments with no actionable content
    - CI status summaries
-   - **Note:** The REST API does not expose thread resolution status — treat all fetched threads as potentially unresolved.
-6. If a specific thread URL was given, filter to just that thread
+5. If a specific thread URL was given, filter to just that thread by matching its `databaseId` against the URL's anchor.
 
 ### Phase 2 — Triage
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -14,7 +14,7 @@ You are performing an end-of-session audit. Review what happened in this session
    - **Scope changes** — anything you did beyond or short of what was originally asked
    - **Follow-ups** — work that remains, was deferred, or needs human verification
 
-   Resolve the worktree root with `git rev-parse --show-toplevel` and check for `<root>/.claude/NOTES.md`. If it exists, read it first — it is the authoritative worklog for this phase. Merge its **Decisions made this session** and **Open questions** into the audit so nothing is lost on reset.
+   Resolve the worktree root with `git rev-parse --show-toplevel` and check for `<root>/.claude/NOTES.md`. If it exists, read it first — it is the authoritative worklog for this phase. Merge its **Decisions made this session** and **Open questions** into the audit so nothing is lost on reset. See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` for the file's section shape and lifecycle rules.
 
 2. For each item, note:
    - What the assumption/decision was


### PR DESCRIPTION
## Summary

Addresses unresolved Copilot review comments from the already-merged PRs #6 and #7, plus one related consistency fix.

Closes #11

## Fixes

**From PR #6 (scaffold + authoring):**
- `_templates/SKILL.template.md` — replace Handlebars `{{...}}` with YAML-valid quoted strings + `#` comments so the template parses cleanly as frontmatter.
- `skills/build/SKILL.md` — drop `worktrunk (wt)` hard requirement; document stock `git worktree` as the baseline.
- `docs/workflow.md` — fix stale "15 files" count and 6 stale `/address-review` references → `/resolve-pr-feedback`.

**From PR #7 (skill migration):**
- `skills/resolve-pr-feedback/SKILL.md` — swap REST `pulls/{n}/reviews` (top-level reviews, no `isResolved`) for a GraphQL `reviewThreads` query so we can filter resolved/outdated threads and bot authors properly.
- `skills/new-skill/SKILL.md` — add follow-up question when the author picks `restricted` tool scope, validate tool names, emit them verbatim as `allowed-tools:`.
- `skills/wrap-up/SKILL.md` — add missing cite to `_shared/notes-md-protocol.md` for NOTES.md shape.
- `skills/discovery/SKILL.md` — drop "Title" bullet from handoff field list; title is set via `gh issue create --title`, not in the body. Now matches the 5-field shape in `_shared/handoff-artifact.md`.

**Extra consistency fix:**
- `.claude-plugin/plugin.json` — drop hardcoded "16 skills" count from description.

## Manual testing

- [ ] `claude plugin validate .` passes
- [ ] `python3 -c "import yaml; yaml.safe_load(open('_templates/SKILL.template.md').read().split('---')[1])"` parses the template frontmatter cleanly
- [ ] `rg '/address-review' docs/ skills/ _shared/ _templates/ README.md` returns zero hits
- [ ] `rg 'worktrunk' skills/build/SKILL.md` shows only the "optional convenience" wording
- [ ] Diff `skills/resolve-pr-feedback/SKILL.md` against PR #7 to confirm the GraphQL block replaces the REST call