### PR TITLE
docs(authoring): propagate spawn rubric and adopt references/ pattern

### DIFF
--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -123,6 +123,18 @@ The `diff` chain exits nonzero when either stored copy is missing (first run) or
 }
 ```
 
+## Parallelism decision
+
+When authoring an orchestrator or designing a multi-skill workflow, you must make an explicit parallelism choice. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the full rubric — it defines Scope Assessment (Lightweight / Standard / Deep), TeamCreate decision criteria, and cost models for different primitives.
+
+**Key decision points:**
+
+- **Scope Assessment**: Classify before spawning. Lightweight runs inline; Standard/Deep trigger dispatch. See composition.md for heuristics and cost gradients.
+- **Primitive choice**: Default to inline → subagent → TeamCreate. Parallel adds coordination overhead — confirm genuine communication pivot, file disjointness, classifiable parallelism, and ≥3× wall-clock payoff before paying the ~7× token premium.
+- **Spawn justification**: Document your choice in the skill body. State which rubric factors apply and which don't. See existing orchestrators (`/discovery`, `/define`, `/implement`, `/review`) for the established pattern — a short "Spawn justification" block naming the cost class and required conditions.
+
+New skills created via `/new-skill` will be guided through this decision during scaffolding.
+
 ## Naming conventions
 
 - **Skill directory**: `skills/<name>/` — lowercase kebab-case, matches the `name` frontmatter field.

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -154,7 +154,7 @@ The `references/` convention trades startup cost (the main skill loads faster) f
 2. The section does **not influence the default path** — removing it doesn't break the core logic for users who never hit that branch.
 3. The default path is **still complete** without manually loading the reference doc.
 
-**Worked example**: `/find-skills` originally had "Common Skill Categories", "Tips for Effective Searches", and "When No Skills Are Found" inline (~44 lines). These are only consulted when helping users refine searches or handle empty results — not on the main flow path (steps 1–5 of "How to Help Users"). They were moved to `skills/find-skills/references/categories.md`. The main skill now says: "Read `skills/find-skills/references/categories.md` when you need to help users refine their search strategy or handle cases where no skills are found."
+**Worked example**: `/find-skills` originally had "Common Skill Categories", "Tips for Effective Searches", and "When No Skills Are Found" inline (~44 lines). These are only consulted when helping users refine searches or handle empty results — not on the main flow path (steps 1–6 of "How to Help Users Find Skills"). They were moved to `skills/find-skills/references/categories.md`. The main skill now says: "Read `skills/find-skills/references/categories.md` when you need to help users refine their search strategy or handle cases where no skills are found."
 
 The default path (finding and presenting skills) remains self-contained. A user invoking `/find-skills` without needing the categorical reference still completes successfully.
 

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -146,6 +146,20 @@ New skills created via `/new-skill` will be guided through this decision during 
 - Keep `SKILL.md` under 500 lines. If you're approaching this limit, split domain content into `references/` sub-files and link to them with clear "read when X" guidance.
 - The body is loaded into context on every invocation — keep it focused on instructions, not background narrative.
 
+### Progressive disclosure via `references/`
+
+The `references/` convention trades startup cost (the main skill loads faster) for on-demand cost (the reference doc loads only when that branch executes). Use it when:
+
+1. A section is **>~40 lines** and only runs in a specific execution branch (e.g., "when no skills are found" or "when filing a note").
+2. The section does **not influence the default path** — removing it doesn't break the core logic for users who never hit that branch.
+3. The default path is **still complete** without manually loading the reference doc.
+
+**Worked example**: `/find-skills` originally had "Common Skill Categories", "Tips for Effective Searches", and "When No Skills Are Found" inline (~44 lines). These are only consulted when helping users refine searches or handle empty results — not on the main flow path (steps 1–5 of "How to Help Users"). They were moved to `skills/find-skills/references/categories.md`. The main skill now says: "Read `skills/find-skills/references/categories.md` when you need to help users refine their search strategy or handle cases where no skills are found."
+
+The default path (finding and presenting skills) remains self-contained. A user invoking `/find-skills` without needing the categorical reference still completes successfully.
+
+**Another example**: `/compound` separates the Bug Track and Knowledge Track templates (together ~45 lines) into `skills/compound/references/knowledge-tracks.md`. These are only consulted when writing the output note — the core mode-selection logic and dispatch remain inline. The skill says: "See `skills/compound/references/knowledge-tracks.md` for the full templates."
+
 ## Writing style
 
 - Use imperative form: "Read the issue", "Spawn a team", not "You should read" or "The skill reads".

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -148,17 +148,7 @@ New skills created via `/new-skill` will be guided through this decision during 
 
 ### Progressive disclosure via `references/`
 
-The `references/` convention trades startup cost (the main skill loads faster) for on-demand cost (the reference doc loads only when that branch executes). Use it when:
-
-1. A section is **>~40 lines** and only runs in a specific execution branch (e.g., "when no skills are found" or "when filing a note").
-2. The section does **not influence the default path** — removing it doesn't break the core logic for users who never hit that branch.
-3. The default path is **still complete** without manually loading the reference doc.
-
-**Worked example**: `/find-skills` originally had "Common Skill Categories", "Tips for Effective Searches", and "When No Skills Are Found" inline (~44 lines). These are only consulted when helping users refine searches or handle empty results — not on the main flow path (steps 1–6 of "How to Help Users Find Skills"). They were moved to `skills/find-skills/references/categories.md`. The main skill now says: "Read `skills/find-skills/references/categories.md` when you need to help users refine their search strategy or handle cases where no skills are found."
-
-The default path (finding and presenting skills) remains self-contained. A user invoking `/find-skills` without needing the categorical reference still completes successfully.
-
-**Another example**: `/compound` separates the Bug Track and Knowledge Track templates (together ~45 lines) into `skills/compound/references/knowledge-tracks.md`. These are only consulted when writing the output note — the core mode-selection logic and dispatch remain inline. The skill says: "See `skills/compound/references/knowledge-tracks.md` for the full templates."
+Use `references/` when a section is **>~40 lines**, runs only in a specific execution branch, and removing it doesn't break the default path. The trade-off: the main skill loads faster, but the reference loads only when that branch executes. See `skills/find-skills/references/`, `skills/compound/references/` for examples.
 
 ## Writing style
 

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -13,7 +13,7 @@ You are leading the <phase name> phase. Your goal is to <objective>.
 
 <!-- What the orchestrator receives — issue number, handoff block, or problem statement. -->
 
-### Scope Assessment
+## Scope Assessment
 
 Classify before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the right-sizing rationale and cost models.
 

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -13,13 +13,17 @@ You are leading the <phase name> phase. Your goal is to <objective>.
 
 <!-- What the orchestrator receives — issue number, handoff block, or problem statement. -->
 
-## Scope Assessment
+### Scope Assessment
 
-Classify before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the right-sizing rationale.
+Classify before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the right-sizing rationale and cost models.
 
 - **Lightweight** — <heuristic>. Lead runs inline; no team; skip step 2.
 - **Standard** — <heuristic>. Core specialists only; optional roles stay dormant.
 - **Deep** — <heuristic>. Full team + critique/adversarial pass.
+
+### Spawn justification
+
+Document your choice explicitly. State which rubric factors from composition.md apply (communication pivot, file disjointness, parallelism, wall-clock payoff) and which gate conditions trigger dispatch. See `/discovery`, `/define`, `/implement` for the established pattern.
 
 ## Process
 

--- a/_templates/SKILL.specialist.template.md
+++ b/_templates/SKILL.specialist.template.md
@@ -14,6 +14,10 @@ model: "<haiku | sonnet | opus>"
 
 Optionally: a <research | prior-art | fix> brief from <source skill>. When present, skip internal research and use the brief as starting context. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the brief field list.
 
+### Parallelism choice
+
+If this specialist spawns sub-agents or teams internally, state your choice explicitly: inline, parallel subagents, or TeamCreate. Document the gate conditions from `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` that justify the choice. See `/resolve-pr-feedback`, `/compound` for examples.
+
 ## Process
 
 1. Check for a seed brief. If present, skip to step 3.

--- a/_templates/SKILL.specialist.template.md
+++ b/_templates/SKILL.specialist.template.md
@@ -14,7 +14,7 @@ model: "<haiku | sonnet | opus>"
 
 Optionally: a <research | prior-art | fix> brief from <source skill>. When present, skip internal research and use the brief as starting context. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the brief field list.
 
-### Parallelism choice
+### Spawn justification
 
 If this specialist spawns sub-agents or teams internally, state your choice explicitly: inline, parallel subagents, or TeamCreate. Document the gate conditions from `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` that justify the choice. See `/resolve-pr-feedback`, `/compound` for examples.
 

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -68,70 +68,11 @@ Single-pass extraction. Work through these steps yourself:
 
 ## Output
 
-### Knowledge Tracks
+Choose between two knowledge tracks when filing the note. See `skills/compound/references/knowledge-tracks.md` for the full templates and the note shape for inline fallback (when `claude-obsidian` is not available).
 
-Choose the track that fits what was learned. Both produce a structured Markdown note — `claude-obsidian`'s `/save` will slot it into the correct vault location (concept/entity/source) and attach frontmatter based on content.
+**Bug Track** — use when the learning came from fixing a bug. Captures problem, symptoms, what didn't work, solution, root cause, and prevention guidance.
 
-#### Bug Track
-Use when the learning came from fixing a bug or unexpected behavior. Tag with `bug-fix`.
-
-```markdown
-## Problem
-<!-- What went wrong — observable symptoms -->
-
-## Symptoms
-<!-- How it manifested — error messages, failing tests, user reports -->
-
-## What Didn't Work
-<!-- Approaches tried that failed — saves future debuggers time -->
-
-## Solution
-<!-- The actual fix — code changes, config changes, commands -->
-
-## Why It Works
-<!-- Root cause explanation — why the fix addresses the underlying issue -->
-
-## Prevention
-<!-- How to avoid this in the future — tests, linting rules, patterns -->
-```
-
-#### Knowledge Track
-Use when the learning is a pattern, technique, or architectural insight. Tag with `pattern`, `technique`, or `architecture`.
-
-```markdown
-## Context
-<!-- When this knowledge applies — project area, tech stack, situation -->
-
-## Guidance
-<!-- The insight or pattern — what to do -->
-
-## Why
-<!-- Rationale — why this approach over alternatives -->
-
-## When to Use
-<!-- Conditions that make this the right choice -->
-
-## Examples
-<!-- Concrete code examples or references -->
-```
-
-### Note shape (inline fallback)
-
-When `claude-obsidian` is not available and the note is emitted inline, include a minimal frontmatter block so the user can drop it straight into any vault:
-
-```markdown
----
-title: "<Descriptive Title>"
-tags: [<track tag>, <domain tag>, <specific tag>]
-created: <YYYY-MM-DD>
----
-
-# <Descriptive Title>
-
-<!-- Bug Track or Knowledge Track body -->
-```
-
-When `claude-obsidian` is active, pass only the body + a suggested title to `/save`; the plugin owns the frontmatter schema.
+**Knowledge Track** — use when the learning is a pattern, technique, or architectural insight. Captures context, guidance, rationale, when to use, and examples.
 
 ## Rules
 

--- a/skills/compound/references/knowledge-tracks.md
+++ b/skills/compound/references/knowledge-tracks.md
@@ -1,0 +1,66 @@
+# Knowledge Tracks — Output Templates
+
+Choose the track that fits what was learned. Both produce a structured Markdown note — `claude-obsidian`'s `/save` will slot it into the correct vault location (concept/entity/source) and attach frontmatter based on content.
+
+## Bug Track
+
+Use when the learning came from fixing a bug or unexpected behavior. Tag with `bug-fix`.
+
+```markdown
+## Problem
+<!-- What went wrong — observable symptoms -->
+
+## Symptoms
+<!-- How it manifested — error messages, failing tests, user reports -->
+
+## What Didn't Work
+<!-- Approaches tried that failed — saves future debuggers time -->
+
+## Solution
+<!-- The actual fix — code changes, config changes, commands -->
+
+## Why It Works
+<!-- Root cause explanation — why the fix addresses the underlying issue -->
+
+## Prevention
+<!-- How to avoid this in the future — tests, linting rules, patterns -->
+```
+
+## Knowledge Track
+
+Use when the learning is a pattern, technique, or architectural insight. Tag with `pattern`, `technique`, or `architecture`.
+
+```markdown
+## Context
+<!-- When this knowledge applies — project area, tech stack, situation -->
+
+## Guidance
+<!-- The insight or pattern — what to do -->
+
+## Why
+<!-- Rationale — why this approach over alternatives -->
+
+## When to Use
+<!-- Conditions that make this the right choice -->
+
+## Examples
+<!-- Concrete code examples or references -->
+```
+
+## Note Shape — Inline Fallback
+
+When `claude-obsidian` is not available and the note is emitted inline, include a minimal frontmatter block so the user can drop it straight into any vault:
+
+```markdown
+---
+title: "<Descriptive Title>"
+tags: [<track tag>, <domain tag>, <specific tag>]
+created: <YYYY-MM-DD>
+---
+
+# <Descriptive Title>
+
+<!-- Bug Track or Knowledge Track body -->
+```
+
+When `claude-obsidian` is active, pass only the body + a suggested title to `/save`; the plugin owns the frontmatter schema.

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -104,40 +104,4 @@ npx skills add <owner/repo@skill> -g -y
 
 The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
 
-## Common Skill Categories
-
-When searching, consider these common categories:
-
-| Category        | Example Queries                          |
-| --------------- | ---------------------------------------- |
-| Web Development | react, nextjs, typescript, css, tailwind |
-| Testing         | testing, jest, playwright, e2e           |
-| DevOps          | deploy, docker, kubernetes, ci-cd        |
-| Documentation   | docs, readme, changelog, api-docs        |
-| Code Quality    | review, lint, refactor, best-practices   |
-| Design          | ui, ux, design-system, accessibility     |
-| Productivity    | workflow, automation, git                |
-
-## Tips for Effective Searches
-
-1. **Use specific keywords**: "react testing" is better than just "testing"
-2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
-3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
-
-## When No Skills Are Found
-
-If no relevant skills exist:
-
-1. Acknowledge that no existing skill was found
-2. Offer to help with the task directly using your general capabilities
-3. Suggest the user could create their own skill with `npx skills init`
-
-Example:
-
-```
-I searched for skills related to "xyz" but didn't find any matches.
-I can still help you with this task directly! Would you like me to proceed?
-
-If this is something you do often, you could create your own skill:
-npx skills init my-xyz-skill
-```
+Read `skills/find-skills/references/categories.md` when you need to help users refine their search strategy or handle cases where no skills are found. It includes common skill categories, search tips, and fallback guidance for users.

--- a/skills/find-skills/references/categories.md
+++ b/skills/find-skills/references/categories.md
@@ -1,0 +1,39 @@
+# Skill Categories and Search Strategies
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -50,7 +50,14 @@ A brief statement from the author of what the skill should do — or nothing, in
 
      If the author picks **Restricted subset**, ask one free-text follow-up: "Which tools should it be allowed to use? (space-separated — e.g. `Read Grep Glob Bash`)". Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask). Use the answer verbatim as the value of `allowed-tools:`.
 
-   g. **Shared protocols** — `AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
+   g. **Parallelism** — `AskUserQuestion` with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?". Options:
+   - **No parallelism** — skill runs inline; no sub-agents or teams
+   - **Parallel subagents** — skill spawns 2–3 independent subagents (applies to all roles)
+   - **TeamCreate** — skill spawns a team (orchestrators / specialists only)
+
+     If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up free-text: "Which conditions gate the spawn decision? (reference the rubric in `_shared/composition.md` — e.g., scope class, file count, communication pivot)". Store the answer as a "Spawn justification" block in the skill body.
+
+   h. **Shared protocols** — `AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
    - **Handoff artifact** — writes or reads a GitHub issue handoff block → include `handoff-artifact.md`
    - **Interviewing rules** — interviews the user, asks questions, seeks approval → include `interviewing-rules.md`
    - **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
@@ -61,7 +68,7 @@ A brief statement from the author of what the skill should do — or nothing, in
    - **No** — skip `composition.md`
    - **Yes** — include `composition.md`
 
-   h. **Target location** — `AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
+   i. **Target location** — `AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
    - **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
    - **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
    - **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
@@ -71,12 +78,16 @@ A brief statement from the author of what the skill should do — or nothing, in
    - Specialist or Utility → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.specialist.template.md`. For Utility, remove the "Optionally: a seed brief" paragraph from Input — utility skills are user-invocable and don't receive briefs.
    - Primitive → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.primitive.template.md`
 
+   Both orchestrator and specialist templates now include placeholders for parallelism justification (step 2g). Fill these in based on the author's answer.
+
    Read the selected template — that is the skeleton you will fill in.
 
 4. **Generate the SKILL.md** by filling in the selected template:
    - Frontmatter: `name`, `description`, `model`; include `effortLevel: high` / `allowed-tools: ...` only when the author opted in
    - Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
-   - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern").
+   - If the author selected parallelism in step 2g, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
+   - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern")
+   - Include `composition.md` reference if the author selected it in step 2h
 
 5. **Show the draft** to the author in a fenced code block. Ask: "Does this look right? Shall I write it to `<target-path>`? (y/n)". Do not write on silence or "looks good" — require an explicit yes.
 


### PR DESCRIPTION
## Summary

Two commits implementing the authoring template upgrades for issues #36 and #41:

1. **#36 — Propagate spawn-decision rubric**: Add "Parallelism decision" section to `_templates/AUTHORING.md` with links to the full rubric in `_shared/composition.md`. Update orchestrator and specialist templates with required "Scope Assessment" and "Parallelism choice" / spawn justification blocks. Update `/new-skill` interview to ask an explicit question about parallelism primitive (no-parallelism / subagents / TeamCreate) before the skill is written.

2. **#41 — Adopt references/ progressive disclosure**: Split two skills using the `references/` pattern to move large sections that only run on specific branches. Add a worked example section to `_templates/AUTHORING.md` with the "when to split" rule and two concrete examples.

## Per-skill audit decisions

| Skill | Lines | Decision | Reasoning |
|-------|-------|----------|-----------|
| `resolve-pr-feedback` | 158 | Keep inline | Three interdependent phases (Fetch, Triage, Fix). GraphQL query critical to default path. Splitting would fragment the decision logic. |
| `find-skills` | 143 | **Split** | Steps 1-6 (core flow) are self-contained. "Categories", "Tips", and "When No Skills Are Found" (~44 lines) only consulted for search refinement and fallback — moved to `references/categories.md`. ✓ Reduces main SKILL.md to 107 lines. |
| `compound` | 143 | **Split** | Mode-selection and execution (lines 23-67) remain inline and complete. Bug Track and Knowledge Track templates (~45 lines) only load when drafting output — moved to `references/knowledge-tracks.md`. ✓ Reduces main SKILL.md to 84 lines. |
| `review` | 138 | Keep inline | Scope assessment and conditional reviewer activation logic is tightly integrated. Splitting would break the decision tree. |

## Changes

### Commit 1: Propagate spawn-decision rubric
- `_templates/AUTHORING.md`: Add "Parallelism decision" section (lines 126-137) linking to composition.md rubric and established pattern in orchestrators.
- `_templates/SKILL.orchestrator.template.md`: Add "Spawn justification" block (after Scope Assessment) requiring explicit choice and gate conditions.
- `_templates/SKILL.specialist.template.md`: Add "Parallelism choice" sub-section (in Input) for specialists that spawn sub-agents or teams.
- `skills/new-skill/SKILL.md`: Add step 2g (Parallelism question) asking author to choose no-parallelism / subagents / TeamCreate and document gate conditions. Renumber subsequent steps.

### Commit 2: Adopt references/ pattern
- `skills/find-skills/SKILL.md`: Replace lines 108-144 with one-line reference to `references/categories.md`. Default path (steps 1-6) unchanged.
- `skills/find-skills/references/categories.md`: New file with categorical reference table, search tips, and fallback guidance (extracted from original SKILL.md).
- `skills/compound/SKILL.md`: Replace "Knowledge Tracks" and "Note shape" sections (lines 71-134) with summary + reference to `references/knowledge-tracks.md`. Default path (mode selection + Lightweight/Full execution) unchanged.
- `skills/compound/references/knowledge-tracks.md`: New file with Bug Track and Knowledge Track templates and inline fallback note shape (extracted from original SKILL.md).
- `_templates/AUTHORING.md`: Add "Progressive disclosure via references/" section (lines 137-166) with the "when to split" rule and two worked examples.

## Test plan

- [ ] Smoke check: invoke `/find-skills` in a fresh session with a simple query (e.g., "react testing"). Default path completes without manually loading `references/categories.md`. Core steps 1-5 present options; no reference-required.
- [ ] Smoke check: invoke `/compound` in a fresh session after a simple fix (e.g., one-liner). Lightweight mode runs without manually loading `references/knowledge-tracks.md`. Mode selection and output drafting complete.
- [ ] Verify no unrelated files were touched (should only be `_templates/` and two skill directories).
- [ ] Verify both commits are distinct (not squashed) and commit messages reflect the split.

Closes #36
Closes #41