### PR TITLE
feat(skills): audit all spawn sites against TeamCreate rubric

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -12,7 +12,7 @@ You are leading an architecture team. Your job is to explore technical approache
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
 - **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
-- **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
+- **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -9,10 +9,10 @@ You are leading an architecture team. Your job is to explore technical approache
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Research team** (codebase + patterns/learnings): 2 parallel subagents — comm-pivot ✗ (read-only research, no mid-task coordination needed), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× for two independent reads. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (codebase agent → patterns agent).
-- **Architecture session** (analyst + architect + devil's advocate): analyst subagent + architect lead-inline (grill-me) + devil's advocate subagent — comm-pivot ✗ (architect is the interactive lead; analyst seeds context before; devil's advocate critiques after), sequential reasoning required for interactive grill-me, wall-clock payoff <3×. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (analyst and devil's advocate are subagents; architect runs in lead session).
+- **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
+- **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -7,6 +7,13 @@ effortLevel: high
 
 You are leading an architecture team. Your job is to explore technical approaches with the user and converge on the right architecture for the feature.
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Research team** (codebase + patterns/learnings): 2 parallel subagents — comm-pivot ✗ (read-only research, no mid-task coordination needed), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× for two independent reads. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (codebase agent → patterns agent).
+- **Architecture session** (analyst + architect + devil's advocate): analyst subagent + architect lead-inline (grill-me) + devil's advocate subagent — comm-pivot ✗ (architect is the interactive lead; analyst seeds context before; devil's advocate critiques after), sequential reasoning required for interactive grill-me, wall-clock payoff <3×. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (analyst and devil's advocate are subagents; architect runs in lead session).
+
 ## Input
 
 A GitHub issue with problem statement and acceptance criteria (from /discovery).
@@ -15,7 +22,7 @@ A GitHub issue with problem statement and acceptance criteria (from /discovery).
 
 1. Read the issue and understand the requirements
 
-2. **Dispatch parallel research agents** using TeamCreate before the architecture team begins:
+2. **Dispatch 2 parallel research subagents** (one Task tool call per agent in a single message) before the architecture session begins:
    - **Codebase research agent** — systematic scan of relevant code: technology stack, module structure, related implementations, naming conventions, existing patterns. Outputs a structured context brief.
    - **Patterns/learnings agent** — gathers prior art from, in order:
      1. **The claude-obsidian vault, if available.** If `claude-obsidian:wiki-query` is usable, ask it for concepts/entities/sources/meta relevant to the feature (prior decisions, patterns, bug-fix history). Use whatever vocabulary the plugin expects — the agent does not know or need a filesystem path.
@@ -26,16 +33,14 @@ A GitHub issue with problem statement and acceptance criteria (from /discovery).
 
    **Gate rule**: skip external/web research when internal sources (vault + project docs) yield 3+ direct pattern examples. Always run full research for security, payments, privacy topics, or when local patterns are thin (fewer than 3 examples).
 
-   Research results feed into the architecture team's context before they begin proposing approaches.
+   Research results feed into the architecture session before it begins proposing approaches.
 
-3. **Spawn an architecture team** using TeamCreate, providing them with the research output:
-   - **Codebase analyst** — reviews the research brief and explores specific architectural constraints: module boundaries, deployment topology, and integration points NOT covered by the research scan
-   - **Solution architect** — uses /grill-me to explore approaches with the user, informed by both research and analyst findings
-   - **Devil's advocate** — challenges proposed approaches, identifies risks, edge cases, and scaling concerns
+3. **Run the architecture session** sequentially:
+   - Run the **Codebase analyst** as a subagent seeded with the research brief; it explores specific architectural constraints (module boundaries, deployment topology, integration points NOT covered by the research scan) and returns a findings report.
+   - The **Solution architect** runs interactively in the lead session via /grill-me, informed by both the research brief and the analyst's findings.
+   - After the architect session reaches a proposed approach, dispatch the **Devil's advocate** as a subagent to challenge it — identifying risks, edge cases, and scaling concerns. Feed its findings back into the lead session for final resolution.
 
-4. Teammates share findings via messages. The analyst feeds context to the architect; the devil's advocate critiques proposals.
-
-5. For each major decision, present **2-3 approaches** with:
+4. For each major decision, present **2-3 approaches** with:
    - Architecture diagram (Mermaid component/sequence diagram)
    - Trade-off table (pros, cons, complexity, risk)
    - Code structure preview (directory layout, key interfaces)

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -29,10 +29,10 @@ Decision tree:
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard implementation team**: TeamCreate when ≥3 sub-issues OR ≥3 disjoint file groups; otherwise dispatch parallel subagents (one Task tool call per split in a single message) — comm-pivot ✓ at sufficient scale (teammates flag conflicts mid-task), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× only at ≥3 splits. Gated on ≥3 sub-issues OR ≥3 disjoint file groups. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: parallel subagents (for 2 splits) or sequential subagent invocations.
-- **Deep implementation team**: TeamCreate — comm-pivot ✓ (epics require mid-task coordination across modules), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× for epics with 4+ sub-issues. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+- **Standard**: TeamCreate at ≥3 splits, else parallel subagents. Comm-pivot ✓ at scale, disjoint ✓, parallel ✓, payoff ≥3× only at ≥3 splits. Gate: ≥3 sub-issues OR ≥3 disjoint file groups. Fallback: parallel subagents or sequential.
+- **Deep**: TeamCreate. All four ✓ for epics. Fallback: sequential subagents.
 
 ## Process
 
@@ -56,16 +56,10 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamC
 
    **On resume in an existing worktree**, read `./.claude/NOTES.md` _before_ re-reading the issue — it has the latest in-flight state. Resume from its **Next action on resume** field.
 
-3. **Implementation** — shape depends on scope:
-   - **Lightweight**: lead codes inline. No TeamCreate. Skip to step 4.
-   - **Standard**: when ≥3 sub-issues exist OR ≥3 disjoint file groups are identified, spawn an implementation team using TeamCreate; otherwise dispatch parallel subagents (one Task tool call per split in a single message).
-     - Assign each teammate (or subagent) a separate sub-issue or file group to avoid conflicts
-     - Teammates communicate peer-to-peer (TeamCreate) or results are merged by the lead (subagents)
-     - The lead coordinates via the shared task list and merges results
-   - **Deep**: spawn an implementation team using TeamCreate (epic scope justifies the team premium).
-     - Assign each teammate a separate sub-issue or file group to avoid conflicts
-     - Teammates communicate peer-to-peer, share discoveries, and flag potential conflicts
-     - The lead coordinates via the shared task list and merges results
+3. **Implementation** — spawn workers per the Spawn justification block (Lightweight: inline; Standard/Deep: subagents or TeamCreate per gate).
+   - Assign each worker a separate sub-issue or file group to avoid conflicts
+   - With TeamCreate, teammates communicate peer-to-peer; with subagents, the lead merges results
+   - The lead coordinates via the shared task list
 
 4. Each teammate follows **test-driven development (TDD)** for logic-heavy code:
    - Write a failing test first — derive test cases from the acceptance criteria
@@ -99,7 +93,7 @@ A feature branch in a worktree with all acceptance criteria implemented, tests p
 
 - Use superpowers:test-driven-development for the TDD workflow
 - Use `git worktree add` / `git worktree remove` for worktree management. [worktrunk](https://github.com/max-sixty/worktrunk)'s `wt` wrapper is an optional convenience when installed; the skill assumes only the stock `git worktree` commands.
-- Use TeamCreate for Standard scope only when ≥3 sub-issues OR ≥3 disjoint file groups; use parallel subagents below that threshold. Deep scope always uses TeamCreate. Lightweight codes inline without a team.
+- Pick the spawn primitive per the Spawn justification block above. Lightweight codes inline.
 - Do not ask the user whether to use teams — pick the scope and go
 - Do not open a PR — that happens after /implement completes the full cycle
 - Always run the 5-question verification check before marking a task done

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -27,6 +27,13 @@ Decision tree:
 2. Issue has 4+ sub-issues, or touches 3+ independent modules? → Deep
 3. Otherwise → Standard
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Standard implementation team**: TeamCreate when ≥3 sub-issues OR ≥3 disjoint file groups; otherwise dispatch parallel subagents (one Task tool call per split in a single message) — comm-pivot ✓ at sufficient scale (teammates flag conflicts mid-task), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× only at ≥3 splits. Gated on ≥3 sub-issues OR ≥3 disjoint file groups. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: parallel subagents (for 2 splits) or sequential subagent invocations.
+- **Deep implementation team**: TeamCreate — comm-pivot ✓ (epics require mid-task coordination across modules), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× for epics with 4+ sub-issues. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+
 ## Process
 
 ### Step 0 — Repository pre-flight
@@ -51,7 +58,11 @@ Decision tree:
 
 3. **Implementation** — shape depends on scope:
    - **Lightweight**: lead codes inline. No TeamCreate. Skip to step 4.
-   - **Standard / Deep**: spawn an implementation team using TeamCreate.
+   - **Standard**: when ≥3 sub-issues exist OR ≥3 disjoint file groups are identified, spawn an implementation team using TeamCreate; otherwise dispatch parallel subagents (one Task tool call per split in a single message).
+     - Assign each teammate (or subagent) a separate sub-issue or file group to avoid conflicts
+     - Teammates communicate peer-to-peer (TeamCreate) or results are merged by the lead (subagents)
+     - The lead coordinates via the shared task list and merges results
+   - **Deep**: spawn an implementation team using TeamCreate (epic scope justifies the team premium).
      - Assign each teammate a separate sub-issue or file group to avoid conflicts
      - Teammates communicate peer-to-peer, share discoveries, and flag potential conflicts
      - The lead coordinates via the shared task list and merges results
@@ -88,7 +99,7 @@ A feature branch in a worktree with all acceptance criteria implemented, tests p
 
 - Use superpowers:test-driven-development for the TDD workflow
 - Use `git worktree add` / `git worktree remove` for worktree management. [worktrunk](https://github.com/max-sixty/worktrunk)'s `wt` wrapper is an optional convenience when installed; the skill assumes only the stock `git worktree` commands.
-- Use TeamCreate for team coordination in Standard and Deep scope; Lightweight codes inline without a team
+- Use TeamCreate for Standard scope only when ≥3 sub-issues OR ≥3 disjoint file groups; use parallel subagents below that threshold. Deep scope always uses TeamCreate. Lightweight codes inline without a team.
 - Do not ask the user whether to use teams — pick the scope and go
 - Do not open a PR — that happens after /implement completes the full cycle
 - Always run the 5-question verification check before marking a task done

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -10,7 +10,7 @@ You are leading the knowledge compounding phase. Your job is to capture what was
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Full-mode team**: 3 parallel subagents + lead synthesis. Comm-pivot ✗ (independent reads, end-synthesis), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
+- **Full-mode team**: 3 parallel subagents + lead synthesis. Comm-pivot ✗ (independent reads, end-synthesis), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: n/a — no flag dependency (parallel subagents do not require `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`).
 
 This skill extracts the learning and drafts it. **Filing is delegated** to the `claude-obsidian` plugin when available: its `/save` command handles vault placement, frontmatter, cross-links, hot-cache updates, and the operation log automatically. If `claude-obsidian` is not installed, the drafted note is emitted inline for the user to copy into whatever knowledge store they prefer.
 

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -6,6 +6,12 @@ model: sonnet
 
 You are leading the knowledge compounding phase. Your job is to capture what was just learned — the fix, the insight, the pattern — into a structured, reusable artifact that future agents and developers can discover and reuse.
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Full-mode compounding team** (context analyst + solution extractor + overlap scanner): 3 parallel subagents + lead synthesis — comm-pivot ✗ (three independent reads with end-synthesis by lead; no mid-task coordination needed), file-disjoint ✓ (each reads a different dimension of the conversation), classifiably parallel ✓, wall-clock payoff ≥3× for independent reads. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (context analyst → solution extractor → overlap scanner → lead synthesis).
+
 This skill extracts the learning and drafts it. **Filing is delegated** to the `claude-obsidian` plugin when available: its `/save` command handles vault placement, frontmatter, cross-links, hot-cache updates, and the operation log automatically. If `claude-obsidian` is not installed, the drafted note is emitted inline for the user to copy into whatever knowledge store they prefer.
 
 ## Input
@@ -43,7 +49,7 @@ Single-pass extraction. Work through these steps yourself:
 
 ### Full
 
-1. **Spawn a compounding team** using TeamCreate with three specialists:
+1. **Dispatch 3 parallel subagents** (one Task tool call per agent in a single message):
    - **Context analyst** — reviews the full conversation history and git diff to extract: what broke, what was tried, what worked, and why.
    - **Solution extractor** — distills the fix into a reusable pattern: root cause, solution steps, prevention guidance.
    - **Overlap scanner** — if `claude-obsidian:wiki-query` is available, asks it for existing coverage of the module, symptoms, or root cause. Reports:
@@ -52,7 +58,7 @@ Single-pass extraction. Work through these steps yourself:
      - **No overlap** → recommend creating new.
      - If `wiki-query` is not available, report `"skipped: no vault query tool available"`.
 
-2. Teammates share findings via messages. Synthesize into a single drafted note.
+2. Wait for all three subagents to return, then synthesize their findings into a single drafted note (lead synthesis).
 
 3. File the note:
    - If `claude-obsidian:save` is available → invoke `/save` with the drafted content and, if the overlap scanner recommended an update, pass the target note identifier so `/save` updates in place rather than creating a new note.

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -8,9 +8,9 @@ You are leading the knowledge compounding phase. Your job is to capture what was
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Full-mode compounding team** (context analyst + solution extractor + overlap scanner): 3 parallel subagents + lead synthesis — comm-pivot ✗ (three independent reads with end-synthesis by lead; no mid-task coordination needed), file-disjoint ✓ (each reads a different dimension of the conversation), classifiably parallel ✓, wall-clock payoff ≥3× for independent reads. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (context analyst → solution extractor → overlap scanner → lead synthesis).
+- **Full-mode team**: 3 parallel subagents + lead synthesis. Comm-pivot ✗ (independent reads, end-synthesis), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
 
 This skill extracts the learning and drafts it. **Filing is delegated** to the `claude-obsidian` plugin when available: its `/save` command handles vault placement, frontmatter, cross-links, hot-cache updates, and the operation log automatically. If `claude-obsidian` is not installed, the drafted note is emitted inline for the user to copy into whatever knowledge store they prefer.
 

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -30,11 +30,11 @@ Decision tree:
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Research team** (codebase + patterns/learnings): 2 parallel subagents — comm-pivot ✗ (read-only research, no mid-task coordination needed), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× for two independent reads. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (codebase agent → patterns agent).
-- **Standard definition team** (architecture → design): sequential subagent invocations — comm-pivot ✗ (design follows architecture, strictly ordered), sequential reasoning required, no parallel speedup. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: same — sequential subagents do not require the experimental flag.
-- **Deep critique team**: TeamCreate — comm-pivot ✓ (adversarial reviewers coordinate critique findings across migration, security, and rollout axes), classifiably parallel ✓, wall-clock payoff ≥3× for high-risk plans. Gated on Deep scope AND a security/payments/migration signal in the issue. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (critic runs after architecture and design complete).
+- **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
+- **Standard definition team**: sequential subagents (architecture → design). Comm-pivot ✗ (strictly ordered), parallel ✗, no speedup. Fallback: n/a — no flag dependency.
+- **Deep critique team**: TeamCreate. Comm-pivot ✓ (cross-axis critique), disjoint ✓, parallel ✓, payoff ≥3× for high-risk plans. Gate: Deep scope AND security/payments/migration signal. Fallback: sequential subagents.
 
 ## Process
 
@@ -46,10 +46,10 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamC
 
    The brief feeds both the architecture and design specialists as seed context.
 
-3. **Run the definition specialists sequentially** — shape depends on scope:
-   - **Lightweight**: lead writes the architecture summary inline against the research already in the issue. No team.
-   - **Standard**: run the **Architecture specialist** as a sequential subagent seeded with the research brief (skips its own research phase). Then run the **Design specialist** as a sequential subagent seeded with the research brief when the feature has visual aspects. Each is a Task tool call with the prior output as seed brief.
-   - **Deep**: same specialists as Standard, then spawn a **TeamCreate critique team** to critique the plan before finalizing (adversarial review, migration safety, rollout risks) — gated on Deep scope AND a security/payments/migration signal in the issue.
+3. **Run the definition specialists** per the Spawn justification block:
+   - **Lightweight**: lead writes the architecture summary inline against the research already in the issue.
+   - **Standard**: run Architecture as a sequential subagent seeded with the research brief, then Design as a sequential subagent when the feature has visual aspects.
+   - **Deep**: same as Standard, then spawn the critique team (adversarial review, migration safety, rollout risks).
 
 4. The architecture specialist goes first. Once technical decisions are approved by the user, the design specialist (if applicable) works within those constraints. In Deep scope, the critique team runs after both and before user sign-off.
 
@@ -67,6 +67,6 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamC
 ## Rules
 
 - **Require explicit full approval** before finalizing. Partial feedback is NOT approval.
-- Deep scope spawns a TeamCreate critique team before finalizing only when a security/payments/migration signal is present; Standard uses sequential subagents; Lightweight skips both.
+- Spawn primitives and gates per the Spawn justification block above.
 - Respect existing codebase patterns unless there's a strong reason to deviate
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -33,7 +33,7 @@ Decision tree:
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
 - **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
-- **Standard definition team**: sequential subagents (architecture → design). Comm-pivot ✗ (strictly ordered), parallel ✗, no speedup. Fallback: n/a — no flag dependency.
+- **Standard definition team**: sequential subagents (architecture → design). Comm-pivot ✗ (strictly ordered), disjoint n/a (sequential), parallel ✗, payoff <3×. Fallback: n/a — no flag dependency.
 - **Deep critique team**: TeamCreate. Comm-pivot ✓ (cross-axis critique), disjoint ✓, parallel ✓, payoff ≥3× for high-risk plans. Gate: Deep scope AND security/payments/migration signal. Fallback: sequential subagents.
 
 ## Process

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -28,20 +28,28 @@ Decision tree:
 2. Touches auth/security/payments/privacy, crosses modules, or changes architecture? → Deep
 3. Otherwise → Standard
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Research team** (codebase + patterns/learnings): 2 parallel subagents — comm-pivot ✗ (read-only research, no mid-task coordination needed), file-disjoint ✓, classifiably parallel ✓, wall-clock payoff ≥3× for two independent reads. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (codebase agent → patterns agent).
+- **Standard definition team** (architecture → design): sequential subagent invocations — comm-pivot ✗ (design follows architecture, strictly ordered), sequential reasoning required, no parallel speedup. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: same — sequential subagents do not require the experimental flag.
+- **Deep critique team**: TeamCreate — comm-pivot ✓ (adversarial reviewers coordinate critique findings across migration, security, and rollout axes), classifiably parallel ✓, wall-clock payoff ≥3× for high-risk plans. Gated on Deep scope AND a security/payments/migration signal in the issue. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (critic runs after architecture and design complete).
+
 ## Process
 
 1. Read the issue to understand the problem statement and acceptance criteria.
 
-2. **Dispatch a research team** (TeamCreate; Standard/Deep only — skip in Lightweight):
+2. **Dispatch 2 parallel research subagents** (one Task tool call per agent in a single message; Standard/Deep only — skip in Lightweight):
    - **Codebase research agent** — scans tech stack, modules, related implementations, naming, existing patterns. Outputs a structured brief.
    - **Patterns/learnings agent** — gathers prior art from, in order: (1) the claude-obsidian vault via `claude-obsidian:wiki-query` if available (concepts/entities/sources/meta); (2) project docs (READMEs, ADRs, `docs/**`); (3) external sources via Context7 when local patterns are thin. If `claude-obsidian` is not installed, step 1 is skipped with a note. Skip external research when internal sources yield 3+ direct pattern examples; always run full research for security/payments/privacy.
 
    The brief feeds both the architecture and design specialists as seed context.
 
-3. **Spawn a definition team** — shape depends on scope:
+3. **Run the definition specialists sequentially** — shape depends on scope:
    - **Lightweight**: lead writes the architecture summary inline against the research already in the issue. No team.
-   - **Standard**: TeamCreate with the **Architecture specialist** (runs /architecture seeded with the research brief; skips its own research phase). Add the **Design specialist** (runs /design seeded with the research brief) when the feature has visual aspects.
-   - **Deep**: same specialists as Standard, then spawn a second TeamCreate to critique the plan before finalizing (adversarial review, migration safety, rollout risks).
+   - **Standard**: run the **Architecture specialist** as a sequential subagent seeded with the research brief (skips its own research phase). Then run the **Design specialist** as a sequential subagent seeded with the research brief when the feature has visual aspects. Each is a Task tool call with the prior output as seed brief.
+   - **Deep**: same specialists as Standard, then spawn a **TeamCreate critique team** to critique the plan before finalizing (adversarial review, migration safety, rollout risks) — gated on Deep scope AND a security/payments/migration signal in the issue.
 
 4. The architecture specialist goes first. Once technical decisions are approved by the user, the design specialist (if applicable) works within those constraints. In Deep scope, the critique team runs after both and before user sign-off.
 
@@ -59,6 +67,6 @@ Decision tree:
 ## Rules
 
 - **Require explicit full approval** before finalizing. Partial feedback is NOT approval.
-- Deep scope always spawns a second team to critique the plan before finalizing; Standard may skip it; Lightweight never needs one.
+- Deep scope spawns a TeamCreate critique team before finalizing only when a security/payments/migration signal is present; Standard uses sequential subagents; Lightweight skips both.
 - Respect existing codebase patterns unless there's a strong reason to deviate
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -36,7 +36,7 @@ Decision tree:
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard session**: domain researcher subagent + analyst lead-inline. Comm-pivot ✗ (one-shot handoff), parallel ✗ (analyst interactive), payoff <3×. Fallback: n/a — no flag dependency.
+- **Standard session**: domain researcher subagent + analyst lead-inline. Comm-pivot ✗ (one-shot handoff), disjoint n/a (sequential), parallel ✗ (analyst interactive), payoff <3×. Fallback: n/a — no flag dependency.
 - **Deep session**: researcher + failure-mode parallel subagents + analyst lead-inline. Comm-pivot ✗, disjoint ✓, parallel ✓ for subagent pair, payoff <3× total. Fallback: sequential subagents.
 
 ## Process

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -32,16 +32,22 @@ Decision tree:
 2. Does it cross module boundaries, touch auth/security/payments, or require architecture decisions? → Deep
 3. Otherwise → Standard
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Standard discovery session** (domain researcher + problem analyst): domain researcher subagent + problem analyst lead-inline — comm-pivot ✗ (researcher does a one-shot codebase read; analyst runs interactively in lead session), sequential handoff, wall-clock payoff <3×. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (researcher is a subagent; analyst runs in lead session).
+- **Deep discovery session** (researcher + failure-mode + analyst): researcher subagent + failure-mode subagent + analyst lead-inline — comm-pivot ✗ (researcher and failure-mode analyst do independent reads; problem analyst is the interactive lead), classifiably parallel for the two subagents ✓, wall-clock payoff ≥3× for the subagent pair. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (researcher → failure-mode → analyst lead-inline).
+
 ## Process
 
 ### Standard / Deep
 
 1. Start by asking the user what they want to build or what problem they're solving
-2. **Spawn a discovery team** using TeamCreate, up to three specialists for Standard scope, up to five for Deep, depending on the complexity of the problem:
-   - **Problem analyst** — uses /grill-me to interview the user: who is this for, what problem does it solve, what does success look like, what's out of scope
-   - **Domain researcher** — explores the codebase for immediate framing context: existing patterns, related features, module boundaries. (Prior-art / institutional memory is upstream — see `## Input`.)
-   - _(Deep only)_ **Failure-mode analyst** — explores competitive alternatives and failure modes: how this could break at scale, security/privacy edge cases, user-experience regressions. Prior-art research is handled by the upstream Prior-Art Scout.
-3. Teammates share findings via messages. The domain researcher surfaces codebase context that informs the analyst's questions.
+2. **Dispatch subagents and run the problem analyst in the lead session**:
+   - **Standard**: dispatch the **Domain researcher** as a subagent to explore the codebase for immediate framing context (existing patterns, related features, module boundaries). The **Problem analyst** runs interactively in the lead session via /grill-me, informed by the researcher's findings when available.
+   - **Deep**: dispatch the **Domain researcher** and the **Failure-mode analyst** as parallel subagents (one Task tool call per agent in a single message). The failure-mode analyst explores competitive alternatives and failure modes (scale, security/privacy edge cases, UX regressions). The **Problem analyst** runs interactively in the lead session via /grill-me, incorporating both subagents' findings.
+3. Subagent findings are fed into the lead session to inform the analyst's questions before the grill-me interaction begins.
 4. **Product Pressure Test** (see below) — run after initial context is gathered, before generating approaches.
 5. For each major concept or decision point, **produce a visual**:
    - User journey → flowchart or sequence diagram (Mermaid)

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -34,10 +34,10 @@ Decision tree:
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard discovery session** (domain researcher + problem analyst): domain researcher subagent + problem analyst lead-inline — comm-pivot ✗ (researcher does a one-shot codebase read; analyst runs interactively in lead session), sequential handoff, wall-clock payoff <3×. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (researcher is a subagent; analyst runs in lead session).
-- **Deep discovery session** (researcher + failure-mode + analyst): researcher subagent + failure-mode subagent + analyst lead-inline — comm-pivot ✗ (researcher and failure-mode analyst do independent reads; problem analyst is the interactive lead), classifiably parallel for the two subagents ✓, wall-clock payoff ≥3× for the subagent pair. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (researcher → failure-mode → analyst lead-inline).
+- **Standard session**: domain researcher subagent + analyst lead-inline. Comm-pivot ✗ (one-shot handoff), parallel ✗ (analyst interactive), payoff <3×. Fallback: n/a — no flag dependency.
+- **Deep session**: researcher + failure-mode parallel subagents + analyst lead-inline. Comm-pivot ✗, disjoint ✓, parallel ✓ for subagent pair, payoff <3× total. Fallback: sequential subagents.
 
 ## Process
 
@@ -47,16 +47,15 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamC
 2. **Dispatch subagents and run the problem analyst in the lead session**:
    - **Standard**: dispatch the **Domain researcher** as a subagent to explore the codebase for immediate framing context (existing patterns, related features, module boundaries). The **Problem analyst** runs interactively in the lead session via /grill-me, informed by the researcher's findings when available.
    - **Deep**: dispatch the **Domain researcher** and the **Failure-mode analyst** as parallel subagents (one Task tool call per agent in a single message). The failure-mode analyst explores competitive alternatives and failure modes (scale, security/privacy edge cases, UX regressions). The **Problem analyst** runs interactively in the lead session via /grill-me, incorporating both subagents' findings.
-3. Subagent findings are fed into the lead session to inform the analyst's questions before the grill-me interaction begins.
-4. **Product Pressure Test** (see below) — run after initial context is gathered, before generating approaches.
-5. For each major concept or decision point, **produce a visual**:
+3. **Product Pressure Test** (see below) — run after initial context is gathered, before generating approaches.
+4. For each major concept or decision point, **produce a visual**:
    - User journey → flowchart or sequence diagram (Mermaid)
    - Feature comparison → table
    - System boundaries → ASCII or Mermaid diagram
    - Data relationships → entity diagrams
    - Alternatives → side-by-side comparison tables with trade-offs
-6. After each visual, confirm understanding before moving on
-7. Synthesize team findings into a structured problem statement
+5. After each visual, confirm understanding before moving on
+6. Synthesize team findings into a structured problem statement
 
 ### Lightweight
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -10,7 +10,7 @@ You are leading a design team. Your job is to explore visual and interaction des
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Design session**: researcher subagent → proposer lead-inline (grill-me) → a11y subagent. Comm-pivot ✗ (sequential handoff), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
+- **Design session**: researcher subagent → proposer lead-inline (grill-me) → a11y subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -8,9 +8,9 @@ You are leading a design team. Your job is to explore visual and interaction des
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Design session** (researcher + proposer + a11y reviewer): researcher subagent + proposer lead-inline (grill-me) + a11y reviewer subagent — comm-pivot ✗ (proposer is the interactive lead; researcher seeds context before; a11y reviewer critiques after), sequential reasoning required for interactive grill-me, wall-clock payoff <3×. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (researcher and a11y reviewer are subagents; proposer runs in lead session).
+- **Design session**: researcher subagent → proposer lead-inline (grill-me) → a11y subagent. Comm-pivot ✗ (sequential handoff), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
 
 ## Input
 
@@ -25,8 +25,7 @@ Optionally: a research brief from /define's research team. Fields: `tech_stack`,
    - Dispatch the **UX researcher** as a subagent to explore existing UI patterns in the codebase, accessibility requirements, and design system constraints; its findings seed the proposer.
    - The **Design proposer** runs interactively in the lead session via /grill-me, informed by the researcher's findings.
    - After the proposer session reaches proposed designs, dispatch the **Accessibility reviewer** as a subagent to evaluate each proposal for a11y compliance, keyboard navigation, and screen reader support. Feed its findings back into the lead session for final resolution.
-3. The researcher seeds the proposer; the a11y reviewer's findings inform final design decisions.
-4. For each design decision, present **2-3 visual approaches**:
+3. For each design decision, present **2-3 visual approaches**:
    - Code prototypes with screenshots (HTML/React/etc.)
    - Wireframe diagrams (ASCII or Mermaid)
    - Interaction flow diagrams (state machines, sequence diagrams)

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -6,6 +6,12 @@ model: sonnet
 
 You are leading a design team. Your job is to explore visual and interaction design approaches with the user and converge on the right design for the feature.
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Design session** (researcher + proposer + a11y reviewer): researcher subagent + proposer lead-inline (grill-me) + a11y reviewer subagent — comm-pivot ✗ (proposer is the interactive lead; researcher seeds context before; a11y reviewer critiques after), sequential reasoning required for interactive grill-me, wall-clock payoff <3×. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (researcher and a11y reviewer are subagents; proposer runs in lead session).
+
 ## Input
 
 A GitHub issue with architecture decisions (from /define).
@@ -15,11 +21,11 @@ Optionally: a research brief from /define's research team. Fields: `tech_stack`,
 ## Process
 
 1. Read the issue and architecture decisions to understand constraints
-2. **Spawn a design team** using TeamCreate:
-   - **UX researcher** — explores existing UI patterns in the codebase, accessibility requirements, and design system constraints
-   - **Design proposer** — uses /grill-me to explore design options with the user, producing prototypes for each approach
-   - **Accessibility reviewer** — evaluates each proposal for a11y compliance, keyboard navigation, and screen reader support
-3. Teammates share findings via messages. The researcher feeds context to the proposer; the a11y reviewer critiques proposals.
+2. **Run the design session** sequentially:
+   - Dispatch the **UX researcher** as a subagent to explore existing UI patterns in the codebase, accessibility requirements, and design system constraints; its findings seed the proposer.
+   - The **Design proposer** runs interactively in the lead session via /grill-me, informed by the researcher's findings.
+   - After the proposer session reaches proposed designs, dispatch the **Accessibility reviewer** as a subagent to evaluate each proposal for a11y compliance, keyboard navigation, and screen reader support. Feed its findings back into the lead session for final resolution.
+3. The researcher seeds the proposer; the a11y reviewer's findings inform final design decisions.
 4. For each design decision, present **2-3 visual approaches**:
    - Code prototypes with screenshots (HTML/React/etc.)
    - Wireframe diagrams (ASCII or Mermaid)

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -25,25 +25,28 @@ Decision tree:
 2. Does it touch auth/security/payments, cross modules, change architecture, or span multiple teams? → Deep
 3. Otherwise → Standard
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Standard discovery team**: describe lead-inline + Prior-Art Scout parallel subagent + specify sequential subagent — comm-pivot ✗ (specialists hand off asynchronously; no mid-task peer coordination needed), tasks are read-only or run interactively in the lead session, wall-clock payoff <3×. Activated for Standard scope. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (Prior-Art Scout → describe → specify).
+- **Deep discovery team**: TeamCreate — comm-pivot ✓ (adversarial questioner reacts live to flow-analyst and prior-art findings), classifiably parallel ✓ (multi-perspective synthesis with adversarial challenge), wall-clock payoff ≥3× for cross-module or security-scope work. Gated on Deep scope. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (Prior-Art Scout → describe → flow analyst → specify → adversarial questioner).
+
 ## Process
 
 ### Standard
 
-1. **Spawn a discovery team** using TeamCreate with up to three specialists, depending on the complexity of the problem:
-   - **Describe specialist** — runs /describe to explore the problem space with the user. Produces visualizations, explores user stories, maps boundaries.
-   - **Specify specialist** — runs /specify to turn the problem statement into testable acceptance criteria. Produces concrete GIVEN/WHEN/THEN scenarios.
-   - **Prior-Art Scout** — gathers institutional memory in parallel with the describe specialist. Sources, in order:
+1. **Dispatch the Prior-Art Scout as a parallel subagent** (one Task tool call) while beginning the describe flow in the lead session:
+   - **Prior-Art Scout** — gathers institutional memory in parallel. Sources, in order:
      1. **The claude-obsidian vault, if available.** If `claude-obsidian:wiki-query` is usable, ask it for concepts/entities/sources/meta relevant to the topic (prior decisions, patterns, bug-fix history). If not installed, record `Vault query skipped — claude-obsidian not installed.` in the brief.
      2. **Past GitHub issues and PRs** via `gh issue list --search "<topic>" --state all` and `gh pr list --search "<topic>" --state all`.
      3. **Project documentation** — ADRs and design notes under `docs/**` and relevant READMEs.
 
      Output: a structured brief with **Prior decisions**, **Prior attempts and outcomes**, **Related open/closed issues**, **Relevant patterns**. Feeds both describe and specify.
 
-2. The Prior-Art Scout runs in parallel with the describe specialist — no blocking. Its brief is passed to `/describe` as seed context; the describe specialist skips its own prior-art exploration when a brief is provided (mirrors the `/define` → `/architecture` seed-brief contract).
+2. **Run /describe in the lead session** (lead-inline) to explore the problem space with the user. When the Prior-Art Scout brief is available, incorporate it as seed context; the lead skips its own prior-art exploration when a brief is provided (mirrors the `/define` → `/architecture` seed-brief contract).
 
-3. The describe specialist goes first with the user. Once the problem statement is clear and the user has explicitly approved it, hand findings (plus the scout brief) to the specify specialist.
-
-4. The specify specialist drills into requirements, with the scout brief available as supplementary context. Once acceptance criteria are approved by the user, combine outputs.
+3. Once the problem statement is clear and the user has explicitly approved it, run /specify as a **sequential subagent**, passing findings and the scout brief as seed context. Once acceptance criteria are approved by the user, combine outputs.
 
 ### Deep
 

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -27,10 +27,10 @@ Decision tree:
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard discovery team**: describe lead-inline + Prior-Art Scout parallel subagent + specify sequential subagent — comm-pivot ✗ (specialists hand off asynchronously; no mid-task peer coordination needed), tasks are read-only or run interactively in the lead session, wall-clock payoff <3×. Activated for Standard scope. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (Prior-Art Scout → describe → specify).
-- **Deep discovery team**: TeamCreate — comm-pivot ✓ (adversarial questioner reacts live to flow-analyst and prior-art findings), classifiably parallel ✓ (multi-perspective synthesis with adversarial challenge), wall-clock payoff ≥3× for cross-module or security-scope work. Gated on Deep scope. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations (Prior-Art Scout → describe → flow analyst → specify → adversarial questioner).
+- **Standard team**: describe lead-inline + scout parallel subagent + specify sequential subagent. Comm-pivot ✗ (async handoff), disjoint ✓, parallel ✓ scout-only, payoff <3×. Fallback: sequential subagents (scout → describe → specify).
+- **Deep team**: TeamCreate. Comm-pivot ✓ (adversarial questioner reacts live), disjoint ✓, parallel ✓, payoff ≥3× cross-module/security. Gate: Deep scope. Fallback: sequential subagents.
 
 ## Process
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -36,6 +36,10 @@ Once you've assessed the scope as **Standard** or **Deep**, inspect the GitHub i
 
 Skip this gate for **Lightweight** scope.
 
+### Spawn justification
+
+`/implement` is a coordinator (per `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md`). It dispatches `/build`, `/review`, `/verify`, `/compound`, and `/wrap-up` sequentially; each owns its own scope assessment and spawn rubric. The team premium (or its absence) is paid inside the sub-skills, not here.
+
 ## Process
 
 **Autonomy contract**: inside a single `/implement` invocation, run build → review → verify → fix cycles back-to-back without asking the user between sub-skills. The only user-interrupt point is after the PR is opened and the cycle has either (a) passed clean, (b) exhausted 3 cycles with findings remaining, or (c) hit a blocker the sub-skill cannot resolve. Status updates during the loop are informational only — do **not** end them with a question.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -36,10 +36,6 @@ Once you've assessed the scope as **Standard** or **Deep**, inspect the GitHub i
 
 Skip this gate for **Lightweight** scope.
 
-### Spawn justification
-
-Coordinator (per `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md`) — no spawn site. Dispatches `/build`, `/review`, `/verify`, `/compound`, `/wrap-up` sequentially; each owns its own rubric.
-
 ## Process
 
 **Autonomy contract**: inside a single `/implement` invocation, run build → review → verify → fix cycles back-to-back without asking the user between sub-skills. The only user-interrupt point is after the PR is opened and the cycle has either (a) passed clean, (b) exhausted 3 cycles with findings remaining, or (c) hit a blocker the sub-skill cannot resolve. Status updates during the loop are informational only — do **not** end them with a question.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -38,7 +38,7 @@ Skip this gate for **Lightweight** scope.
 
 ### Spawn justification
 
-`/implement` is a coordinator (per `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md`). It dispatches `/build`, `/review`, `/verify`, `/compound`, and `/wrap-up` sequentially; each owns its own scope assessment and spawn rubric. The team premium (or its absence) is paid inside the sub-skills, not here.
+Coordinator (per `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md`) — no spawn site. Dispatches `/build`, `/review`, `/verify`, `/compound`, `/wrap-up` sequentially; each owns its own rubric.
 
 ## Process
 

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -8,9 +8,9 @@ You are leading the PR feedback resolution process. Your job is to systematicall
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Fix team**: TeamCreate when ≥3 non-overlapping file groups; otherwise dispatch parallel subagents (one Task tool call per file group in a single message) — comm-pivot ✓ at sufficient scale (agents may surface cross-thread regressions), file-disjoint ✓ (conflict avoidance already mapped), classifiably parallel ✓, wall-clock payoff ≥3× only at ≥3 file groups. Gated on ≥3 non-overlapping file groups. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: parallel subagents (for 1–2 groups) or sequential subagent invocations.
+- **Fix team**: TeamCreate at ≥3 file groups, else parallel subagents. Comm-pivot ✓ at scale (cross-thread regressions), disjoint ✓ (mapped pre-dispatch), parallel ✓, payoff ≥3× at ≥3 groups. Gate: ≥3 non-overlapping file groups. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: parallel subagents or sequential.
 
 ## Input
 
@@ -93,9 +93,9 @@ Group threads by concern category. Present the triage summary to the user before
 
 **Conflict avoidance:** Before dispatching, map each thread to the file(s) it affects. No two agents may work on the same file in parallel. Threads touching the same file are handled sequentially within one agent.
 
-**Dispatch fix agents** — when ≥3 non-overlapping file groups exist, spawn a fix team using TeamCreate; otherwise dispatch parallel subagents (one Task tool call per file group in a single message):
-- One agent (or subagent) per non-overlapping file group
-- Each agent receives its assigned threads and the full PR diff for context
+**Dispatch fix agents** per the Spawn justification gate (TeamCreate at ≥3 file groups, else parallel subagents):
+- One worker per non-overlapping file group
+- Each receives its assigned threads and the full PR diff for context
 - Each agent:
   1. Reads the review comment carefully
   2. Reads the relevant code in context (not just the diff line)

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -6,6 +6,12 @@ model: sonnet
 
 You are leading the PR feedback resolution process. Your job is to systematically process review feedback on a pull request — triage it, fix what can be fixed, and reply with clear verdicts.
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Fix team**: TeamCreate when ≥3 non-overlapping file groups; otherwise dispatch parallel subagents (one Task tool call per file group in a single message) — comm-pivot ✓ at sufficient scale (agents may surface cross-thread regressions), file-disjoint ✓ (conflict avoidance already mapped), classifiably parallel ✓, wall-clock payoff ≥3× only at ≥3 file groups. Gated on ≥3 non-overlapping file groups. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: parallel subagents (for 1–2 groups) or sequential subagent invocations.
+
 ## Input
 
 Either:
@@ -87,8 +93,8 @@ Group threads by concern category. Present the triage summary to the user before
 
 **Conflict avoidance:** Before dispatching, map each thread to the file(s) it affects. No two agents may work on the same file in parallel. Threads touching the same file are handled sequentially within one agent.
 
-**Spawn a fix team** using TeamCreate:
-- One agent per non-overlapping file group
+**Dispatch fix agents** — when ≥3 non-overlapping file groups exist, spawn a fix team using TeamCreate; otherwise dispatch parallel subagents (one Task tool call per file group in a single message):
+- One agent (or subagent) per non-overlapping file group
 - Each agent receives its assigned threads and the full PR diff for context
 - Each agent:
   1. Reads the review comment carefully

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -8,9 +8,9 @@ You are leading the PR feedback resolution process. Your job is to systematicall
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Fix team**: TeamCreate at ≥3 file groups, else parallel subagents. Comm-pivot ✓ at scale (cross-thread regressions), disjoint ✓ (mapped pre-dispatch), parallel ✓, payoff ≥3× at ≥3 groups. Gate: ≥3 non-overlapping file groups. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: parallel subagents or sequential.
+- **Fix team**: TeamCreate at ≥3 file groups, else parallel subagents. Comm-pivot ✓ at scale (cross-thread regressions), disjoint ✓ (mapped pre-dispatch), parallel ✓, payoff ≥3× at ≥3 groups. Gate: ≥3 non-overlapping file groups. Fallback: parallel subagents or sequential.
 
 ## Input
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -42,6 +42,13 @@ Decision tree:
 2. Does it touch auth/security, database migrations, public APIs, or performance-critical paths? → Deep
 3. Otherwise → Standard
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Standard review team**: TeamCreate when ≥3 reviewers are active after diff analysis; otherwise dispatch 2 parallel subagents (one Task tool call per reviewer in a single message) — comm-pivot ✓ (reviewers converge on disagreements), file-disjoint ✓ (reviewers read the same diff independently), classifiably parallel ✓, wall-clock payoff ≥3× only at ≥3 active reviewers. Gated on ≥3 reviewers active. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+- **Deep review team**: TeamCreate — comm-pivot ✓ (security and performance reviewers must coordinate on findings), file-disjoint ✓, classifiably parallel ✓ (4 independent review axes), wall-clock payoff ≥3× with opus premium justified by finding criticality. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+
 ## Process
 
 ### Lightweight
@@ -61,7 +68,7 @@ Decision tree:
    - **Performance reviewer** — activate when the diff touches database queries or data access patterns (e.g., `query`, `findAll`, `SELECT`, `JOIN`, `index`). Trigger on file paths matching `**/db/**`, `**/queries/**` or database-related content — NOT on generic JS iteration methods like `forEach` or `map`.
    - **Migration reviewer** — activate when the diff includes schema changes or data migrations. Trigger on file paths matching `**/migrations/**`, `**/db/**` or content matching `CREATE TABLE`, `ALTER TABLE`, `addColumn`, `migration`.
 
-3. **Spawn a review team** using TeamCreate with `model: "sonnet"` and the base reviewers plus any activated conditional reviewers. Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
+3. **Dispatch reviewers** — when ≥3 reviewers are active after diff analysis, spawn a review team using TeamCreate with `model: "sonnet"`; otherwise dispatch 2 parallel subagents (one Task tool call per reviewer in a single message). Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
    - **Correctness reviewer** (always-on) — checks that the implementation satisfies every acceptance criterion, handles edge cases, and has no logical errors.
    - **Standards reviewer** (always-on) — checks code style, naming, patterns, test quality, and adherence to project conventions.
    - **Security reviewer** (conditional) — checks for authentication/authorization bugs, injection vulnerabilities, secret exposure, and unsafe data handling.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -44,10 +44,10 @@ Decision tree:
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard review team**: TeamCreate when ≥3 reviewers are active after diff analysis; otherwise dispatch 2 parallel subagents (one Task tool call per reviewer in a single message) — comm-pivot ✓ (reviewers converge on disagreements), file-disjoint ✓ (reviewers read the same diff independently), classifiably parallel ✓, wall-clock payoff ≥3× only at ≥3 active reviewers. Gated on ≥3 reviewers active. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
-- **Deep review team**: TeamCreate — comm-pivot ✓ (security and performance reviewers must coordinate on findings), file-disjoint ✓, classifiably parallel ✓ (4 independent review axes), wall-clock payoff ≥3× with opus premium justified by finding criticality. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+- **Standard**: TeamCreate at ≥3 active reviewers, else 2 parallel subagents. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
+- **Deep**: TeamCreate. All four ✓ across 4 review axes; opus premium justified by criticality. Fallback: sequential subagents.
 
 ## Process
 
@@ -68,7 +68,7 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamC
    - **Performance reviewer** — activate when the diff touches database queries or data access patterns (e.g., `query`, `findAll`, `SELECT`, `JOIN`, `index`). Trigger on file paths matching `**/db/**`, `**/queries/**` or database-related content — NOT on generic JS iteration methods like `forEach` or `map`.
    - **Migration reviewer** — activate when the diff includes schema changes or data migrations. Trigger on file paths matching `**/migrations/**`, `**/db/**` or content matching `CREATE TABLE`, `ALTER TABLE`, `addColumn`, `migration`.
 
-3. **Dispatch reviewers** — when ≥3 reviewers are active after diff analysis, spawn a review team using TeamCreate with `model: "sonnet"`; otherwise dispatch 2 parallel subagents (one Task tool call per reviewer in a single message). Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
+3. **Dispatch reviewers** per the Spawn justification gate (TeamCreate at ≥3 active reviewers with `model: "sonnet"`, else parallel subagents). Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
    - **Correctness reviewer** (always-on) — checks that the implementation satisfies every acceptance criterion, handles edge cases, and has no logical errors.
    - **Standards reviewer** (always-on) — checks code style, naming, patterns, test quality, and adherence to project conventions.
    - **Security reviewer** (conditional) — checks for authentication/authorization bugs, injection vulnerabilities, secret exposure, and unsafe data handling.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -8,9 +8,9 @@ You are leading a requirements team. Your job is to turn a problem statement int
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Requirements team** (happy-path + edge-case analysts): sequential grill-me passes in the lead session — comm-pivot ✗ (both analysts contend for the same user input channel; parallelizing them would fragment the conversation), classifiably sequential ✓ (interactive grill-me degrades under MAS), no parallel speedup. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (both passes run in the lead session).
+- **Requirements (happy-path + edge-case)**: sequential grill-me passes in lead session. Comm-pivot ✗ (analysts contend for the same user input channel), parallel ✗ (interactive). Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -6,6 +6,12 @@ model: sonnet
 
 You are leading a requirements team. Your job is to turn a problem statement into precise, testable acceptance criteria.
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Requirements team** (happy-path + edge-case analysts): sequential grill-me passes in the lead session — comm-pivot ✗ (both analysts contend for the same user input channel; parallelizing them would fragment the conversation), classifiably sequential ✓ (interactive grill-me degrades under MAS), no parallel speedup. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: n/a — no flag dependency (both passes run in the lead session).
+
 ## Input
 
 A problem statement from /describe, or a user-provided feature description.
@@ -15,10 +21,10 @@ Optionally: a prior-art brief from /discovery's Prior-Art Scout. Fields: `proble
 ## Process
 
 1. Review the problem statement (or ask the user to describe the feature)
-2. **Spawn a requirements team** using TeamCreate:
-   - **Happy-path analyst** — uses /grill-me to drill into normal usage flows, expected behavior, and performance expectations
-   - **Edge-case analyst** — uses /grill-me to drill into boundaries, error scenarios, security considerations, and failure modes
-3. Teammates work in parallel, share findings via messages, and challenge each other's assumptions
+2. **Run two sequential grill-me passes in the lead session**:
+   - **Happy-path pass** — use /grill-me to drill into normal usage flows, expected behavior, and performance expectations
+   - **Edge-case pass** — use /grill-me to drill into boundaries, error scenarios, security considerations, and failure modes
+3. Incorporate findings from both passes and challenge assumptions across them
 4. For each requirement, produce a **concrete testable scenario**:
    ```
    GIVEN <precondition>

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -10,7 +10,7 @@ You are leading a requirements team. Your job is to turn a problem statement int
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Requirements (happy-path + edge-case)**: sequential grill-me passes in lead session. Comm-pivot ✗ (analysts contend for the same user input channel), parallel ✗ (interactive). Fallback: n/a — no flag dependency.
+- **Requirements (happy-path + edge-case)**: sequential grill-me passes in lead session. Comm-pivot ✗ (analysts contend for the same user input channel), disjoint n/a (sequential), parallel ✗ (interactive), payoff <3×. Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -42,9 +42,9 @@ Decision tree:
 
 ### Spawn justification
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Standard/Deep QA team**: TeamCreate when ≥4 acceptance criteria; otherwise dispatch parallel subagents (one Task tool call per criteria group in a single message) — comm-pivot ✓ (teammates cross-verify each other's findings), file-disjoint ✓ (criteria are independent), classifiably parallel ✓, wall-clock payoff ≥3× only at ≥4 AC. Gated on ≥4 acceptance criteria. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+- **Standard/Deep QA**: TeamCreate at ≥4 AC, else parallel subagents. Comm-pivot ✓ (cross-verify findings), disjoint ✓, parallel ✓, payoff ≥3× at ≥4 AC. Gate: ≥4 acceptance criteria. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagents.
 
 ## Process
 
@@ -59,12 +59,11 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamC
 
 1. Read the GitHub issue and extract all acceptance criteria.
 
-2. **Dispatch QA verifiers** — when ≥4 acceptance criteria exist, spawn a QA team using TeamCreate; otherwise dispatch parallel subagents (one Task tool call per criteria group in a single message):
-   - Split acceptance criteria across teammates (or subagents)
-   - Each is dispatched with the verification package (diff + AC + test commands) only — never the build session history
-   - Each verifies their assigned criteria independently
-   - Teammates cross-verify each other's findings via messages (TeamCreate) or findings are merged by the lead (subagents)
-   - **Deep scope only**: add one specialist QA teammate matched to the diff — security QA when the diff touches auth/authz/secret handling, performance QA when it touches queries/hot paths/migrations.
+2. **Dispatch QA verifiers** per the Spawn justification gate (TeamCreate at ≥4 AC, else parallel subagents):
+   - Split acceptance criteria across workers
+   - Each worker receives only the verification package (diff + AC + test commands) — never the build session history
+   - With TeamCreate, teammates cross-verify via messages; with subagents, the lead merges findings
+   - **Deep scope only**: add one specialist worker matched to the diff — security QA for auth/authz/secret handling, performance QA for queries/hot paths/migrations.
 
 3. Each teammate:
    - Uses superpowers:verification-before-completion as their verification framework

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -42,9 +42,9 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard/Deep QA**: TeamCreate at ≥4 AC, else parallel subagents. Comm-pivot ✓ (cross-verify findings), disjoint ✓, parallel ✓, payoff ≥3× at ≥4 AC. Gate: ≥4 acceptance criteria. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagents.
+- **Standard/Deep QA**: TeamCreate at ≥4 AC, else parallel subagents. Comm-pivot ✓ (cross-verify findings), disjoint ✓, parallel ✓, payoff ≥3× at ≥4 AC. Gate: ≥4 acceptance criteria. Fallback: sequential subagents.
 
 ## Process
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -40,6 +40,12 @@ Decision tree:
 2. Touches auth/security, migrations, public APIs, or perf-critical paths? → Deep
 3. Otherwise → Standard
 
+### Spawn justification
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the four-criterion `TeamCreate` rubric and primitive ladder.
+
+- **Standard/Deep QA team**: TeamCreate when ≥4 acceptance criteria; otherwise dispatch parallel subagents (one Task tool call per criteria group in a single message) — comm-pivot ✓ (teammates cross-verify each other's findings), file-disjoint ✓ (criteria are independent), classifiably parallel ✓, wall-clock payoff ≥3× only at ≥4 AC. Gated on ≥4 acceptance criteria. Fallback when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset: sequential subagent invocations.
+
 ## Process
 
 ### Lightweight
@@ -53,11 +59,11 @@ Decision tree:
 
 1. Read the GitHub issue and extract all acceptance criteria.
 
-2. **Spawn a QA team** using TeamCreate:
-   - Split acceptance criteria across teammates
-   - Each teammate is dispatched with the verification package (diff + AC + test commands) only — never the build session history
-   - Each teammate verifies their assigned criteria independently
-   - Teammates cross-verify each other's findings via messages
+2. **Dispatch QA verifiers** — when ≥4 acceptance criteria exist, spawn a QA team using TeamCreate; otherwise dispatch parallel subagents (one Task tool call per criteria group in a single message):
+   - Split acceptance criteria across teammates (or subagents)
+   - Each is dispatched with the verification package (diff + AC + test commands) only — never the build session history
+   - Each verifies their assigned criteria independently
+   - Teammates cross-verify each other's findings via messages (TeamCreate) or findings are merged by the lead (subagents)
    - **Deep scope only**: add one specialist QA teammate matched to the diff — security QA when the diff touches auth/authz/secret handling, performance QA when it touches queries/hot paths/migrations.
 
 3. Each teammate:


### PR DESCRIPTION
Closes #34

## Summary

- Adds `### Spawn justification` blocks to all in-scope `SKILL.md` files (11 of 12 — `/implement` is a coordinator and AC5 was dropped during implementation; see issue body for rationale).
- Each block cites the four rubric criteria from `_shared/composition.md`, names the chosen primitive, documents any activation gate, and provides a `Fallback:` line. The `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` flag-unset condition is declared once at the top of each block where it's relevant; sites that aren't flag-dependent (parallel subagents, lead-inline, sequential subagents) say `n/a — no flag dependency`.
- Updates Process sections in all affected skills to match new primitives.
- `_shared/composition.md` is unchanged (rubric is read-only per issue constraint).

### Downgrades (TeamCreate → lighter primitive)

| Skill | Spawn site | Old | New |
|---|---|---|---|
| `/discovery` Standard | discovery team | TeamCreate | describe lead-inline + scout parallel subagent + specify sequential subagent |
| `/define` | research team | TeamCreate | 2 parallel subagents |
| `/define` Standard | definition team | TeamCreate | sequential subagent invocations |
| `/architecture` | research | TeamCreate | 2 parallel subagents |
| `/architecture` | session | TeamCreate | analyst subagent + architect lead-inline + devil's advocate subagent |
| `/design` | session | TeamCreate | researcher subagent + proposer lead-inline + a11y subagent |
| `/specify` | requirements team | TeamCreate | sequential grill-me passes (lead session) |
| `/describe` Standard | discovery session | TeamCreate | domain researcher subagent + analyst lead-inline |
| `/describe` Deep | discovery session | TeamCreate | researcher + failure-mode parallel subagents + analyst lead-inline |
| `/compound` Full | compounding team | TeamCreate | 3 parallel subagents + lead synthesis |

### Gates (TeamCreate retained with concrete activation condition)

| Skill | Gate |
|---|---|
| `/discovery` Deep | Deep scope |
| `/define` Deep critique | Deep scope + security/payments/migration signal |
| `/build` Standard | ≥3 sub-issues OR ≥3 disjoint file groups |
| `/review` Standard | ≥3 reviewers active after diff analysis |
| `/verify` Standard/Deep | ≥4 acceptance criteria |
| `/resolve-pr-feedback` | ≥3 non-overlapping file groups |

### Coordinator note

`/implement` has no spawn site of its own and no Spawn justification block — its existing autonomy contract in the Process section already documents the coordinator role. Issue #34 AC5 was dropped during implementation with rationale recorded on the issue body.

## Manual testing

1. Read `skills/specify/SKILL.md` → verify `### Spawn justification` block appears before `## Input`, names sequential grill-me passes, includes a `Fallback:` line with `n/a — no flag dependency`, and lists all four rubric criteria (comm-pivot, disjoint n/a, parallel, payoff).
2. Read `skills/build/SKILL.md` → verify the Standard step 3 says "spawn workers per the Spawn justification block" and the Spawn justification block has a concrete `≥3 sub-issues OR ≥3 disjoint file groups` gate.
3. Read `skills/implement/SKILL.md` → confirm no `### Spawn justification` block (intentionally dropped).
4. Run `grep -l "### Spawn justification" skills/*/SKILL.md | wc -l` → should return 11 (all in-scope skills except `/implement`).
5. Run `grep -l "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" skills/*/SKILL.md` → should match only the skills whose primary primitive is `TeamCreate` (or whose justification block declares the preamble line). Skills built solely on parallel/sequential subagents or lead-inline use `n/a — no flag dependency` and intentionally don't restate the flag string.
6. Confirm `git diff main -- _shared/composition.md` is empty.