### PR TITLE
Encode PR thread-resolution and citation-verification in skills

### DIFF
--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -122,6 +122,19 @@ jq -n --arg body "{reply}" '{"body": $body}' | \
   gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies --input -
 ```
 
+After posting the reply, resolve the thread for verdicts `fixed`, `fixed-differently`, and `not-addressing`. Leave `needs-human` and `replied` unresolved — an open thread is the correct signal that human follow-up is still needed.
+
+```bash
+gh api graphql -f threadId="{thread_node_id}" -f query='
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: { threadId: $threadId }) {
+      thread { id isResolved }
+    }
+  }'
+```
+
+Use `-f` (string) not `-F` (typed) for `threadId` — GitHub node IDs are base64 strings; `-F` would coerce incorrectly.
+
 ### Needs-Human Escalation
 
 Before escalating, perform a full investigation:

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -44,4 +44,5 @@ A numbered list of acceptance criteria, each as a testable scenario. These will 
 ## Rules
 
 - Every criterion must be testable — no vague language ("should be fast", "user-friendly")
+- Before treating a URL or external claim as authoritative, fetch and confirm it. Never paste an unverified citation directly into a spec or issue body.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol — apply it throughout all user interactions.


### PR DESCRIPTION
## Summary

- `resolve-pr-feedback`: after posting a reply, resolve the thread via GraphQL `resolveReviewThread` for `fixed`, `fixed-differently`, and `not-addressing` verdicts; leave `needs-human` and `replied` unresolved so reviewers can follow up.
- `specify`: require fetch-and-confirm before treating any URL or external claim as authoritative; prohibit pasting unverified citations into spec/issue bodies.

## Manual Testing

1. Run `/resolve-pr-feedback` on a PR with open review threads; confirm threads are resolved after replies with `fixed`/`fixed-differently`/`not-addressing` verdicts, and left open for `needs-human`/`replied`.
2. Run `/specify` on a feature with an external reference; confirm the skill fetches and verifies the URL before including it in the spec.

Closes #54