### PR TITLE
Use human-readable section headings in issue bodies

### DIFF
--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -14,17 +14,6 @@ Every handoff artifact contains:
 4. **Evidence** — links to commits, PRs, benchmark output, design reviews, or approvals that justify each decision. *(Optional — omit heading when empty.)*
 5. **Open questions** — things the next phase must resolve. Explicit — no "obvious, will figure out later". *(Optional — omit heading when empty.)*
 
-## Phase headings
-
-Each phase uses a fixed, human-readable heading that describes what the section contains — not the name of the command that produced it:
-
-| Phase | Section heading |
-|-------|----------------|
-| `/discovery` | `## Requirements` |
-| `/define` | `## Implementation plan` |
-| `/implement` | `## Implementation notes` |
-| `/wrap-up` | `## Session handoff` |
-
 ## Shape
 
 Always update the **issue body** in place. If a section for the current phase (e.g. `## Implementation plan` for `/define`, `## Session handoff` for `/wrap-up`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids.
@@ -64,7 +53,15 @@ When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase
 
 ## Rules
 
-- **Name sections by content, not by command.** Use the phase-specific heading from the table above (e.g. `## Implementation plan`, `## Requirements`) — never the slash command name (e.g. `## /define`, `## Handoff: /define → /implement`).
+- **Name sections by content, not by command.** Use the phase-specific heading below — never the slash command name (e.g. `## /define`, `## Handoff: /define → /implement`):
+
+  | Phase | Section heading |
+  |-------|----------------|
+  | `/discovery` | `## Requirements` |
+  | `/define` | `## Implementation plan` |
+  | `/implement` | `## Implementation notes` |
+  | `/wrap-up` | `## Session handoff` |
+
 - **Update the body, not a comment.** Every phase edits the issue body in place — append a new section if one does not exist for the current phase, edit the existing section if it does. Comments are for discussion only.
 - **Reset after updating.** Once the body is updated, tell the user to start the next phase in a fresh session. Do not call the next skill from within the current one.
 - **For cross-phase state, the issue body wins.** If in-context recall disagrees with the body, trust the body.

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -14,14 +14,25 @@ Every handoff artifact contains:
 4. **Evidence** — links to commits, PRs, benchmark output, design reviews, or approvals that justify each decision. *(Optional — omit heading when empty.)*
 5. **Open questions** — things the next phase must resolve. Explicit — no "obvious, will figure out later". *(Optional — omit heading when empty.)*
 
+## Phase headings
+
+Each phase uses a fixed, human-readable heading that describes what the section contains — not the name of the command that produced it:
+
+| Phase | Section heading |
+|-------|----------------|
+| `/discovery` | `## Requirements` |
+| `/define` | `## Implementation plan` |
+| `/implement` | `## Implementation notes` |
+| `/wrap-up` | `## Session handoff` |
+
 ## Shape
 
-Always update the **issue body** in place. If a section for the current phase (e.g. `## Solution` for `/define`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids.
+Always update the **issue body** in place. If a section for the current phase (e.g. `## Implementation plan` for `/define`, `## Session handoff` for `/wrap-up`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids.
 
 Fields appear in this order: Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions. Omit optional fields entirely when empty — a missing heading means zero items, not an unwritten section. Never write placeholder text ("None", "No open questions", etc.).
 
 ```markdown
-## Handoff: /<prev> → /<next>
+## Implementation plan
 
 **Acceptance criteria** (from /discovery, unchanged)
 - AC1: ...
@@ -53,6 +64,7 @@ When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase
 
 ## Rules
 
+- **Name sections by content, not by command.** Use the phase-specific heading from the table above (e.g. `## Implementation plan`, `## Requirements`) — never the slash command name (e.g. `## /define`, `## Handoff: /define → /implement`).
 - **Update the body, not a comment.** Every phase edits the issue body in place — append a new section if one does not exist for the current phase, edit the existing section if it does. Comments are for discussion only.
 - **Reset after updating.** Once the body is updated, tell the user to start the next phase in a fresh session. Do not call the next skill from within the current one.
 - **For cross-phase state, the issue body wins.** If in-context recall disagrees with the body, trust the body.

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -63,7 +63,7 @@ In this workflow:
 
 ### 4. Write `/wrap-up` output into the issue body before the session ends
 
-`/wrap-up` surfaces assumptions, uncertainties, and follow-ups — but without persistence, that output stays in the conversation and is lost when the session ends. That defeats rule (1). Fix: whenever `/wrap-up` runs at a phase boundary, edit the GitHub issue **body** in place to append a `## Wrap-up — session handoff` section. The captured content then survives the reset and lives in the same scan-readable artifact as the rest of the phase state.
+`/wrap-up` surfaces assumptions, uncertainties, and follow-ups — but without persistence, that output stays in the conversation and is lost when the session ends. That defeats rule (1). Fix: whenever `/wrap-up` runs at a phase boundary, edit the GitHub issue **body** in place to append a `## Session handoff` section. The captured content then survives the reset and lives in the same scan-readable artifact as the rest of the phase state.
 
 ## Why
 
@@ -90,7 +90,7 @@ A note on Opus 4.5/4.6 and "context anxiety": Anthropic reports they dropped con
 A worked instance of the canonical template from `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`, paste-ready into the issue body before resetting the session:
 
 ```markdown
-## Handoff: /define → /implement
+## Implementation notes
 
 **Acceptance criteria** (from /discovery, unchanged)
 - AC1: CSV export button appears on /reports for users with `reports.read`

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -90,7 +90,7 @@ A note on Opus 4.5/4.6 and "context anxiety": Anthropic reports they dropped con
 A worked instance of the canonical template from `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`, paste-ready into the issue body before resetting the session:
 
 ```markdown
-## Implementation notes
+## Implementation plan
 
 **Acceptance criteria** (from /discovery, unchanged)
 - AC1: CSV export button appears on /reports for users with `reports.read`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -88,16 +88,16 @@ AC are the contract `/implement` verifies against, so silent changes have blast 
 - **What it does:** Spawns research agents (codebase research + patterns/learnings scan against the claude-obsidian vault via `wiki-query` when available, else skipped with a note), then dispatches:
   - `/architecture` (`skills/architecture/SKILL.md`) — codebase analyst + solution architect + devil's advocate converge on a technical approach, producing component diagrams, trade-off tables, and a sub-task dependency graph. Uses `/grill-me` (`skills/grill-me/SKILL.md`) to pin down open decisions with the user.
   - `/design` (`skills/design/SKILL.md`) — UX researcher + design proposer + a11y reviewer, only when the task has visual aspects. Produces prototypes, wireframes, and interaction flows.
-- **Outcome:** The issue body is updated in place with a `## Define Outcome` section (see below), plus any sub-issues created and linked. **User approval is required** before `/implement`.
+- **Outcome:** The issue body is updated in place with a `## Implementation plan` section (see below), plus any sub-issues created and linked. **User approval is required** before `/implement`.
 - **Hands off to:** `/implement`.
 
 ### Sub-issue inheritance
 
 Each sub-issue receives the same five-field block inherited from the parent epic, pre-populated with the slice of acceptance criteria it covers.
 
-### `## Define Outcome` block
+### `## Implementation plan` block
 
-`/define` writes a `## Define Outcome` section into the epic issue body containing:
+`/define` writes a `## Implementation plan` section into the epic issue body containing:
 
 - The chosen architecture / decomposition rationale.
 - The sub-issue breakdown (list with links) and dependency graph.
@@ -105,7 +105,7 @@ Each sub-issue receives the same five-field block inherited from the parent epic
 
 ### Re-run semantics
 
-Re-running `/define` **replaces the `## Define Outcome` block in place**. No collapsed history.
+Re-running `/define` **replaces the `## Implementation plan` block in place**. No collapsed history.
 
 - The preamble reads the existing block before replacing, so architecture decisions still valid are carried forward intentionally (not by accumulation).
 - If a sub-issue was linked to a specific architecture decision that no longer appears in the new block, the sub-issue link becomes the only remaining reference — this forces the re-run to confront whether the sub-issue is still valid.
@@ -118,7 +118,7 @@ When `/define` re-runs and the sub-issue breakdown changes, old sub-issues are r
 | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Still maps cleanly to a slice of the new breakdown | Keep it; update its body with the new AC slice.                                                                         |
 | No longer maps                                     | Post comment: "Superseded by re-defined scope in #\<epic\>. Closing unless there's work already in flight." Then close. |
-| Maps partially                                     | Leave open; post a comment with the delta; flag in `## Define Outcome` as "needs manual review".                        |
+| Maps partially                                     | Leave open; post a comment with the delta; flag in `## Implementation plan` as "needs manual review".                        |
 
 ---
 
@@ -137,7 +137,7 @@ When `/define` re-runs and the sub-issue breakdown changes, old sub-issues are r
 
 ### Preamble (read before doing anything)
 
-Before writing any code, `/implement` fetches the issue body **and all comments**. Any comment newer than the last `## Define Outcome` update is treated as material input. If conflicting information is found, `/implement` **halts and asks** — it never silently picks one interpretation.
+Before writing any code, `/implement` fetches the issue body **and all comments**. Any comment newer than the last `## Implementation plan` update is treated as material input. If conflicting information is found, `/implement` **halts and asks** — it never silently picks one interpretation.
 
 ### Issue comments posted by `/implement`
 
@@ -145,7 +145,7 @@ One comment per meaningful state change. Never more.
 
 | Checkpoint                                                                   | Comment                                                                                                                                                                                     |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Start**                                                                    | `🤖 Starting implementation. Working from ## Define Outcome (last updated <date>). Branch: <branch>. Will post again when a draft PR is open or if the fix-cycle escalates to needs-human.` |
+| **Start**                                                                    | `🤖 Starting implementation. Working from ## Implementation plan (last updated <date>). Branch: <branch>. Will post again when a draft PR is open or if the fix-cycle escalates to needs-human.` |
 | **Escalation** (only if max fix-cycle iterations hit or an AC cannot be met) | `🤖 Fix-cycle escalated after N iterations. Blocking issue: <one-line>. Details: <fold with reviewer findings and failing AC>. Need guidance before continuing.`                            |
 | **PR open**                                                                  | `🤖 Draft PR opened: #<n>. AC status: <n/n met>. Review + verify clean. Ready for human review.`                                                                                            |
 | **Consolidation** (only if `/compound` filed new wiki notes)                 | `🤖 Captured learnings: <note title>` (or `inline` when claude-obsidian is not installed).                                                                                                  |
@@ -219,7 +219,7 @@ The following three regions are always rewritten in place on re-run. None accumu
 | ------------------------- | ------------ |
 | Problem statement         | `/discovery` |
 | Acceptance criteria       | `/discovery` |
-| `## Define Outcome` block | `/define`    |
+| `## Implementation plan` block | `/define`    |
 
 Each re-running phase reads the existing region before overwriting so carry-forwards are deliberate. Stale downstream artifacts (sub-issues, open PRs) get a reconciliation pass in the phase's postamble.
 

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -46,7 +46,7 @@ Decision tree:
 4. The architecture specialist goes first. Once technical decisions are approved by the user, the design specialist (if applicable) works within those constraints. In Deep scope, the critique team runs after both and before user sign-off.
 
 5. **Update the GitHub issue body** with decisions. The body is the handoff artifact, single source of truth — always update it in place, never post handoff state as a comment:
-   - If the body already has a `## Solution` section, edit it. If not, append one.
+   - If the body already has a `## Implementation plan` section, edit it. If not, append one.
    - Record architecture decisions and design decisions (with visuals) inside that section.
    - Create sub-issues with GitHub relationships if the work decomposes.
    - Define the dependency graph — identify what can be parallelized.

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -70,7 +70,7 @@ Decision tree:
 
    **(a) Problem statement preamble** — `/discovery`-only, not part of the handoff field order. From /describe output: what the user is trying to do, why the current state is inadequate, who is affected. This is the framing the rest of the issue depends on. Subsequent phases do not update this section.
 
-   **(b) Handoff block** — the five fields below, in this order, matching `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. Field order is uniform across all phases so the next session can scan-read it. (The issue _title_ is set via `gh issue create --title` and is not part of the body handoff block.)
+   **(b) Handoff block** — under a `## Requirements` heading, the five fields below, in this order, matching `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`. Field order is uniform across all phases so the next session can scan-read it. (The issue _title_ is set via `gh issue create --title` and is not part of the body handoff block.)
    - **Acceptance criteria** — from /specify output, as a numbered list of testable scenarios
    - **Constraints** — explicit in/out scope boundaries, non-negotiable decisions surfaced during discovery
    - **Prior decisions** *(optional — omit if empty)* — any decisions already made during discovery (one line each, with rationale)

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -29,7 +29,7 @@ Decision tree:
 
 **Design gate** (Standard / Deep only):
 
-Once you've assessed the scope as **Standard** or **Deep**, inspect the GitHub issue body for a `## Decisions` or `## Solution` section containing architecture and design decisions from `/define`. If absent:
+Once you've assessed the scope as **Standard** or **Deep**, inspect the GitHub issue body for a `## Implementation plan` section containing architecture and design decisions from `/define`. If absent:
 - **Pause** and prompt: _"No architecture/design decisions recorded on this issue. Run `/define` first, or confirm this is a trivial enough change to skip the gate."_
 - If the user confirms this is trivial enough (typo, single-line fix, etc.), downgrade to **Trivial** scope and proceed.
 - Otherwise, wait for the user to run `/define`.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -28,7 +28,7 @@ The current conversation history and `./.claude/NOTES.md` if present; optionally
 
 3. **Determine the active issue.** Check the git branch name for an issue reference, or run `gh issue list --search <branch-slug>`, or ask the user directly. The audit must be tied to a specific issue — this is the handoff artifact for the next phase. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the shape.
 
-4. **Draft the body update.** Produce the audit in the Output format below. Fetch the current issue body (`gh issue view N --json body -q .body`), append or replace a `## Wrap-up — session handoff` section, and show the proposed new body to the user with: `Update issue #N body? (y/n)`. On yes, run `gh issue edit N --body-file -` with the new body. **Never auto-update** — wrong issue, leaked assumptions, or duplicate sections on replay all have real blast radius. Keep the draft visible in the terminal even if the user declines, so they can copy it manually.
+4. **Draft the body update.** Produce the audit in the Output format below. Fetch the current issue body (`gh issue view N --json body -q .body`), append or replace a `## Session handoff` section, and show the proposed new body to the user with: `Update issue #N body? (y/n)`. On yes, run `gh issue edit N --body-file -` with the new body. **Never auto-update** — wrong issue, leaked assumptions, or duplicate sections on replay all have real blast radius. Keep the draft visible in the terminal even if the user declines, so they can copy it manually.
 
 ## Output
 
@@ -38,7 +38,7 @@ Example (for issue #42):
 
     paste into issue #42 body — handoff artifact
 
-        ## Wrap-up — session handoff
+        ## Session handoff
 
         ### Assumptions Made
         - [assumption] — [why] — [risk if wrong]


### PR DESCRIPTION
Standardize section headings in GitHub issue bodies to use human-readable names describing content, not the commands that produced them.

Phase mapping:
- /discovery → `## Requirements`
- /define → `## Implementation plan`
- /implement → `## Implementation notes`
- /wrap-up → `## Session handoff`

## Changes
- `_shared/handoff-artifact.md`: Phase table, updated template, 'name by content' rule
- `skills/`: All phase skills updated to use new headings
- `docs/`: Aligned workflow and context-hygiene docs

Closes #27