### PR TITLE
docs: document version lockstep and Release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ Shared protocols live at `_shared/`:
 | `compaction-protocol.md` | Context editing → delegation → /compact order                      |
 | `composition.md`         | Multi-skill composition patterns, skill roles, and brief contracts |
 
+## Releasing
+
+Versions in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (both `metadata.version` and `plugins[0].version`) must agree — the marketplace listing and distribution tooling depend on it. Trigger the **Release** workflow (`.github/workflows/release.yml`) via `workflow_dispatch` to bump all three in lockstep, commit, tag, and publish. Do not hand-edit; if you must, update all three fields in the same commit.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Adds a "Releasing" section to README documenting that `plugin.json` and `marketplace.json` (both `metadata.version` and `plugins[0].version`) must agree, and pointing at the `workflow_dispatch` Release workflow as the canonical way to bump them.

## Context
Closes #40. The original drift (plugin.json 0.3.0 vs marketplace.json 0.2.0) was already resolved — all three fields now sit at 0.4.0 and the Release workflow (`.github/workflows/release.yml`) bumps them in lockstep. This PR addresses the remaining acceptance criterion: "Bump policy documented in one place."

## Test plan
- [x] `jq -r .version .claude-plugin/plugin.json` == `jq -r .metadata.version .claude-plugin/marketplace.json` == `jq -r '.plugins[0].version' .claude-plugin/marketplace.json` → `0.4.0`
- [x] README renders with the new section between "Authoring standard" and "License"