### PR TITLE
ci: add release workflow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "claude-workflow: standardized /discovery → /define → /implement lifecycle for Claude Code",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "plugins": [
     {
@@ -17,7 +17,7 @@
         "ref": "main"
       },
       "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. 17 skills, shared protocols, authoring standard, /new-skill scaffolder.",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "author": {
         "name": "Michal Konopski",
         "url": "https://github.com/misiekhardcore"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute next version
+        id: bump
+        run: |
+          set -euo pipefail
+          name=$(jq -r '.name' .claude-plugin/plugin.json)
+          current=$(jq -r '.version' .claude-plugin/plugin.json)
+          IFS='.' read -r major minor patch <<<"$current"
+          case "${{ inputs.bump }}" in
+            major) major=$((major+1)); minor=0; patch=0 ;;
+            minor) minor=$((minor+1)); patch=0 ;;
+            patch) patch=$((patch+1)) ;;
+          esac
+          new="${major}.${minor}.${patch}"
+          {
+            echo "name=$name"
+            echo "version=$new"
+            echo "tag=v$new"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Bump plugin.json and marketplace.json
+        run: |
+          set -euo pipefail
+          v="${{ steps.bump.outputs.version }}"
+          tmp=$(mktemp)
+          jq --arg v "$v" '.version = $v' .claude-plugin/plugin.json > "$tmp"
+          mv "$tmp" .claude-plugin/plugin.json
+          jq --arg v "$v" '.metadata.version = $v | .plugins[0].version = $v' .claude-plugin/marketplace.json > "$tmp"
+          mv "$tmp" .claude-plugin/marketplace.json
+
+      - name: Commit, tag, push
+        run: |
+          set -euo pipefail
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git commit -m "chore: release ${{ steps.bump.outputs.tag }}"
+          git tag -a "${{ steps.bump.outputs.tag }}" -m "${{ steps.bump.outputs.tag }}"
+          git push origin HEAD
+          git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Package source tarball
+        run: |
+          set -euo pipefail
+          name="${{ steps.bump.outputs.name }}"
+          version="${{ steps.bump.outputs.version }}"
+          file="${name}-${version}.tar.gz"
+          git archive \
+            --format=tar.gz \
+            --prefix="${name}-${version}/" \
+            -o "$file" \
+            "${{ steps.bump.outputs.tag }}"
+          echo "artifact=$file" >> "$GITHUB_ENV"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.bump.outputs.tag }}" \
+            --title "${{ steps.bump.outputs.tag }}" \
+            --generate-notes \
+            "$artifact"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — `workflow_dispatch` with a `patch`/`minor`/`major` bump input. Reads current version from `plugin.json`, bumps both `plugin.json` and `marketplace.json`, commits as `github-actions[bot]`, tags `vX.Y.Z`, pushes, and calls `gh release create --generate-notes` with a `git archive` source tarball attached.
- Resyncs `.claude-plugin/marketplace.json` 0.2.0 → 0.3.0 to match `plugin.json` (existing drift).

Uses the default `GITHUB_TOKEN` with `contents: write`; no secrets to configure.

## Test plan
- [ ] Merge to `main`.
- [ ] Run the workflow via **Actions → Release → Run workflow** with bump=`patch`.
- [ ] Verify: commit `chore: release vX.Y.Z` on `main`, tag pushed, release created with auto-generated notes, `claude-workflow-X.Y.Z.tar.gz` attached.
- [ ] Verify `plugin.json` and `marketplace.json` versions match after the run.