### PR TITLE
docs: omit empty handoff sections in issue/PR descriptions

### DIFF
--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -8,15 +8,17 @@ This file is reference material — read it on demand when the skill reaches a h
 
 Every handoff artifact contains:
 
-1. **Acceptance criteria** — testable scenarios, unchanged from `/discovery`. One line each.
-2. **Constraints** — files in scope, files out of scope, non-negotiable decisions from `/define`.
-3. **Prior decisions** — "we chose X over Y because Z" entries. One line each. Include links to the conversation or code that produced the decision.
-4. **Evidence** — links to commits, PRs, benchmark output, design reviews, or approvals that justify each decision.
-5. **Open questions** — things the next phase must resolve. Explicit — no "obvious, will figure out later".
+1. **Acceptance criteria** — testable scenarios, unchanged from `/discovery`. One line each. **Mandatory.**
+2. **Constraints** — files in scope, files out of scope, non-negotiable decisions from `/define`. **Mandatory.**
+3. **Prior decisions** — "we chose X over Y because Z" entries. One line each. Include links to the conversation or code that produced the decision. *(Optional — omit heading when empty.)*
+4. **Evidence** — links to commits, PRs, benchmark output, design reviews, or approvals that justify each decision. *(Optional — omit heading when empty.)*
+5. **Open questions** — things the next phase must resolve. Explicit — no "obvious, will figure out later". *(Optional — omit heading when empty.)*
 
 ## Shape
 
-Always update the **issue body** in place. If a section for the current phase (e.g. `## Solution` for `/define`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids. Keep field order consistent across phases so the next session can scan-read the body top to bottom.
+Always update the **issue body** in place. If a section for the current phase (e.g. `## Solution` for `/define`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids.
+
+Fields appear in this order: Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions. Omit optional fields entirely when empty — a missing heading means zero items, not an unwritten section. Never write placeholder text ("None", "No open questions", etc.).
 
 ```markdown
 ## Handoff: /<prev> → /<next>
@@ -30,17 +32,14 @@ Always update the **issue body** in place. If a section for the current phase (e
 - Out of scope: <paths>
 - Must reuse: <existing module/util>
 
-**Prior decisions**
+**Prior decisions** (optional)
 - <one-line decision> (why: <rationale>)
-- ...
 
-**Evidence**
+**Evidence** (optional)
 - <link to commit | PR | benchmark | design review>
-- ...
 
-**Open questions**
+**Open questions** (optional)
 - <question the next phase must resolve>
-- ...
 ```
 
 ## Precedence
@@ -59,7 +58,7 @@ When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase
 - **For cross-phase state, the issue body wins.** If in-context recall disagrees with the body, trust the body.
 - **Never include secrets.** Evidence links should point to internal systems, not pasted API keys, credentials, or internal hostnames in log dumps.
 - **Never drop prior decisions to save space.** If the list is long, that's the workflow working — not a bug.
-- **Open questions are mandatory.** If there are none, say so explicitly ("No open questions") — never omit the section.
+- **Mandatory fields:** Acceptance criteria and Constraints — include on every handoff. **Optional fields:** Prior decisions, Evidence, and Open questions — omit the heading entirely when empty. Never write placeholder text ("None", "No open questions", etc.).
 
 ## Final-pass checklist
 

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -50,7 +50,7 @@ Decision tree:
    - Record architecture decisions and design decisions (with visuals) inside that section.
    - Create sub-issues with GitHub relationships if the work decomposes.
    - Define the dependency graph — identify what can be parallelized.
-   - The updated body is the sole input to `/implement` — a fresh session will read it, not this conversation. Include all five handoff fields (Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions). See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
+   - The updated body is the sole input to `/implement` — a fresh session will read it, not this conversation. Mandatory fields: Acceptance criteria and Constraints. Optional fields (omit heading when empty, no "None" placeholders): Prior decisions, Evidence, Open questions. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
 
 6. Present all decisions to the user for approval. Do not proceed until sign-off.
 

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -73,9 +73,9 @@ Decision tree:
    **(b) Handoff block** — the five fields below, in this order, matching `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. Field order is uniform across all phases so the next session can scan-read it. (The issue _title_ is set via `gh issue create --title` and is not part of the body handoff block.)
    - **Acceptance criteria** — from /specify output, as a numbered list of testable scenarios
    - **Constraints** — explicit in/out scope boundaries, non-negotiable decisions surfaced during discovery
-   - **Prior decisions** — any decisions already made during discovery (one line each, with rationale)
-   - **Evidence** — links to design reviews, benchmarks, prior discussions
-   - **Open questions** — things `/define` must resolve, explicit (say "None" if there are none)
+   - **Prior decisions** *(optional — omit if empty)* — any decisions already made during discovery (one line each, with rationale)
+   - **Evidence** *(optional — omit if empty)* — links to design reviews, benchmarks, prior discussions
+   - **Open questions** *(optional — omit if empty)* — things `/define` must resolve
 
 2. Present the issue to the user for approval. Do not proceed until sign-off.
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -56,7 +56,7 @@ Example (for issue #42):
 
 - Be honest about uncertainty — this is a self-audit, not a sales pitch
 - Include assumptions even if you are fairly confident — the user decides what matters
-- If nothing significant was assumed, say so briefly and do not pad the report
+- Omit subsections with nothing to report (Assumptions Made, Uncertain Decisions, Scope Notes, Follow-ups) — a missing subsection means zero items. Never write "None" or other placeholder text.
 - The audit is not complete until it is written into the issue body or the user has explicitly declined
 - Update the issue **body** in place — never post the audit as a comment. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
 - Never auto-update without user confirmation — show the draft and ask first


### PR DESCRIPTION
## Summary

Replaces the "Open questions are mandatory / say 'None' if there are none" rule with an omit-when-empty contract across the four handoff-shaped docs. Acceptance criteria and Constraints remain mandatory on every handoff; Prior decisions, Evidence, and Open questions are now omitted entirely when empty. A missing heading means zero items — no more `- None.` boilerplate.

Files touched (all in scope, per issue):
- `_shared/handoff-artifact.md` — "The five fields" list, Shape prose + block, Rules
- `skills/discovery/SKILL.md` — handoff-field list
- `skills/define/SKILL.md:53` — mandatory/optional split
- `skills/wrap-up/SKILL.md:59` — audit subsections rule

Closes #26

## Manual testing

Docs-only change — verify by reading and grepping.

1. **AC1** — open `_shared/handoff-artifact.md`, confirm the Rules section (~line 61) reads "Mandatory fields: Acceptance criteria and Constraints … Optional fields: Prior decisions, Evidence, and Open questions — omit the heading entirely when empty."
2. **AC2** — in the same file, confirm the prose above the shape block documents field ordering, and the shape block's `Prior decisions`, `Evidence`, `Open questions` headings each carry `(optional)`.
3. **AC3** — open `skills/discovery/SKILL.md` (~line 76–78); confirm all three optional fields show `*(optional — omit if empty)*` and that the "say 'None' if there are none" guidance is gone.
4. **AC4** — open `skills/define/SKILL.md:53`; confirm it names mandatory fields and says optional fields are omitted when empty with no "None" placeholders.
5. **AC5** — open `skills/wrap-up/SKILL.md:59`; confirm it lists the four audit subsections and states a missing subsection means zero items.
6. **AC6** — from the repo root, run:
   \`\`\`
   rg -n 'say.*[Nn]one|No open questions' _shared/handoff-artifact.md skills/discovery/SKILL.md skills/define/SKILL.md skills/wrap-up/SKILL.md
   \`\`\`
   Only matches should be in rules that forbid the phrases. No placeholder instructions should remain.