### PR TITLE
Discovery prior-art scout + orchestrator/skill improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ The building blocks: `/describe`, `/specify`, `/architecture`, `/design`, `/buil
 
 ## Prerequisites
 
-Skills that spawn parallel sub-agents require `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set in the environment. Without it, `TeamCreate` is unavailable and skills fall back to sequential execution.
+Skills that spawn parallel sub-agents require `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set in the environment. Without it, `TeamCreate` is unavailable and skills fall back to sequential execution, noting the degraded mode explicitly.
 
 ## Implementation Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ For the full lifecycle walkthrough — prerequisites, outcomes, and handoffs for
 
 The building blocks: `/describe`, `/specify`, `/architecture`, `/design`, `/build`, `/review`, `/verify`, `/grill-me`, `/wrap-up`, `/prune`, `/compound`.
 
+## Prerequisites
+
+Skills that spawn parallel sub-agents require `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set in the environment. Without it, `TeamCreate` is unavailable and skills fall back to sequential execution.
+
 ## Implementation Rules
 
 - **Default to single-agent.** Use `TeamCreate` only for parallelizable work across 3+ independent files or sub-issues.

--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -95,6 +95,13 @@ When passing a seed brief to a specialist:
 Optional: when invoked as a specialist from `/discovery`, may receive a **prior-art brief** as seed context (from the Prior-Art Scout). When a brief is provided, skip any internal prior-art search and incorporate the brief into the Product Pressure Test and problem statement synthesis. Without a brief, proceed as described below.
 ```
 
+`skills/describe/SKILL.md` shows the entry-point pattern: the specialist immediately classifies scope before any user interaction, which lets the orchestrator route it to Lightweight / Standard / Deep without overriding internal logic:
+
+```
+(blank line — signals start of scope classification block)
+Before starting, classify the task scope:
+```
+
 ## Hierarchical decomposition
 
 Orchestrators may nest: `/discovery` delegates to `/describe` and `/specify`; `/implement` delegates to `/build`, `/review`, and `/verify`. Rules:

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -7,7 +7,11 @@ model: "<opus for research-leading orchestrators; sonnet for coordinator orchest
 
 You are leading the <phase name> phase. Your goal is to <objective>.
 
-<!-- Coordinator variants (e.g. /implement): drop step 2 — upstream phases or sub-skills own research. -->
+<!--
+Research-leading vs coordinator orchestrator:
+- Research-leading (e.g. /discovery, /define): keep step 2 (Dispatch a research team) — the orchestrator is where deep reasoning happens.
+- Coordinator (e.g. /implement): omit step 2. Upstream phases or the sub-skills being sequenced own research; adding a research team here is redundant.
+-->
 
 ## Input
 

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -32,7 +32,8 @@ Classify before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` 
    - **Specialist B** — runs /<skill> to <do thing>.
 4. <Serialization rule — which specialist goes first and why.>
 5. **Write the handoff artifact** — update the GitHub issue body in place with decisions and the five-field block. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
-6. Present output to the user for approval. After sign-off, tell them to start the next phase in a fresh session.
+6. Present output to the user for approval.
+7. After sign-off, tell them to start the next phase in a fresh session.
 
 ## Output
 
@@ -44,3 +45,4 @@ Classify before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` 
 - Spawn research team before the main team in Standard/Deep — never skip the seed-brief gate.
 - Lightweight runs inline — never pay coordination overhead for under-a-minute work.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` and `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the five-field handoff shape.

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -7,11 +7,7 @@ model: "<opus for research-leading orchestrators; sonnet for coordinator orchest
 
 You are leading the <phase name> phase. Your goal is to <objective>.
 
-<!--
-Research-leading vs coordinator orchestrator:
-- Research-leading (e.g. /discovery, /define): keep step 2 (Dispatch a research team) — the orchestrator is where deep reasoning happens.
-- Coordinator (e.g. /implement): omit step 2. Upstream phases or the sub-skills being sequenced own research; adding a research team here is redundant.
--->
+<!-- Coordinator variants (e.g. /implement): drop step 2 — upstream phases or sub-skills own research. -->
 
 ## Input
 
@@ -49,4 +45,3 @@ Classify before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` 
 - Spawn research team before the main team in Standard/Deep — never skip the seed-brief gate.
 - Lightweight runs inline — never pay coordination overhead for under-a-minute work.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` and `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
-- See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the five-field handoff shape.


### PR DESCRIPTION
## Summary
- Adds discovery prior-art scout workflow and codifies multi-skill composition standards (issue #13)
- Right-sizes orchestrator teams and adds autonomous `/implement` loop
- Improves docs: Mermaid workflow graph, legend clarifications, contrast, table formatting
- Skill polish: `AskUserQuestion` adoption, `allowed-tools` clarification, Phase 0 → Scope Assessment rename

## Test plan
- [ ] Review diff against `main` (branch is 11 ahead / 2 behind — may need rebase)
- [ ] Verify skill frontmatter renders in Claude Code
- [ ] Sanity-check Mermaid diagram in README