### PR TITLE
docs: add token-budgets reference doc (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The building blocks: `/describe`, `/specify`, `/architecture`, `/design`, `/buil
 
 ## Token budgets
 
-For per-artifact budgets (`.claude/NOTES.md` <1k, issue body <2k, seed brief <500 tokens), per-phase context targets, CLAUDE.md placement and sizing, the `@`-import syntax, and the skill-invocation duplication anti-pattern, see `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md`. Read it once when setting up a new project and revisit when long sessions start misbehaving.
+Per-artifact and per-phase budgets, CLAUDE.md placement, and `@`-imports: `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md`.
 
 ## Authoring New Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ The building blocks: `/describe`, `/specify`, `/architecture`, `/design`, `/buil
 - **Use the cheapest viable model.** Skills set their own `model:` and `effortLevel:` — trust them.
 - **Respond concisely.** No filler, no preamble.
 
+## Token budgets
+
+For per-artifact budgets (`.claude/NOTES.md` <1k, issue body <2k, seed brief <500 tokens), per-phase context targets, CLAUDE.md placement and sizing, the `@`-import syntax, and the skill-invocation duplication anti-pattern, see `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md`. Read it once when setting up a new project and revisit when long sessions start misbehaving.
+
 ## Authoring New Skills
 
 To scaffold a new skill conforming to this standard, run `/new-skill`. It will interview you, generate a conformant `SKILL.md`, and write it to your chosen location.

--- a/README.md
+++ b/README.md
@@ -155,8 +155,6 @@ When working across multiple plugins and repositories, see [`docs/cross-plugin.m
 - Inter-plugin dependency declarations
 - Optional `claude-obsidian` integration via runtime detection
 
-CLAUDE.md placement (`~/.claude/CLAUDE.md`, `./CLAUDE.md`, `./CLAUDE.local.md`) and sizing targets are in [`docs/token-budgets.md`](docs/token-budgets.md).
-
 ## Authoring standard
 
 This plugin ships an authoring standard for creating new skills:

--- a/README.md
+++ b/README.md
@@ -144,12 +144,18 @@ Without `claude-obsidian` every skill still runs; vault operations are skipped w
 
 Full lifecycle walkthrough: [`docs/workflow.md`](docs/workflow.md)
 
+## Token budgets and CLAUDE.md placement
+
+Per-artifact and per-phase token budgets, the context-rot threshold (~12% of window), CLAUDE.md placement and `@`-import syntax, and the skill-invocation duplication anti-pattern: [`docs/token-budgets.md`](docs/token-budgets.md). For *why* phases reset, see [`docs/context-hygiene.md`](docs/context-hygiene.md).
+
 ## Ecosystem
 
 When working across multiple plugins and repositories, see [`docs/cross-plugin.md`](docs/cross-plugin.md) for guidance on:
 - MCP scope (shared vs. plugin-bundled servers)
 - Inter-plugin dependency declarations
-- CLAUDE.md layering (`~/.claude/CLAUDE.md`, `./CLAUDE.md`, `./CLAUDE.local.md`)
+- Optional `claude-obsidian` integration via runtime detection
+
+CLAUDE.md placement (`~/.claude/CLAUDE.md`, `./CLAUDE.md`, `./CLAUDE.local.md`) and sizing targets are in [`docs/token-budgets.md`](docs/token-budgets.md).
 
 ## Authoring standard
 

--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -150,3 +150,9 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the five-field hando
 | **Subagent re-research**    | Custom subagents start fresh and re-read files the lead loaded | Pass file paths and prior findings in the spawn prompt — no inheritance  |
 | **Team idle drift**         | Teammates left running after the task is done keep burning tokens | Shut down explicitly; idle teammates do not auto-terminate              |
 | **`/batch` cross-talk**     | Batched items try to coordinate via filesystem side effects   | Use `TeamCreate` when coordination is required; `/batch` assumes self-contained items |
+
+## See also
+
+- `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md` — per-artifact budgets (seed brief <500 tokens, sub-agent report 1–2k tokens) and per-phase context targets that the cost rubric above assumes.
+- `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` — why phases reset and how briefs avoid context bleed across specialist boundaries.
+- `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` — five-field issue-body shape that crosses phase boundaries.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -100,4 +100,4 @@ On a fresh session in an existing worktree, `.claude/NOTES.md` exists ⇒ this i
 
 ## Why
 
-Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale, and `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md` for the <1k cap on this file in context with the other artifact budgets.
+Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale and `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md` for the <1k cap alongside the other artifact budgets.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -100,4 +100,4 @@ On a fresh session in an existing worktree, `.claude/NOTES.md` exists ⇒ this i
 
 ## Why
 
-Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale.
+Context rot makes in-context recall unreliable for long sessions, even when the window is nowhere near full. The fix is to externalize the state that the model needs to trust — onto disk, in a file the model re-reads on demand. A gitignored worktree-local worklog is the cheapest durable answer. See `${CLAUDE_PLUGIN_ROOT}/docs/context-hygiene.md` for the full rationale, and `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md` for the <1k cap on this file in context with the other artifact budgets.

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -151,6 +151,7 @@ This matches Anthropic's sub-agent pattern: the reviewer runs in isolation, retu
 
 ## See Also
 
+- `${CLAUDE_PLUGIN_ROOT}/docs/token-budgets.md` — concrete per-artifact and per-phase budgets the rules above assume; CLAUDE.md placement and `@`-import syntax.
 - `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` — canonical handoff shape.
 - `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` — trigger list and tool order for in-phase context pressure.
 - `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` — NOTES.md as an external ledger the model can diff against after `/compact`.

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -33,4 +33,5 @@ If a future skill makes the vault mandatory, declare `dependencies: ["claude-obs
 ## See also
 
 - [`README.md`](../README.md) — `claude-obsidian` integration overview
+- [`token-budgets.md`](token-budgets.md) — CLAUDE.md placement, `@`-import syntax, and per-artifact token budgets that compose with the MCP-scope rules above
 - [`plugin.json`](../.claude-plugin/plugin.json) — plugin metadata

--- a/docs/token-budgets.md
+++ b/docs/token-budgets.md
@@ -1,0 +1,132 @@
+# Token Budgets
+
+User-facing budgets and CLAUDE.md placement rules that the rest of this plugin assumes. Read this once when setting up the workflow on a new project; revisit when the model starts misbehaving in long sessions.
+
+The companion doc [`context-hygiene.md`](context-hygiene.md) explains *why* the workflow resets between phases; this doc gives the concrete numbers and placement rules that make those resets cheap.
+
+## The threshold
+
+Context rot — degradation of retrieval, reasoning, and instruction-following — kicks in well before the window fills. Anthropic's guidance: treat the rot threshold as roughly **12% of the window** (~120k of a 1M-token model), not the window itself ([Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)). Every budget below is sized so a phase finishes under that threshold with margin.
+
+## Per-artifact budgets
+
+The lifecycle moves state between three artifact tiers. Each has a hard cap that other skills assume:
+
+| Artifact | Cap | Why this number |
+| --- | --- | --- |
+| `.claude/NOTES.md` (per session) | **<1k tokens** | Re-read on every resume and before every `/compact`; must fit in one screen ([`_shared/notes-md-protocol.md`](../_shared/notes-md-protocol.md)) |
+| GitHub issue body (handoff artifact) | **<2k tokens** | Loaded fully at the start of every phase; the five-field shape in [`_shared/handoff-artifact.md`](../_shared/handoff-artifact.md) targets this |
+| Seed brief to a sub-agent | **<500 tokens** | A brief is objective + constraint + report contract — not session history. Sub-agents return 1–2k token reports, not the briefs they received |
+| Sub-agent report back to lead | 1–2k tokens | Quoted from Anthropic's reference figure for the isolation pattern; enforced by asking for a "focused report bounded by what the lead needs to decide" |
+
+If any artifact crosses its cap, the cause is almost always content that belongs in another tier: a long decision log in NOTES.md belongs in the issue body; a seed brief restating the conversation belongs in the issue body, not the brief.
+
+## Per-phase budgets
+
+The full session context — system prompt + CLAUDE.md + prior turns + tool output — at handoff:
+
+| Phase boundary | Target context size | Verification |
+| --- | --- | --- |
+| End of `/discovery` | **<15k tokens** | `/context` after the issue body is written, before resetting |
+| End of `/define` | **<15k tokens** | Same — define ends with the implementation plan written into the issue |
+| End of `/implement` (build → review → verify) | **<20k tokens** | `/context` after the draft PR is opened |
+
+These are *targets*, not enforced caps. They exist to make it obvious when a phase is dragging context that should have been delegated or reset. Crossing 30k near a phase boundary is the signal to bring forward the next reset and harvest into the issue body.
+
+### Verification with `/context`
+
+Run `/context` at the start and end of each phase:
+
+```
+/context
+```
+
+Compare the system + tools + messages totals against the targets above. The relevant deltas:
+
+- **System + CLAUDE.md jumps between sessions** → a CLAUDE.md edit grew the per-turn cost. Trim or move content out (see CLAUDE.md placement below).
+- **Messages line growing toward 30k inside a phase** → run context editing or delegate the next bulk lookup to a sub-agent ([`_shared/compaction-protocol.md`](../_shared/compaction-protocol.md)).
+- **End-of-phase total over target** → harvest into the issue body now, do not carry conversation across the boundary.
+
+## CLAUDE.md placement
+
+CLAUDE.md is loaded verbatim every turn. Where the file lives determines who pays for it.
+
+| Path | Loaded by | Lifetime | Use for |
+| --- | --- | --- | --- |
+| `~/.claude/CLAUDE.md` | Every session, every project | User-global | Tone, formatting, global rules, memory-system pointers |
+| `./CLAUDE.md` | Every session in this repo | Project, committed to git | Tech stack, build commands, project invariants, directory map |
+| `./CLAUDE.local.md` | Every session in this repo, only on this machine | Personal, **gitignored** | Local overrides, personal scratch rules, machine-specific paths |
+| `./<subdir>/CLAUDE.md` | Sessions whose CWD enters that subdir | Subsystem | Subsystem quirks that don't apply to the whole repo |
+
+All files in the current path stack are loaded *additively* — global + project + subdir all pay tokens on every turn. Don't duplicate rules across levels.
+
+**Sizing targets** (from Anthropic's [costs guidance](https://code.claude.com/docs/en/costs) and the wiki concept note `claude-md-sizing`):
+
+| Scope | Recommended | Hard cap |
+| --- | --- | --- |
+| Global `~/.claude/CLAUDE.md` | <50 lines | 100 lines |
+| Project `./CLAUDE.md` | <200 lines | 300 lines |
+| Subdirectory `./sub/CLAUDE.md` | <50 lines | 100 lines |
+
+Move out anything not used in the majority of sessions: long rule blocks (>50 lines) into a dedicated `REFERENCE.md` read on demand; workflow-specific instructions (PR review, migration steps) into skills that load only when invoked.
+
+## `@`-imports
+
+CLAUDE.md supports `@path/to/file` to inline another markdown file at load time. Imports recurse up to **5 hops** ([Memory docs](https://code.claude.com/docs/en/memory)).
+
+```markdown
+# CLAUDE.md
+
+Tone and global rules go here directly.
+
+For the full lifecycle walkthrough — only relevant when working in this repo:
+@docs/workflow.md
+
+Personal overrides (gitignored, optional):
+@CLAUDE.local.md
+```
+
+The cost of an `@`-import is identical to inlining the same content — imports are a *organization* tool, not a deferral mechanism. If a doc is only useful sometimes, link it (`See [docs/X.md](...) when ...`) rather than `@`-importing it.
+
+## Avoid skill-invocation duplication
+
+Each `/skill` invocation loads the full skill body verbatim into context. Invoking the same skill multiple times duplicates that body — the model already has the content from the first invocation, and the second copy adds rot without adding information. Documented as upstream [anthropics/claude-code#11065](https://github.com/anthropics/claude-code/issues/11065).
+
+**Rule:** invoke each skill **once per task**. Downstream turns reference its outputs — the issue body, NOTES.md, the diff, the previous tool result — not a re-invocation.
+
+**Anti-pattern:**
+
+```
+/discovery   # writes issue #482
+/define      # writes the implementation plan into #482
+
+# later in the same session, after some confusion:
+/discovery   # re-loads the entire skill body to "re-check the spec"
+```
+
+The fix: read the issue body or NOTES.md instead. The skill body has nothing to add on a re-read — the artifacts it produced are what carry the state.
+
+This is a different failure from `/compact` over-aggression: `/compact` paraphrases reasoning, while skill duplication just inflates the context with identical text. Both raise the rot floor; only one is trivially avoidable.
+
+## When to read this doc
+
+- Setting up a new project: pick CLAUDE.md placement and trim the template.
+- The model starts confusing phases or re-litigating decisions: check the per-phase totals with `/context`.
+- A skill author asks "where should this rule live": placement table above answers it.
+- Reviewing a PR that grows CLAUDE.md by >20 lines: justify against the sizing targets.
+
+## See also
+
+- [`context-hygiene.md`](context-hygiene.md) — *why* phases reset and how the four hygiene rules interact.
+- [`cross-plugin.md`](cross-plugin.md) — MCP-server sizing (each server adds tool-name overhead even when schemas defer).
+- [`_shared/notes-md-protocol.md`](../_shared/notes-md-protocol.md) — `.claude/NOTES.md` shape and update cadence.
+- [`_shared/handoff-artifact.md`](../_shared/handoff-artifact.md) — five-field issue-body structure.
+- [`_shared/composition.md`](../_shared/composition.md) — sub-agent vs `TeamCreate` cost rubric.
+
+## Sources
+
+- Anthropic — [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+- Anthropic — [Claude Code costs](https://code.claude.com/docs/en/costs) — CLAUDE.md "under 200 lines" guidance
+- Anthropic — [Memory](https://code.claude.com/docs/en/memory) — `@`-import syntax and recursion limit
+- Anthropic — [Managing context on the Claude Developer Platform](https://www.anthropic.com/news/context-management) — 84% context-editing reduction figure
+- anthropics/claude-code#11065 — skill-invocation duplication bug report


### PR DESCRIPTION
Closes #29.

## Summary
- New top-level reference `docs/token-budgets.md` consolidating per-artifact and per-phase token budgets that were previously only accessible to skill authors.
- Adds the broadened-scope subsections from the issue comment: CLAUDE.md placement map, `@`-import syntax (5-hop recursion limit), and the skill-invocation duplication anti-pattern (anthropics/claude-code#11065).
- Wires cross-references from `README.md`, `CLAUDE.md`, `_shared/composition.md`, `_shared/notes-md-protocol.md`, `docs/context-hygiene.md`, and `docs/cross-plugin.md` so the layering rules agree across docs.

## Acceptance (from #29)
- [x] `docs/token-budgets.md` committed
- [x] Linked from `README.md` and `CLAUDE.md`
- [x] Cross-referenced from `_shared/notes-md-protocol.md` and `_shared/composition.md`
- [x] Cross-referenced from `docs/cross-plugin.md` per the comment so layering rules agree

## Test plan
- [ ] Render the new doc on GitHub and confirm relative links resolve to the correct files
- [ ] Skim `README.md` "Token budgets and CLAUDE.md placement" section in the rendered view
- [ ] Confirm `_shared/notes-md-protocol.md` "Why" section now mentions the budget caps doc
- [ ] Confirm `docs/context-hygiene.md` "See Also" lists the budget doc as the first entry