### PR TITLE
docs(skills): audit specialist spawn sites and add model tier recommendations

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -11,8 +11,8 @@ You are leading an architecture team. Your job is to explore technical approache
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
-- **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
+- **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Model: dispatch with `model: "sonnet"` — both agents (codebase research and patterns/learnings) are read-only research, not deep architecture reasoning; sonnet handles this capably at lower token cost. Fallback: sequential subagents.
+- **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Model: analyst and devil's advocate subagents use `model: "sonnet"` (constraint analysis and systematic challenge); lead architect (interactive) stays `opus`. Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -36,8 +36,8 @@ Decision tree:
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard session**: domain researcher subagent + analyst lead-inline. Comm-pivot ✗ (one-shot handoff), disjoint n/a (sequential), parallel ✗ (analyst interactive), payoff <3×. Fallback: n/a — no flag dependency.
-- **Deep session**: researcher + failure-mode parallel subagents + analyst lead-inline. Comm-pivot ✗, disjoint ✓, parallel ✓ for subagent pair, payoff <3× total. Fallback: sequential subagents.
+- **Standard session**: domain researcher subagent + analyst lead-inline. Comm-pivot ✗ (one-shot handoff), disjoint n/a (sequential), parallel ✗ (analyst interactive), payoff <3×. Model: domain researcher uses `model: "sonnet"` (reading code and extracting patterns) — only lead analyst needs `opus` for interactive problem discovery. Fallback: n/a — no flag dependency.
+- **Deep session**: researcher + failure-mode parallel subagents + analyst lead-inline. Comm-pivot ✗, disjoint ✓, parallel ✓ for subagent pair, payoff <3× total. Model: domain researcher and failure-mode analyst both use `model: "sonnet"` (research and analysis) — only lead analyst needs `opus` for interactive discovery. Fallback: sequential subagents.
 
 ## Process
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -10,7 +10,7 @@ You are leading a design team. Your job is to explore visual and interaction des
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
-- **Design session**: researcher subagent → proposer lead-inline (grill-me) → a11y subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Fallback: n/a — no flag dependency.
+- **Design session**: researcher subagent → proposer lead-inline (grill-me) → a11y subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Model: UX researcher and accessibility reviewer both use `model: "haiku"` (pattern search and accessibility checklist validation are systematic, not creative) — reserve `sonnet` for the design proposer lead session (interactive, requires design judgment). Fallback: n/a — no flag dependency.
 
 ## Input
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -44,10 +44,10 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset. Model tiers: see **Configuration** section.
 
-- **Standard**: TeamCreate at ≥3 active reviewers, else 2 parallel subagents. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
-- **Deep**: TeamCreate. All four ✓ across 4 review axes; opus premium justified by criticality. Fallback: sequential subagents.
+- **Standard**: TeamCreate at ≥3 active reviewers, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
+- **Deep**: TeamCreate with `model: "opus"`. All four ✓ across 4 review axes; opus premium justified by criticality. Fallback: sequential subagents.
 
 ## Process
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -46,7 +46,7 @@ Decision tree:
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset. Model tiers: see **Configuration** section.
 
-- **Standard**: TeamCreate at ≥3 active reviewers, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
+- **Standard**: TeamCreate with `model: "sonnet"` at ≥3 active reviewers, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
 - **Deep**: TeamCreate with `model: "opus"`. All four ✓ across 4 review axes; opus premium justified by criticality. Fallback: sequential subagents.
 
 ## Process

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -44,7 +44,7 @@ Decision tree:
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
 
-- **Standard/Deep QA**: TeamCreate at ≥4 AC, else parallel subagents. Comm-pivot ✓ (cross-verify findings), disjoint ✓, parallel ✓, payoff ≥3× at ≥4 AC. Gate: ≥4 acceptance criteria. Fallback: sequential subagents.
+- **Standard/Deep QA**: TeamCreate at ≥4 AC, else parallel subagents. Comm-pivot ✓ (cross-verify findings), disjoint ✓, parallel ✓, payoff ≥3× at ≥4 AC. Model: dispatch QA workers with `model: "haiku"` — QA verification is highly structured (AC-based pass/fail with evidence collection); haiku handles this capably and matches the lead agent's model tier. Gate: ≥4 acceptance criteria. Fallback: sequential subagents.
 
 ## Process
 


### PR DESCRIPTION
Closes #35

## Summary

Audits the seven specialist skills in scope — `/describe`, `/review`, `/verify`, `/architecture`, `/design`, `/specify`, and `/grill-me` — against the cost rubric established in PR #47. Adds explicit `model:` recommendations at each spawn site where `sonnet` or `haiku` can perform the task capably, saving tokens vs. `opus`.

- All spawn configurations are documented and justified per composition.md rubric.
- Scope-based gating (Lightweight → no team, Standard/Deep → gated workers) already handles team collapses for simplest cases; no further intra-scope optimizations identified.
- Model tier recommendations added to all five specialists with subagent spawning: `/describe`, `/architecture`, `/design`, `/verify`, `/review`.

## Per-specialist findings

| Skill | Spawn config | Status | Optimization |
|---|---|---|---|
| `/describe` Standard | domain researcher subagent + analyst lead-inline | **Correct** | domain researcher: sonnet (research work) |
| `/describe` Deep | researcher + failure-mode parallel subagents + analyst lead-inline | **Correct** | both researchers: sonnet (research/analysis) |
| `/review` Lightweight | lead reviewer only (inline) | **Correct** | n/a (no subagents) |
| `/review` Standard | TeamCreate ≥3 reviewers, else 2 parallel subagents | **Correct** | subagents: sonnet per Configuration section |
| `/review` Deep | TeamCreate with opus | **Correct** | n/a (already critical scope) |
| `/verify` Lightweight | lead verification inline | **Correct** | n/a (no subagents) |
| `/verify` Standard/Deep | TeamCreate ≥4 AC, else parallel subagents | **Correct** | workers: haiku (structured QA, matches lead tier) |
| `/architecture` Research | 2 parallel subagents | **Correct** | both: sonnet (read-only research) |
| `/architecture` Session | analyst → architect lead-inline → devil's advocate | **Correct** | analyst and devil's advocate: sonnet; lead: opus |
| `/design` Session | researcher → proposer lead-inline → a11y subagent | **Correct** | researcher and a11y: haiku (systematic work); proposer: sonnet |
| `/specify` | sequential grill-me passes (lead session) | **Correct** | n/a (already inline, no subagents) |
| `/grill-me` | pure interactive primitive (inline) | **Correct** | n/a (confirmed remains inline) |

## Spawn behavior defense

All spawn configurations are retained as correct for the following reasons:

1. **Scope-based gating works** — Lightweight scope already collapses unnecessary teams (verification and analysis happen inline for simple cases), so no further collapse opportunities exist without changing scope definitions.

2. **No communication pivot above current threshold** — All spawn sites either have no mid-task communication (researcher → analyst is one-shot handoff) or are already flagged as interactive (lead sessions). No sites were found that would benefit from collapsing to sequential when they currently run parallel.

3. **Payoff justified** — Research subagents (researcher, analyst, devil's advocate, a11y) run in parallel to the lead session's interactive work when parallelizable, providing wall-clock optimization. Teams that don't meet parallelism criteria already use sequential subagents.

## Acceptance checklist

- [x] Each specialist's spawn behavior is documented and justified.
- [x] Inner-team collapses identified: scope-based gating (Lightweight scope) already handles simplest cases by running work inline instead of delegating to subagents; no further optimizations needed.
- [x] Model tiers called out per spawn site: sonnet for research/analysis work; haiku for structured validation; opus reserved for lead-interactive and critical tasks.