### PR TITLE
docs: add cross-plugin coordination guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,13 @@ Without `claude-obsidian` every skill still runs; vault operations are skipped w
 
 Full lifecycle walkthrough: [`docs/workflow.md`](docs/workflow.md)
 
+## Ecosystem
+
+When working across multiple plugins and repositories, see [`docs/cross-plugin.md`](docs/cross-plugin.md) for guidance on:
+- MCP scope (shared vs. plugin-bundled servers)
+- Inter-plugin dependency declarations
+- CLAUDE.md layering (`~/.claude/CLAUDE.md`, `./CLAUDE.md`, `./CLAUDE.local.md`)
+
 ## Authoring standard
 
 This plugin ships an authoring standard for creating new skills:

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -1,159 +1,38 @@
 # Cross-plugin Coordination
 
-Guidance for plugins that integrate with each other and share MCPs across the claude-workflow ecosystem (claude-workflow, claude-obsidian, claude-config).
+Plugin-specific decisions for the `claude-workflow` + `claude-obsidian` + `claude-config` ecosystem. For the general semantics of CLAUDE.md layering, `plugin.json.dependencies`, and MCP namespacing, see Anthropic's Claude Code plugin documentation and the [MCP specification](https://modelcontextprotocol.io/) — this doc only records what is specific to *this* ecosystem.
 
-## MCP scope rule
+## MCP scope
 
-Shared MCPs live at **user scope** (in `~/.claude/`), owned and versioned by `claude-config`. Plugin-bundled MCPs only when the MCP is **plugin-specific** — tied to that plugin's function and not shared across other plugins.
+Shared MCP servers live at user scope in `~/.claude/`, owned by `claude-config`. Plugins bundle MCPs only when the MCP is plugin-specific.
 
-**Rationale**: When two plugins ship overlapping MCP servers, Claude Code runs both with different namespace identifiers (`atlassian` vs `plugin:claude-workflow:atlassian`), wasting capacity, introducing routing confusion, and making it unclear which version is active. Centralizing shared MCPs avoids this duplication failure mode.
+Why: when two plugins bundle overlapping servers, Claude Code loads both under different identifiers (`<name>` vs `plugin:<plugin>:<name>`), forcing every consumer to branch on which is live. Centralising shared MCPs in `claude-config` eliminates the duplicate.
 
-### Worked example: duplicate identifiers
+`claude-workflow` bundles no MCPs.
 
-Suppose both `claude-workflow` and `claude-obsidian` ship an `llm-context` MCP to manage context size.
+## Optional `claude-obsidian` integration
 
-**Bad** (current buggy pattern):
-- `claude-workflow` installs MCP `llm-context@v1.0` bundled in `.claude-plugin/mcp/`
-- `claude-obsidian` installs MCP `llm-context@v1.1` bundled in `.claude-plugin/mcp/`
-- Claude Code loads **both** at startup:
-  - `llm-context` (from `claude-workflow`, v1.0)
-  - `plugin:claude-obsidian:llm-context` (from `claude-obsidian`, v1.1)
-- Skills must branch on which identifier is live, breaking composability and doubling testing burden.
+`claude-workflow` integrates with `claude-obsidian` via **runtime detection**, not via `plugin.json.dependencies`. A hard dependency would block install for users who don't want the vault; runtime detection lets the integration degrade gracefully.
 
-**Good** (shared user scope):
-- `claude-config` owns `llm-context@v1.2` in `~/.claude/mcp/llm-context/`
-- Both plugins reference it from settings (no bundled copies).
-- Claude Code loads **one** MCP at startup: `llm-context` (v1.2, shared).
-- All skills and plugins use the same interface.
+Skills probe for these commands; if present, the vault-aware path activates, otherwise the skill falls back inline:
 
-**Decision for this plugin**: `claude-workflow` does not bundle any MCPs. It documents the optional `claude-obsidian` integration at runtime (see "Dependency declarations" below).
+- `claude-obsidian:save` — file structured notes
+- `claude-obsidian:wiki-query` — overlap detection and prior-pattern lookup
+- `claude-obsidian:wiki-lint` — vault health audits
 
-## Dependency declarations
+If a future skill makes the vault mandatory, declare `dependencies: ["claude-obsidian"]` in `plugin.json` and update this section.
 
-`plugin.json.dependencies` is a formal field in the Anthropic plugins schema for declaring hard dependencies on other plugins. This plugin **does not populate it for the optional `claude-obsidian` integration** — it uses runtime detection instead.
+## CLAUDE.md ownership in this ecosystem
 
-### Reasoning
+| Layer | Path | Owner | Contains |
+|---|---|---|---|
+| Ecosystem | `~/.claude/CLAUDE.md` | `claude-config` repo | Cross-project conventions, plugin install guidance, shared shortcuts |
+| Project | `./CLAUDE.md` (committed) | The project repo | Project-specific idioms, code style, how to invoke the project's skills/tests |
+| Personal | `./CLAUDE.local.md` (gitignored) | Individual user | Local quirks, per-machine overrides |
 
-1. **Runtime detection keeps the integration optional.** If `claude-obsidian` were a hard dependency in `plugin.json`, Claude Code would block installation for users who don't have it, even if they never plan to use the vault-aware skills. That's too coercive.
-
-2. **Integration is graceful degeneracy, not breakage.** Skills like `/compound` and `/prune` run correctly whether `claude-obsidian` is installed or not — they emit structured notes inline when the vault is unavailable, or delegate to `/save` when it is. No error state; no unmet requirement.
-
-3. **Runtime detection is discoverable.** When a user runs `/compound` without `claude-obsidian`, the skill's response includes an install suggestion. That discovery path is lower friction than a hard dependency that fails at plugin load time.
-
-### Integration pattern
-
-Skills detect `claude-obsidian` availability by checking for its commands at runtime:
-- `claude-obsidian:save` — for filing structured notes
-- `claude-obsidian:wiki-query` — for overlap detection and prior-pattern lookup
-- `claude-obsidian:wiki-lint` — for vault health audits
-
-If any of these are available, the vault-aware path activates. Otherwise, the skill emits or reports inline.
-
-**If this decision changes in the future** (e.g., the vault becomes mandatory for a new skill), add `dependencies: ["claude-obsidian"]` to `plugin.json` and document the reason in this section.
-
-## CLAUDE.md layering
-
-The ecosystem layers guidance across three files, each with a different scope and audience.
-
-### `~/.claude/CLAUDE.md` — ecosystem scope (owned by claude-config)
-
-**Lives in**: `$HOME/.claude/CLAUDE.md` (user home, not a project repo)
-
-**Audience**: all Claude Code users and all plugins running on this machine
-
-**Owns**:
-- Cross-project conventions and standards (e.g., "always commit before tests", "max context is 50k tokens")
-- Plugin installation and marketplace guidance
-- Shared workflow shortcuts (e.g., "run `/wrap-up` before ending a session")
-- Environment variables and global settings
-- High-level multi-repo principles (repo cross-references, workspace layout)
-
-**Does NOT own**:
-- Project-specific code style or idioms
-- Individual plugin implementation details (that belongs in each plugin's own CLAUDE.md)
-- Local machine quirks (those belong in CLAUDE.local.md)
-
-**Authored by**: the `claude-config` repo (user's dotfiles/settings)
-
-### `./CLAUDE.md` — project scope (committed to the repo)
-
-**Lives in**: the root of each repo (e.g., `claude-workflow/CLAUDE.md`, `myapp/CLAUDE.md`)
-
-**Audience**: Claude Code and any user working on this repo
-
-**Owns**:
-- Project-specific workflow guidance and idioms (e.g., "run `/build` against the issue, never free-form")
-- Code style, naming conventions, architecture rules for *this* project
-- How to invoke the project's own skills, tests, or CI/CD
-- Plugin configuration relevant only to this repo
-- How to run the project locally (steps that apply to all contributors)
-
-**Does NOT own**:
-- User's personal local quirks (e.g., "I always edit in Vim", "my preferred test runner")
-- System-wide conventions from `~/.claude/CLAUDE.md` (those are inherited; mention them here only to call out exceptions)
-- Credentials or secrets (those belong in `.env` or CLAUDE.local.md, gitignored)
-
-**Authored by**: the project maintainers, committed to git
-
-**For monorepos and parent/child repos**: if the repo is a monorepo (e.g., `packages/*/`), create `./CLAUDE.md` at the root for monorepo-wide rules, and optionally `packages/*/CLAUDE.md` for package-specific overrides. Submodules and referenced external repos should each have their own committed CLAUDE.md; the parent does not duplicate it.
-
-### `./CLAUDE.local.md` — personal scope (gitignored)
-
-**Lives in**: the root of the repo, gitignored (add `CLAUDE.local.md` to `.gitignore`)
-
-**Audience**: the individual user (not shared)
-
-**Owns**:
-- Personal machine-specific tweaks for *this* repo (e.g., "alias `npm test` to `npm run test:fast`", "use Prettier instead of the default formatter")
-- Local environment variables specific to development
-- Per-machine debugging toggles or performance overrides
-- Personal task macros or per-repo quick commands
-
-**Does NOT own**:
-- Anything that affects the repo's collective experience (use `./CLAUDE.md` instead)
-- Secrets and credentials (use `.env` or a proper secrets manager)
-- Filesystem paths outside this repo (use `~/.claude/CLAUDE.local.md` if you need a per-machine global setting)
-
-**Authored by**: the individual user, never committed
-
-### Layering summary
-
-| File | Scope | Inherited by | Overridden by |
-|------|-------|--------------|---------------|
-| `~/.claude/CLAUDE.md` | Ecosystem | All repos | `./CLAUDE.md` |
-| `./CLAUDE.md` | Project (committed) | This repo | `./CLAUDE.local.md` |
-| `./CLAUDE.local.md` | Personal (gitignored) | This repo only | —— |
-
-Read order when initializing Claude Code in a repo:
-
-1. **`~/.claude/CLAUDE.md`** (global defaults)
-2. **`./CLAUDE.md`** (project overrides)
-3. **`./CLAUDE.local.md`** (personal machine tweaks, if it exists)
-
-Each layer should assume the previous one is loaded and state only what differs.
-
-### Example: adding a new rule
-
-**Scenario**: The `claude-workflow` project adopts a new convention: "always write acceptance criteria in the GitHub issue before calling `/build`."
-
-- If this rule applies **across all projects** the user works on, add it to `~/.claude/CLAUDE.md` in `claude-config`.
-- If it applies **only to claude-workflow**, add it to `claude-workflow/CLAUDE.md` (committed).
-- If the user wants a personal exception on their machine only (e.g., "I skip this in my local development"), add it to `claude-workflow/CLAUDE.local.md` (gitignored).
-
-### When to grep existing docs
-
-Before adding content to any layer, grep the docs at that layer and all inherited layers to avoid duplication. Example from this repo:
-
-```bash
-grep -r "runtime detection" ~/.claude/CLAUDE.md ./CLAUDE.md ./CLAUDE.local.md 2>/dev/null
-```
-
-If the rule already exists in a parent layer, reference it instead of repeating it.
+Each layer assumes the previous one is loaded and states only what differs. Before adding a rule, grep existing layers — if it already exists upstream, reference it instead of duplicating.
 
 ## See also
 
-- `README.md:127` — current implicit `claude-obsidian` integration documentation
-- `plugin.json` — formal plugin metadata and dependencies field
-- [Anthropic plugins reference](https://docs.anthropic.com/en/docs/build-with-claude/plugins) — `plugin.json` schema
-- [Anthropic MCP specification](https://modelcontextprotocol.io/) — shared MCP servers and namespacing
-
+- [`README.md`](../README.md) — `claude-obsidian` integration overview
+- [`plugin.json`](../.claude-plugin/plugin.json) — plugin metadata

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -1,0 +1,159 @@
+# Cross-plugin Coordination
+
+Guidance for plugins that integrate with each other and share MCPs across the claude-workflow ecosystem (claude-workflow, claude-obsidian, claude-config).
+
+## MCP scope rule
+
+Shared MCPs live at **user scope** (in `~/.claude/`), owned and versioned by `claude-config`. Plugin-bundled MCPs only when the MCP is **plugin-specific** — tied to that plugin's function and not shared across other plugins.
+
+**Rationale**: When two plugins ship overlapping MCP servers, Claude Code runs both with different namespace identifiers (`atlassian` vs `plugin:claude-workflow:atlassian`), wasting capacity, introducing routing confusion, and making it unclear which version is active. Centralizing shared MCPs avoids this duplication failure mode.
+
+### Worked example: duplicate identifiers
+
+Suppose both `claude-workflow` and `claude-obsidian` ship an `llm-context` MCP to manage context size.
+
+**Bad** (current buggy pattern):
+- `claude-workflow` installs MCP `llm-context@v1.0` bundled in `.claude-plugin/mcp/`
+- `claude-obsidian` installs MCP `llm-context@v1.1` bundled in `.claude-plugin/mcp/`
+- Claude Code loads **both** at startup:
+  - `llm-context` (from `claude-workflow`, v1.0)
+  - `plugin:claude-obsidian:llm-context` (from `claude-obsidian`, v1.1)
+- Skills must branch on which identifier is live, breaking composability and doubling testing burden.
+
+**Good** (shared user scope):
+- `claude-config` owns `llm-context@v1.2` in `~/.claude/mcp/llm-context/`
+- Both plugins reference it from settings (no bundled copies).
+- Claude Code loads **one** MCP at startup: `llm-context` (v1.2, shared).
+- All skills and plugins use the same interface.
+
+**Decision for this plugin**: `claude-workflow` does not bundle any MCPs. It documents the optional `claude-obsidian` integration at runtime (see "Dependency declarations" below).
+
+## Dependency declarations
+
+`plugin.json.dependencies` is a formal field in the Anthropic plugins schema for declaring hard dependencies on other plugins. This plugin **does not populate it for the optional `claude-obsidian` integration** — it uses runtime detection instead.
+
+### Reasoning
+
+1. **Runtime detection keeps the integration optional.** If `claude-obsidian` were a hard dependency in `plugin.json`, Claude Code would block installation for users who don't have it, even if they never plan to use the vault-aware skills. That's too coercive.
+
+2. **Integration is graceful degeneracy, not breakage.** Skills like `/compound` and `/prune` run correctly whether `claude-obsidian` is installed or not — they emit structured notes inline when the vault is unavailable, or delegate to `/save` when it is. No error state; no unmet requirement.
+
+3. **Runtime detection is discoverable.** When a user runs `/compound` without `claude-obsidian`, the skill's response includes an install suggestion. That discovery path is lower friction than a hard dependency that fails at plugin load time.
+
+### Integration pattern
+
+Skills detect `claude-obsidian` availability by checking for its commands at runtime:
+- `claude-obsidian:save` — for filing structured notes
+- `claude-obsidian:wiki-query` — for overlap detection and prior-pattern lookup
+- `claude-obsidian:wiki-lint` — for vault health audits
+
+If any of these are available, the vault-aware path activates. Otherwise, the skill emits or reports inline.
+
+**If this decision changes in the future** (e.g., the vault becomes mandatory for a new skill), add `dependencies: ["claude-obsidian"]` to `plugin.json` and document the reason in this section.
+
+## CLAUDE.md layering
+
+The ecosystem layers guidance across three files, each with a different scope and audience.
+
+### `~/.claude/CLAUDE.md` — ecosystem scope (owned by claude-config)
+
+**Lives in**: `$HOME/.claude/CLAUDE.md` (user home, not a project repo)
+
+**Audience**: all Claude Code users and all plugins running on this machine
+
+**Owns**:
+- Cross-project conventions and standards (e.g., "always commit before tests", "max context is 50k tokens")
+- Plugin installation and marketplace guidance
+- Shared workflow shortcuts (e.g., "run `/wrap-up` before ending a session")
+- Environment variables and global settings
+- High-level multi-repo principles (repo cross-references, workspace layout)
+
+**Does NOT own**:
+- Project-specific code style or idioms
+- Individual plugin implementation details (that belongs in each plugin's own CLAUDE.md)
+- Local machine quirks (those belong in CLAUDE.local.md)
+
+**Authored by**: the `claude-config` repo (user's dotfiles/settings)
+
+### `./CLAUDE.md` — project scope (committed to the repo)
+
+**Lives in**: the root of each repo (e.g., `claude-workflow/CLAUDE.md`, `myapp/CLAUDE.md`)
+
+**Audience**: Claude Code and any user working on this repo
+
+**Owns**:
+- Project-specific workflow guidance and idioms (e.g., "run `/build` against the issue, never free-form")
+- Code style, naming conventions, architecture rules for *this* project
+- How to invoke the project's own skills, tests, or CI/CD
+- Plugin configuration relevant only to this repo
+- How to run the project locally (steps that apply to all contributors)
+
+**Does NOT own**:
+- User's personal local quirks (e.g., "I always edit in Vim", "my preferred test runner")
+- System-wide conventions from `~/.claude/CLAUDE.md` (those are inherited; mention them here only to call out exceptions)
+- Credentials or secrets (those belong in `.env` or CLAUDE.local.md, gitignored)
+
+**Authored by**: the project maintainers, committed to git
+
+**For monorepos and parent/child repos**: if the repo is a monorepo (e.g., `packages/*/`), create `./CLAUDE.md` at the root for monorepo-wide rules, and optionally `packages/*/CLAUDE.md` for package-specific overrides. Submodules and referenced external repos should each have their own committed CLAUDE.md; the parent does not duplicate it.
+
+### `./CLAUDE.local.md` — personal scope (gitignored)
+
+**Lives in**: the root of the repo, gitignored (add `CLAUDE.local.md` to `.gitignore`)
+
+**Audience**: the individual user (not shared)
+
+**Owns**:
+- Personal machine-specific tweaks for *this* repo (e.g., "alias `npm test` to `npm run test:fast`", "use Prettier instead of the default formatter")
+- Local environment variables specific to development
+- Per-machine debugging toggles or performance overrides
+- Personal task macros or per-repo quick commands
+
+**Does NOT own**:
+- Anything that affects the repo's collective experience (use `./CLAUDE.md` instead)
+- Secrets and credentials (use `.env` or a proper secrets manager)
+- Filesystem paths outside this repo (use `~/.claude/CLAUDE.local.md` if you need a per-machine global setting)
+
+**Authored by**: the individual user, never committed
+
+### Layering summary
+
+| File | Scope | Inherited by | Overridden by |
+|------|-------|--------------|---------------|
+| `~/.claude/CLAUDE.md` | Ecosystem | All repos | `./CLAUDE.md` |
+| `./CLAUDE.md` | Project (committed) | This repo | `./CLAUDE.local.md` |
+| `./CLAUDE.local.md` | Personal (gitignored) | This repo only | —— |
+
+Read order when initializing Claude Code in a repo:
+
+1. **`~/.claude/CLAUDE.md`** (global defaults)
+2. **`./CLAUDE.md`** (project overrides)
+3. **`./CLAUDE.local.md`** (personal machine tweaks, if it exists)
+
+Each layer should assume the previous one is loaded and state only what differs.
+
+### Example: adding a new rule
+
+**Scenario**: The `claude-workflow` project adopts a new convention: "always write acceptance criteria in the GitHub issue before calling `/build`."
+
+- If this rule applies **across all projects** the user works on, add it to `~/.claude/CLAUDE.md` in `claude-config`.
+- If it applies **only to claude-workflow**, add it to `claude-workflow/CLAUDE.md` (committed).
+- If the user wants a personal exception on their machine only (e.g., "I skip this in my local development"), add it to `claude-workflow/CLAUDE.local.md` (gitignored).
+
+### When to grep existing docs
+
+Before adding content to any layer, grep the docs at that layer and all inherited layers to avoid duplication. Example from this repo:
+
+```bash
+grep -r "runtime detection" ~/.claude/CLAUDE.md ./CLAUDE.md ./CLAUDE.local.md 2>/dev/null
+```
+
+If the rule already exists in a parent layer, reference it instead of repeating it.
+
+## See also
+
+- `README.md:127` — current implicit `claude-obsidian` integration documentation
+- `plugin.json` — formal plugin metadata and dependencies field
+- [Anthropic plugins reference](https://docs.anthropic.com/en/docs/build-with-claude/plugins) — `plugin.json` schema
+- [Anthropic MCP specification](https://modelcontextprotocol.io/) — shared MCP servers and namespacing
+

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -8,6 +8,16 @@ Shared MCP servers live at user scope in `~/.claude/`, owned by `claude-config`.
 
 Why: when two plugins bundle overlapping servers, Claude Code loads both under different identifiers (`<name>` vs `plugin:<plugin>:<name>`), forcing every consumer to branch on which is live. Centralising shared MCPs in `claude-config` eliminates the duplicate.
 
+**Worked example.** Suppose both `claude-workflow` and `claude-obsidian` ship an `obsidian-vault` MCP server. Claude Code loads them as two separate clients:
+
+| Source | Tool identifier in skill bodies |
+| --- | --- |
+| `claude-config` (user scope) | `mcp__obsidian-vault__obsidian_get_file_contents` |
+| `claude-workflow` plugin     | `mcp__plugin_claude-workflow_obsidian-vault__obsidian_get_file_contents` |
+| `claude-obsidian` plugin     | `mcp__plugin_claude-obsidian_obsidian-vault__obsidian_get_file_contents` |
+
+Both plugins boot a separate server process pointed at the same vault, doubling resource use and racing on writes. Skills written against one identifier silently no-op when only the other is installed. Permission allowlists need three entries instead of one. Centralising the server in `claude-config` collapses all three rows back to a single identifier.
+
 `claude-workflow` bundles no MCPs.
 
 ## Optional `claude-obsidian` integration

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -1,24 +1,22 @@
 # Cross-plugin Coordination
 
-Plugin-specific decisions for the `claude-workflow` + `claude-obsidian` + `claude-config` ecosystem. For the general semantics of CLAUDE.md layering, `plugin.json.dependencies`, and MCP namespacing, see Anthropic's Claude Code plugin documentation and the [MCP specification](https://modelcontextprotocol.io/) — this doc only records what is specific to *this* ecosystem.
+Plugin-specific decisions for `claude-workflow` and how it coexists with other Claude Code plugins (notably `claude-obsidian`). For the general semantics of CLAUDE.md layering, `plugin.json.dependencies`, and MCP namespacing, see Anthropic's Claude Code plugin documentation and the [MCP specification](https://modelcontextprotocol.io/) — this doc only records what is specific to *this* plugin.
 
 ## MCP scope
 
-Shared MCP servers live at user scope in `~/.claude/`, owned by `claude-config`. Plugins bundle MCPs only when the MCP is plugin-specific.
+`claude-workflow` bundles no MCP servers. When a plugin needs an MCP that another plugin (or the user's own config) already provides, install it once at user scope in `~/.claude/` rather than bundling a duplicate.
 
-Why: when two plugins bundle overlapping servers, Claude Code loads both under different identifiers (`<name>` vs `plugin:<plugin>:<name>`), forcing every consumer to branch on which is live. Centralising shared MCPs in `claude-config` eliminates the duplicate.
+Why: when two plugins bundle overlapping servers, Claude Code loads both under different identifiers (`<name>` vs `plugin:<plugin>:<name>`), forcing every consumer to branch on which is live.
 
 **Worked example.** Suppose both `claude-workflow` and `claude-obsidian` ship an `obsidian-vault` MCP server. Claude Code loads them as two separate clients:
 
 | Source | Tool identifier in skill bodies |
 | --- | --- |
-| `claude-config` (user scope) | `mcp__obsidian-vault__obsidian_get_file_contents` |
+| User scope (`~/.claude/`)    | `mcp__obsidian-vault__obsidian_get_file_contents` |
 | `claude-workflow` plugin     | `mcp__plugin_claude-workflow_obsidian-vault__obsidian_get_file_contents` |
 | `claude-obsidian` plugin     | `mcp__plugin_claude-obsidian_obsidian-vault__obsidian_get_file_contents` |
 
-Both plugins boot a separate server process pointed at the same vault, doubling resource use and racing on writes. Skills written against one identifier silently no-op when only the other is installed. Permission allowlists need three entries instead of one. Centralising the server in `claude-config` collapses all three rows back to a single identifier.
-
-`claude-workflow` bundles no MCPs.
+Both plugins boot a separate server process pointed at the same vault, doubling resource use and racing on writes. Skills written against one identifier silently no-op when only the other is installed. Permission allowlists need three entries instead of one. Installing the server once at user scope collapses all three rows back to a single identifier.
 
 ## Optional `claude-obsidian` integration
 
@@ -31,10 +29,6 @@ Skills probe for these commands; if present, the vault-aware path activates, oth
 - `claude-obsidian:wiki-lint` — vault health audits
 
 If a future skill makes the vault mandatory, declare `dependencies: ["claude-obsidian"]` in `plugin.json` and update this section.
-
-## CLAUDE.md ownership
-
-`~/.claude/CLAUDE.md` is sourced from the [`claude-config`](https://github.com/misiekhardcore/claude-config) repo, not authored ad-hoc per machine. For the semantics of project (`./CLAUDE.md`) vs personal (`./CLAUDE.local.md`) scopes and load order, see Claude Code's memory documentation.
 
 ## See also
 

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -22,15 +22,9 @@ Skills probe for these commands; if present, the vault-aware path activates, oth
 
 If a future skill makes the vault mandatory, declare `dependencies: ["claude-obsidian"]` in `plugin.json` and update this section.
 
-## CLAUDE.md ownership in this ecosystem
+## CLAUDE.md ownership
 
-| Layer | Path | Owner | Contains |
-|---|---|---|---|
-| Ecosystem | `~/.claude/CLAUDE.md` | `claude-config` repo | Cross-project conventions, plugin install guidance, shared shortcuts |
-| Project | `./CLAUDE.md` (committed) | The project repo | Project-specific idioms, code style, how to invoke the project's skills/tests |
-| Personal | `./CLAUDE.local.md` (gitignored) | Individual user | Local quirks, per-machine overrides |
-
-Each layer assumes the previous one is loaded and states only what differs. Before adding a rule, grep existing layers — if it already exists upstream, reference it instead of duplicating.
+`~/.claude/CLAUDE.md` is sourced from the [`claude-config`](https://github.com/misiekhardcore/claude-config) repo, not authored ad-hoc per machine. For the semantics of project (`./CLAUDE.md`) vs personal (`./CLAUDE.local.md`) scopes and load order, see Claude Code's memory documentation.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Adds comprehensive cross-plugin coordination documentation addressing three ecosystem hazards:
1. MCP duplication — shared MCPs should live at user scope (owned by claude-config), not bundled in plugins
2. Inter-plugin dependencies — documents decision to keep `claude-obsidian` optional via runtime detection
3. CLAUDE.md layering — clarifies scope for `~/.claude/CLAUDE.md` (ecosystem), `./CLAUDE.md` (project), and `./CLAUDE.local.md` (personal)

Includes worked example of the duplicate-identifier failure mode and rationale for runtime detection pattern.

## Closes

Closes #42

## Decision: plugin.json.dependencies

**Decision**: Keep `claude-obsidian` as optional via runtime detection. Do NOT populate `plugin.json.dependencies`.

**Reasoning**:
- Hard dependency would block installation for users without `claude-obsidian`, even if they don't need vault features
- Skills degrade gracefully: `/compound` and `/prune` emit/report inline when vault is unavailable; no error state
- Runtime detection (checking for `claude-obsidian:save`, `claude-obsidian:wiki-query`, `claude-obsidian:wiki-lint`) is discoverable — inline suggestions guide users to install if needed

## Follow-up (out of scope)

Manual companion-issue filing deferred:
- `misiekhardcore/claude-obsidian` — document MCP scope and CLAUDE.md placement for that plugin
- `misiekhardcore/claude-config` — document ownership of shared MCPs and ecosystem-wide CLAUDE.md guidance

These are filed manually by the user (GitHub API MCP cannot create cross-repo issues), not in this PR.

## Test plan

- [ ] New doc exists at `docs/cross-plugin.md` with three sections
- [ ] `README.md` links the new doc under "Ecosystem" heading
- [ ] Existing README content at line 127 (claude-obsidian integration) is unchanged
- [ ] Tone and style match `docs/context-hygiene.md` (terse, technical, no marketing)
- [ ] MCP scope example is clear and actionable
- [ ] CLAUDE.md layering table and read order match issue requirements