### PR TITLE
feat: extract repo-preflight to _shared/, add scope-preflight, wire into 4 skills

### DIFF
--- a/_shared/repo-preflight.md
+++ b/_shared/repo-preflight.md
@@ -4,7 +4,7 @@ Used by skills that originate `gh` mutations or `git push` operations. Read this
 
 ## Steps
 
-1. Run `git remote -v` and `pwd` to detect the repository and branch.
+1. Run `git remote -v` and `pwd` to detect the repository and working directory. Run `git branch --show-current` (or `git rev-parse --abbrev-ref HEAD`) to detect the current branch.
 2. Display:
    - Detected repository (owner/repo from origin remote URL)
    - Current branch name

--- a/_shared/repo-preflight.md
+++ b/_shared/repo-preflight.md
@@ -1,0 +1,17 @@
+# Repository Pre-flight — Shared Protocol
+
+Used by skills that originate `gh` mutations or `git push` operations. Read this file when you reach a step that creates or edits issues, comments, PRs, or pushes code.
+
+## Steps
+
+1. Run `git remote -v` and `pwd` to detect the repository and branch.
+2. Display:
+   - Detected repository (owner/repo from origin remote URL)
+   - Current branch name
+   - Working directory path
+3. Ask the user to confirm. Default prompt: "Does this match the repo and branch you intend to operate on?" Callers may override by setting a `Confirmation prompt:` line colocated with the reference.
+4. Do not proceed with any `gh` or `git push` operation until the user explicitly confirms.
+
+## Why
+
+`gh` issue and PR mutations are public, persistent, and cross-repo (the `--repo` flag silently routes to a different upstream). A wrong-repo mutation has higher blast radius than a wrong-branch push. This single gate covers both surfaces.

--- a/_shared/scope-preflight.md
+++ b/_shared/scope-preflight.md
@@ -1,0 +1,30 @@
+# Scope Pre-flight — Shared Protocol
+
+Used by skills that perform bulk file edits. Read this file when you are about to modify multiple files or take an action whose blast radius is unclear from the user's request.
+
+## Trigger
+
+Run this gate when **either** condition holds:
+- The proposed change touches **3 or more files**.
+- The user request matches one of the verbs: `audit`, `refactor`, `normalize`, `sweep`, `propagate`, `extract`, `rename`.
+
+## File-list confirmation
+
+Before editing, present the proposed file list:
+
+> I'm about to modify N files:
+> - `<path 1>`
+> - `<path 2>`
+> - ...
+>
+> Proceed?
+
+Wait for explicit user confirmation. Partial feedback or silence is not approval.
+
+## Refusal
+
+If the user does not confirm, do not edit any of the listed files. Reply:
+
+> Holding off — please clarify which files are in scope.
+
+Re-prompt with a narrowed list when the user provides scope.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -36,15 +36,11 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when
 
 ## Process
 
-### Step 0 — Repository pre-flight
+### Step 0 — Pre-flight
 
-1. Run `git remote -v` and `pwd` to detect the repository and branch.
-2. Display:
-   - Detected repository (owner/repo from origin remote URL)
-   - Current branch name
-   - Working directory path
-3. Ask the user to confirm: "Does this match the repo and branch you intend to work on?"
-4. Do not proceed with any `gh` or `git push` operations until the user explicitly confirms.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Confirmation prompt: "Does this match the repo and branch you intend to work on?"
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` before any bulk file edit.
 
 ### Steps 1+
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -38,9 +38,10 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when
 
 ### Step 0 — Pre-flight
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Confirmation prompt: "Does this match the repo and branch you intend to work on?"
+See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`.
+Confirmation prompt: "Does this match the repo and branch you intend to work on?"
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` before any bulk file edit.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` and run it when its Trigger conditions apply.
 
 ### Steps 1+
 

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -53,7 +53,9 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when
 
 4. The architecture specialist goes first. Once technical decisions are approved by the user, the design specialist (if applicable) works within those constraints. In Deep scope, the critique team runs after both and before user sign-off.
 
-5. **Update the GitHub issue body** with decisions. The body is the handoff artifact, single source of truth — always update it in place, never post handoff state as a comment:
+5. See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` before updating the issue body or creating sub-issues.
+
+   **Update the GitHub issue body** with decisions. The body is the handoff artifact, single source of truth — always update it in place, never post handoff state as a comment:
    - If the body already has a `## Implementation plan` section, edit it. If not, append one.
    - Record architecture decisions and design decisions (with visuals) inside that section.
    - Create sub-issues with GitHub relationships if the work decomposes.

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -69,6 +69,8 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when
 
 ### Issue Creation (all modes)
 
+See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` before any `gh issue` operation.
+
 1. **Create a GitHub issue** (`gh issue create`) as a self-contained brief for the next phase. The issue body has two parts:
 
    **(a) Problem statement preamble** — `/discovery`-only, not part of the handoff field order. From /describe output: what the user is trying to do, why the current state is inadequate, who is affected. This is the framing the rest of the issue depends on. Subsequent phases do not update this section.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -20,15 +20,11 @@ Either:
 
 ## Process
 
-### Phase 0 — Repository pre-flight
+### Phase 0 — Pre-flight
 
-1. Run `git remote -v` and `pwd` to detect the repository and branch.
-2. Display:
-   - Detected repository (owner/repo from origin remote URL)
-   - Current branch name
-   - Working directory path
-3. Ask the user to confirm: "Does this match the repo where you want to resolve PR feedback?"
-4. Do not proceed with any `gh` or `git push` operations until the user explicitly confirms.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Confirmation prompt: "Does this match the repo where you want to resolve PR feedback?"
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` before any bulk file edit.
 
 ### Phase 1 — Fetch
 

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -22,9 +22,10 @@ Either:
 
 ### Phase 0 — Pre-flight
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Confirmation prompt: "Does this match the repo where you want to resolve PR feedback?"
+See `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`.
+Confirmation prompt: "Does this match the repo where you want to resolve PR feedback?"
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` before any bulk file edit.
+If the trigger conditions in `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` apply, run that preflight before making bulk file edits.
 
 ### Phase 1 — Fetch
 


### PR DESCRIPTION
## Summary

- Extracts the duplicate inline 4-step repo-confirmation stanza from `skills/build/SKILL.md` and `skills/resolve-pr-feedback/SKILL.md` into a new canonical `_shared/repo-preflight.md`
- Adds `_shared/scope-preflight.md` with trigger conditions (≥3 files or audit/refactor/normalize/sweep/propagate/extract/rename verbs) and file-list confirmation/refusal templates
- Wires `repo-preflight` into `skills/discovery/SKILL.md` (before `gh issue create`) and `skills/define/SKILL.md` (before issue body update / sub-issue creation) — previously ungated against wrong-repo mutations
- Wires `scope-preflight` into `skills/build/SKILL.md` and `skills/resolve-pr-feedback/SKILL.md` after the repo-preflight reference

## Manual testing

1. Run `/build` on any issue — confirm Step 0 now reads `_shared/repo-preflight.md` reference instead of the inline 4-step stanza
2. Run `/resolve-pr-feedback` — confirm Phase 0 similarly references the shared file
3. Run `/discovery` — confirm the repo-preflight reference appears immediately before `gh issue create` in the skill body
4. Run `/define` — confirm the repo-preflight reference appears immediately before the issue body update step
5. Verify `grep -rE "git remote -v" skills/` returns no matches

Closes #53