### PR TITLE
Add repo pre-flight echo to /build and /resolve-pr-feedback

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -29,6 +29,18 @@ Decision tree:
 
 ## Process
 
+### Step 0 — Repository pre-flight
+
+1. Run `git remote -v` and `pwd` to detect the repository and branch.
+2. Display:
+   - Detected repository (owner/repo from origin remote URL)
+   - Current branch name
+   - Working directory path
+3. Ask the user to confirm: "Does this match the repo and branch you intend to work on?"
+4. Do not proceed with any `gh` or `git push` operations until the user explicitly confirms.
+
+### Steps 1+
+
 1. Read the issue, all comments, and linked sub-issues to understand the full scope.
 
 2. **Create a git worktree** for the feature (`git worktree add`). Worktrees keep the main workspace clean and let teammates operate in isolation. Lightweight still uses a worktree — the isolation is independent of team width.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -14,6 +14,16 @@ Either:
 
 ## Process
 
+### Phase 0 — Repository pre-flight
+
+1. Run `git remote -v` and `pwd` to detect the repository and branch.
+2. Display:
+   - Detected repository (owner/repo from origin remote URL)
+   - Current branch name
+   - Working directory path
+3. Ask the user to confirm: "Does this match the repo where you want to resolve PR feedback?"
+4. Do not proceed with any `gh` or `git push` operations until the user explicitly confirms.
+
 ### Phase 1 — Fetch
 
 1. Determine the current PR:


### PR DESCRIPTION
Closes #17

## Summary
- Adds pre-flight verification to both /build and /resolve-pr-feedback skills
- Detects repo from git remote and displays current branch
- Requires explicit user confirmation before any gh/git push operations

## Changes
- skills/build/SKILL.md: New Step 0 pre-flight with repo detection and user confirmation
- skills/resolve-pr-feedback/SKILL.md: New Phase 0 pre-flight with repo detection and user confirmation