### PR TITLE
feat: /implement end-to-end refactor — specialist-mode contract, PR-body audit, /wrap-up cleanup utility

### DIFF
--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -112,11 +112,30 @@ When passing a seed brief to a specialist:
 2. The specialist checks for the brief at startup. When one is present, it skips its own research phase and uses the brief as starting context.
 3. Keep briefs bounded — never pad with information the specialist can find itself.
 
+**Transport format** — raw YAML inside an XML tag, no inner code fence:
+
+```
+<seed-brief>
+preflight_verified: true
+scope_class: Standard
+repo: owner/repo
+branch: feat/branch-name
+active_issue: 42
+payload:
+  type: fix|research|prior-art
+  # type-specific fields from the table above
+</seed-brief>
+```
+
+The XML tag marks the boundary; the YAML is parseable without a fence. The `payload` envelope decouples brief metadata from the type-specific content. Required fields and validation rules are in `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 `skills/describe/SKILL.md` shows the entry-point pattern — the specialist's `## Input` section declares the seed-brief contract explicitly:
 
 ```
 Optional: when invoked as a specialist from `/discovery`, may receive a **prior-art brief** as seed context (from the Prior-Art Scout). When a brief is provided, skip any internal prior-art search and incorporate the brief into the Product Pressure Test and problem statement synthesis. Without a brief, proceed as described below.
 ```
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the detection mechanism, validation rules, skip-list per specialist, and standalone-fallback behavior.
 
 ## Hierarchical decomposition
 

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -1,6 +1,8 @@
 # Handoff Artifact — Shared Template
 
-Used by phase-boundary skills (`/discovery`, `/define`, `/implement`, `/wrap-up`) to hand off state to the next phase. The GitHub issue body is the artifact. Each phase updates the body in place with the five fields below, then the user resets and starts the next phase in a fresh session.
+Used by phase-boundary skills (`/discovery`, `/define`) to hand off state to the next phase. The GitHub issue body is the artifact. Each phase updates the body in place with the five fields below, then the user resets and starts the next phase in a fresh session.
+
+`/implement` is the **terminal phase** — its output is the PR, not an issue body update. `/wrap-up` is a user-invoked cleanup utility, not a phase-boundary skill.
 
 This file is reference material — read it on demand when the skill reaches a handoff step. Do not preload.
 
@@ -16,7 +18,7 @@ Every handoff artifact contains:
 
 ## Shape
 
-Always update the **issue body** in place. If a section for the current phase (e.g. `## Implementation plan` for `/define`, `## Session handoff` for `/wrap-up`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids.
+Always update the **issue body** in place. If a section for the current phase (e.g. `## Implementation plan` for `/define`) does not exist in the body, append it; if it does, edit it. Comments are for discussion, not for handoff state — scan-reading a thread of comments is exactly the rot pattern this protocol avoids.
 
 Fields appear in this order: Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions. Omit optional fields entirely when empty — a missing heading means zero items, not an unwritten section. Never write placeholder text ("None", "No open questions", etc.).
 
@@ -49,7 +51,7 @@ Two persistent stores, no overlap:
 - **The issue body is authoritative for cross-phase state** — acceptance criteria, locked architectural decisions, the handoff fields above.
 - **`.claude/NOTES.md` is authoritative for in-flight state within a phase** — current task, intra-phase decisions not yet promoted, working open questions. See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`.
 
-When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase needs is **promoted** into the issue body (typically by `/wrap-up`). Until promotion, the issue does not know about it. After promotion, the issue body is the source of truth for that item.
+When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase needs is **promoted** into the issue body. Until promotion, the issue does not know about it. After promotion, the issue body is the source of truth for that item.
 
 ## Rules
 
@@ -59,8 +61,6 @@ When a phase ends, intra-phase state from `.claude/NOTES.md` that the next phase
   |-------|----------------|
   | `/discovery` | `## Requirements` |
   | `/define` | `## Implementation plan` |
-  | `/implement` | `## Implementation notes` |
-  | `/wrap-up` | `## Session handoff` |
 
 - **Update the body, not a comment.** Every phase edits the issue body in place — append a new section if one does not exist for the current phase, edit the existing section if it does. Comments are for discussion only.
 - **Reset after updating.** Once the body is updated, tell the user to start the next phase in a fresh session. Do not call the next skill from within the current one.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -34,7 +34,7 @@ Rule of thumb:
 - **Between features** — promote durable learnings to the vault's concept notes via `/compound` (which delegates to `claude-obsidian`'s `/save` when available). That's what crosses the worktree boundary.
 - **Want a quick "what have I been working on lately" cache across the repo** — that's the vault's hot cache, not NOTES.md. Hot cache is curated and committed; NOTES.md is raw and ephemeral.
 
-`/wrap-up` is the bridge: it harvests NOTES.md at clean exit and drafts a GitHub-issue comment, and it's the natural trigger point to ask whether anything in NOTES.md deserves promotion to the vault.
+`/implement` is the harvest point: at PR creation it reads NOTES.md, flows the decisions and open questions into the PR body, then deletes NOTES.md after `/compound` has run.
 
 ## Location and lifecycle
 
@@ -42,8 +42,9 @@ Rule of thumb:
 - **Created by `/build`** at the start of the phase, immediately after `git worktree add`, with the initial task list harvested from the issue.
 - **Updated by `/build`** after each completed task, each significant decision, and before any summarization-based `/compact`.
 - **Read on resume by `/build`** — before re-reading the issue.
-- **Harvested by `/wrap-up`** into a GitHub issue comment on clean exit.
-- **Left in place** after the phase ends. Cleanup happens when the worktree is removed (`wt remove` deletes the worktree directory and `.claude/NOTES.md` goes with it). Do not delete it from within a running phase.
+- **Harvested by `/implement`** at PR-creation time — `## Decisions made this session` and `## Open questions` flow into the PR body's `## Notes` section.
+- **Deleted by `/implement`** after `/compound` has run. If `/implement` exits abnormally between PR creation and deletion, NOTES.md persists; `/wrap-up`'s worktree removal will clean it up implicitly.
+- **Left in place** by standalone `/build`, `/review`, or `/verify` runs — they do not open PRs and do not harvest. Cleanup happens when the worktree is removed (`wt remove` deletes the worktree directory and `.claude/NOTES.md` goes with it).
 - **Not committed to git.** Ensure `/.claude/NOTES.md` is gitignored at the repo root before creating it; add the entry if missing.
 
 ## Required sections
@@ -79,7 +80,7 @@ Update at these points (bullet-level only — fast):
 - **After each completed task** — flip the checkbox, log any decision that resulted from completing it.
 - **After each significant decision** — one line, with rationale.
 - **Before any summarization-based `/compact`** — write the Keep list into the file *first*, so the post-compaction summary can be diffed against an external record.
-- **Before ending the session normally** — `/wrap-up` will harvest it.
+- **Before ending the session normally** — `/implement` will harvest it at PR-creation time.
 
 Do not update for trivial moves (opening a file, running a test command). It is a checkpoint log, not a transcript.
 
@@ -96,7 +97,7 @@ On a fresh session in an existing worktree, `.claude/NOTES.md` exists ⇒ this i
 
 - **`.claude/NOTES.md` is authoritative for in-flight state.** In-context recall is rot-degraded by the time the file matters; trust the file.
 - **The issue is authoritative for cross-phase state.** Acceptance criteria, locked architectural decisions, prior-phase handoff content live in the issue, not the file.
-- **Never delete it automatically.** The owning session may archive it on clean exit; do not remove it from within a running phase.
+- **Deletion is `/implement`'s responsibility.** It deletes NOTES.md after `/compound` runs at PR-creation time. Standalone `/build` runs leave it in place — do not delete from within a running build phase.
 
 ## Why
 

--- a/_shared/repo-preflight.md
+++ b/_shared/repo-preflight.md
@@ -15,3 +15,7 @@ Used by skills that originate `gh` mutations or `git push` operations. Read this
 ## Why
 
 `gh` issue and PR mutations are public, persistent, and cross-repo (the `--repo` flag silently routes to a different upstream). A wrong-repo mutation has higher blast radius than a wrong-branch push. This single gate covers both surfaces.
+
+## Orchestrator pattern
+
+When an orchestrator (e.g. `/implement`) runs this preflight at entry, it passes `preflight_verified: true` in every seed brief it issues to specialists. Specialists skip this step when a valid seed brief is present — see `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.

--- a/_shared/scope-preflight.md
+++ b/_shared/scope-preflight.md
@@ -28,3 +28,7 @@ If the user does not confirm, do not edit any of the listed files. Reply:
 > Holding off — please clarify which files are in scope.
 
 Re-prompt with a narrowed list when the user provides scope.
+
+## Orchestrator pattern
+
+When an orchestrator (e.g. `/implement`) runs this preflight at entry and passes `scope_class` in every seed brief, specialists skip their own scope-class and file-scope confirmations. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.

--- a/_shared/specialist-mode.md
+++ b/_shared/specialist-mode.md
@@ -1,0 +1,84 @@
+# Specialist Mode — Shared Protocol
+
+A specialist skill runs in one of two modes depending on how it was invoked: **standalone** (invoked directly by the user) or **specialist** (invoked by an orchestrator that has already run preflights and scoped the work).
+
+This file is reference material — read it when a skill needs to detect its invocation mode or document which prompts it skips when seeded.
+
+## Detection
+
+A specialist detects specialist mode by checking for a `<seed-brief>` block in its prompt at startup:
+
+```
+if "<seed-brief>" in prompt → specialist_mode = True
+```
+
+When a seed brief is present, the verified fields in it replace the specialist's own preflight checks. When no brief is present, the specialist runs in standalone mode with all prompts active.
+
+## Seed-brief transport format
+
+Orchestrators pass seed briefs as raw YAML inside an XML tag — no inner code fence:
+
+```
+<seed-brief>
+preflight_verified: true
+scope_class: Lightweight|Standard|Deep
+repo: owner/repo
+branch: feat/branch-name
+active_issue: 42
+payload:
+  type: fix|research|prior-art
+  # type-specific fields per _shared/composition.md
+</seed-brief>
+```
+
+The XML tag marks the boundary; the YAML is parseable without a fence. The `payload` envelope decouples brief metadata from the type-specific research, fix, or prior-art content.
+
+## Required fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `preflight_verified` | boolean | yes | Brief is rejected if `false` or missing |
+| `scope_class` | string | yes | Must be `Lightweight`, `Standard`, or `Deep` |
+| `repo` | string | yes | `owner/repo` — verified against `git remote -v` of the spawning worktree |
+| `branch` | string | yes | `feat/<slug>` — verified against `git rev-parse --abbrev-ref HEAD` |
+| `active_issue` | integer | yes | Ties the brief to its GitHub issue |
+| `payload` | object | yes | `{ type: fix|research|prior-art, ... }` — type-specific fields per `_shared/composition.md` |
+
+When verification fails (wrong repo, wrong branch, missing required field), the specialist rejects the brief and falls back to standalone behavior with full prompts. Log which check failed.
+
+## What gets skipped in specialist mode
+
+Confirmations that verify *state* are skipped when seeded; confirmations that drive *discovery* or *rigor* stay live.
+
+| Specialist | Skipped when seeded | Always kept |
+|-----------|---------------------|-------------|
+| `/build` | repo-preflight, scope-preflight, scope-class confirmation | design gate (architecture must be cross-phase verified) |
+| `/review` | repo-preflight | severity/finding-depth gates |
+| `/verify` | repo-preflight | AC verification rigor |
+| `/describe` | internal prior-art search (declared in Input section) | Product Pressure Test, grill-me interactions |
+| `/specify` | scope-class + file-scope confirmation | AC derivation gates |
+| `/architecture` | codebase-research / patterns-research subagent dispatches | architecture session (grill-me + devil's advocate) |
+| `/design` | design-space research subagents | interactive design session |
+
+Each specialist documents a "Specialist mode" subsection in its own SKILL.md naming which prompts it skips.
+
+## Standalone invocation
+
+When no seed brief is present, the specialist runs with all prompts as documented in its SKILL.md. There is no partial-brief state — either a valid `<seed-brief>` block is present or the specialist runs standalone.
+
+## Orchestrator responsibilities
+
+When an orchestrator spawns a specialist, it must:
+
+1. Run repo-preflight (see `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`) once at entry — not per specialist.
+2. Run scope-preflight (see `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md`) once at entry — not per specialist.
+3. Pass a valid seed brief with `preflight_verified: true` to every specialist it spawns.
+4. Include the verified `repo`, `branch`, and `active_issue` in every brief so specialists can sanity-check without re-running preflight.
+
+Orchestrators that follow this contract: `/implement` → `/build`, `/review`, `/verify`; `/discovery` → `/describe`, `/specify`; `/define` → `/architecture`, `/design`, `/specify`.
+
+## See also
+
+- `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` — seed-brief types (research, prior-art, fix) and the full field list for each.
+- `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` — the preflight protocol orchestrators run once at entry.
+- `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` — the scope-preflight protocol orchestrators run once at entry.

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -12,7 +12,7 @@ Every skill fills one of five authoring roles. These extend the three-role compo
 | **Coordinator orchestrator**      | Sequences already-designed sub-skills in a loop (e.g. build → review → verify). Deep reasoning lives in the sub-skills, not the orchestrator — no research team | `/implement`                                                  | `sonnet`                     |
 | **Specialist**                    | Executes a bounded task; receives a seed brief; reports findings to the orchestrator                                                                            | `/build`, `/review`, `/architecture`, `/specify`              | `sonnet`                     |
 | **Interactive primitive**         | Reusable inline behavior; invoked by specialists; no team, no handoff                                                                                           | `/grill-me`                                                   | `sonnet`                     |
-| **Utility**                       | User-invocable maintenance or post-work skill. No seed-brief contract, no phase handoff artifact, no team gating                                                | `/compound`, `/prune`, `/resolve-pr-feedback`, `/find-skills` | `sonnet` or `haiku`          |
+| **Utility**                       | User-invocable maintenance or post-work skill. No seed-brief contract, no phase handoff artifact, no team gating                                                | `/compound`, `/prune`, `/resolve-pr-feedback`, `/find-skills`, `/wrap-up` | `sonnet` or `haiku`          |
 
 Use the role-specific template:
 
@@ -56,9 +56,10 @@ Shared protocols live at `${CLAUDE_PLUGIN_ROOT}/_shared/`. Reference them on-dem
 
 | `_shared/` file          | Reference when the skill...                                                                                                                                                             |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `handoff-artifact.md`    | Writes or reads a GitHub issue handoff block (phase-boundary skills: `/discovery`, `/define`, `/implement`, `/wrap-up`)                                                                 |
+| `handoff-artifact.md`    | Writes or reads a GitHub issue handoff block (phase-boundary skills: `/discovery`, `/define`). Note: `/implement` is the terminal phase — its output is the PR, not an issue body update. `/wrap-up` is a utility, not a phase-boundary skill. |
 | `interviewing-rules.md`  | Interviews the user — asks questions, seeks approval, uses multi-choice forms (`/discovery`, `/define`, `/describe`, `/specify`, `/architecture`, `/design`, `/grill-me`, `/new-skill`) |
-| `notes-md-protocol.md`   | Creates, updates, or resumes from `.claude/NOTES.md` (`/build`, `/wrap-up`)                                                                                                             |
+| `notes-md-protocol.md`   | Creates, updates, or resumes from `.claude/NOTES.md` (`/build`); harvests and deletes it (`/implement` at PR-creation time)                                                             |
+| `specialist-mode.md`     | Documents or implements specialist-mode detection (seed-brief check, skip-list, standalone fallback) for any skill that can be seeded by an orchestrator                                |
 | `compaction-protocol.md` | Manages in-phase context — clearing stale tool results, delegating bulk reads, using `/compact` (`/build`)                                                                              |
 | `composition.md`         | Authors an orchestrator skill or designs a multi-skill workflow — patterns, briefs, decomposition rules                                                                                 |
 

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -132,9 +132,31 @@ When authoring an orchestrator or designing a multi-skill workflow, you must mak
 
 - **Scope Assessment**: Classify before spawning. Lightweight runs inline; Standard/Deep trigger dispatch. See composition.md for heuristics and cost gradients.
 - **Primitive choice**: Default to inline → subagent → TeamCreate. Parallel adds coordination overhead — confirm genuine communication pivot, file disjointness, classifiable parallelism, and ≥3× wall-clock payoff before paying the ~7× token premium.
-- **Spawn justification**: Document your choice in the skill body. State which rubric factors apply and which don't. See existing orchestrators (`/discovery`, `/define`, `/implement`, `/review`) for the established pattern — a short "Spawn justification" block naming the cost class and required conditions.
+- **Spawn justification**: Document your choice in the skill body. State which rubric factors apply and which don't. See the template below for the canonical shape.
 
 New skills created via `/new-skill` will be guided through this decision during scaffolding.
+
+### Spawn justification template
+
+Every orchestrator or specialist that dispatches a team or subagents includes a `### Spawn justification` block. Copy this structure — apply each rubric criterion explicitly. Vague references make the gate opaque to future authors.
+
+```markdown
+### Spawn justification
+
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
+
+- **<team or session name>**: <shape — e.g. "2 parallel subagents", "TeamCreate at ≥3 splits", "researcher subagent → architect lead-inline → critic subagent">. Comm-pivot <✓|✗> (<one-clause why>), disjoint <✓|✗|n/a> (<why>), parallel <✓|✗> (<why>), payoff <≥3×|<3×> (<why>). Model: <model choice + one-clause rationale>. Fallback: <see options below>.
+```
+
+**`Fallback:` options** — each entry describes what runs when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset (the env-var prerequisite is documented once in composition.md, not per skill):
+
+- `Fallback: sequential subagents` — degrade `TeamCreate` to one-at-a-time subagent dispatch.
+- `Fallback: parallel subagents or sequential` — when the gate already chooses subagents at low scale, this just clarifies the further degradation path.
+- `Fallback: n/a — no flag dependency` — for inline / interactive / single-subagent shapes that don't use `TeamCreate`. Use this exact wording so readers can grep for env-var-dependent skills.
+
+**What stays per-skill**: the rubric application — comm-pivot, disjoint, parallel, payoff judgments are role-specific and load-bearing. Don't compress them. The boilerplate "fallback applies when env var unset" sentence is redundant with composition.md's prerequisite line and should be omitted.
+
+See `skills/architecture/SKILL.md` and `skills/build/SKILL.md` for canonical examples.
 
 ## Naming conventions
 

--- a/docs/context-hygiene.md
+++ b/docs/context-hygiene.md
@@ -61,9 +61,11 @@ In this workflow:
 - `/build` should delegate to an Explore sub-agent for any of: understanding an unfamiliar area of the codebase, parsing a long log, reading API docs, grepping wide paths. Ask for a focused report bounded by what the lead actually needs to make the next decision — not a fixed word limit.
 - Pass briefs, not session history. Sub-agents need objective + constraint + "what to report on" — not the conversation that led you to spawn them.
 
-### 4. Write `/wrap-up` output into the issue body before the session ends
+### 4. Persist end-of-phase state into the issue body before the session ends
 
-`/wrap-up` surfaces assumptions, uncertainties, and follow-ups — but without persistence, that output stays in the conversation and is lost when the session ends. That defeats rule (1). Fix: whenever `/wrap-up` runs at a phase boundary, edit the GitHub issue **body** in place to append a `## Session handoff` section. The captured content then survives the reset and lives in the same scan-readable artifact as the rest of the phase state.
+At phase boundaries (`/discovery`, `/define`), the orchestrator edits the GitHub issue **body** in place with the handoff artifact so state survives the context reset. The captured content lives in the same scan-readable artifact as the rest of the phase state.
+
+For `/implement`: this phase is terminal — its output is the PR, not an issue body update. End-of-phase state (assumptions, uncertainties, follow-ups, outstanding findings) flows into the PR body's `## Notes` section. `/wrap-up` is now a user-invoked cleanup utility (worktree + branch removal), not a phase-boundary skill.
 
 ## Why
 
@@ -81,7 +83,7 @@ A note on Opus 4.5/4.6 and "context anxiety": Anthropic reports they dropped con
 
 - **Rule 1 (reset + artifact)** applies at every phase boundary, always. No exceptions.
 - **Rules 2 and 3** apply within a phase whenever a concept shift occurs. See `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` for the full trigger list and the tool-order decision (context editing → sub-agent → `/compact`).
-- **Rule 4** applies whenever `/wrap-up` runs at a phase boundary — its output is written into the issue body before the session ends.
+- **Rule 4** applies at every phase boundary — `/discovery` and `/define` write to the issue body; `/implement` writes to the PR body. `/wrap-up` is a cleanup utility, not a phase-boundary skill.
 
 ## Examples
 
@@ -156,7 +158,7 @@ This matches Anthropic's sub-agent pattern: the reviewer runs in isolation, retu
 - `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` — trigger list and tool order for in-phase context pressure.
 - `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` — NOTES.md as an external ledger the model can diff against after `/compact`.
 - `${CLAUDE_PLUGIN_ROOT}/skills/compound/SKILL.md` — how learnings from a completed phase become durable wiki notes.
-- `${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/SKILL.md` — end-of-session assumption audit; remember to persist its output per rule (4).
+- `${CLAUDE_PLUGIN_ROOT}/skills/wrap-up/SKILL.md` — worktree + branch cleanup utility; invoke after the PR is merged or accepted.
 
 ## Sources
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -14,6 +14,16 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when
 - **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Model: dispatch with `model: "sonnet"` — both agents (codebase research and patterns/learnings) are read-only research, not deep architecture reasoning; sonnet handles this capably at lower token cost. Fallback: sequential subagents.
 - **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Model: analyst and devil's advocate subagents use `model: "sonnet"` (constraint analysis and systematic challenge); lead architect (interactive) stays `opus`. Fallback: n/a — no flag dependency.
 
+## Specialist mode
+
+When invoked by `/define` with a `<seed-brief>` block, skip:
+- codebase-research subagent dispatch (research brief in the seed brief covers it)
+- patterns/learnings subagent dispatch (prior-art brief in the seed brief covers it)
+
+Always keep: the full architecture session (grill-me + devil's advocate) — interactive reasoning and challenge rounds are not delegatable.
+
+Without a seed brief, run all steps as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Input
 
 A GitHub issue with problem statement and acceptance criteria (from /discovery).

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -9,7 +9,7 @@ You are leading an architecture team. Your job is to explore technical approache
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Model: dispatch with `model: "sonnet"` — both agents (codebase research and patterns/learnings) are read-only research, not deep architecture reasoning; sonnet handles this capably at lower token cost. Fallback: sequential subagents.
 - **Architecture session**: analyst subagent → architect lead-inline (grill-me) → devil's advocate subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Model: analyst and devil's advocate subagents use `model: "sonnet"` (constraint analysis and systematic challenge); lead architect (interactive) stays `opus`. Fallback: n/a — no flag dependency.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -29,7 +29,7 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Standard**: TeamCreate at ≥3 splits, else parallel subagents. Comm-pivot ✓ at scale, disjoint ✓, parallel ✓, payoff ≥3× only at ≥3 splits. Gate: ≥3 sub-issues OR ≥3 disjoint file groups. Fallback: parallel subagents or sequential.
 - **Deep**: TeamCreate. All four ✓ for epics. Fallback: sequential subagents.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -34,6 +34,17 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when
 - **Standard**: TeamCreate at ≥3 splits, else parallel subagents. Comm-pivot ✓ at scale, disjoint ✓, parallel ✓, payoff ≥3× only at ≥3 splits. Gate: ≥3 sub-issues OR ≥3 disjoint file groups. Fallback: parallel subagents or sequential.
 - **Deep**: TeamCreate. All four ✓ for epics. Fallback: sequential subagents.
 
+## Specialist mode
+
+When invoked by `/implement` with a `<seed-brief>` block, skip:
+- repo-preflight (already run by the orchestrator; `preflight_verified: true` is in the brief)
+- scope-preflight (scope class is in the brief as `scope_class`)
+- scope-class confirmation (the orchestrator has already classified)
+
+Always keep: the design gate — architecture decisions must be cross-phase verified even when seeded.
+
+Without a seed brief, run all prompts as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Process
 
 ### Step 0 — Pre-flight

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -16,7 +16,7 @@ This skill extracts the learning and drafts it. **Filing is delegated** to the `
 
 ## Input
 
-The current conversation context — a completed debugging session, feature implementation, or fix.
+The current conversation context — a completed debugging session, feature implementation, or fix. When invoked from `/implement` end-of-flow, may also read `<worktree-root>/.claude/NOTES.md` for in-phase decisions and open questions not yet captured in the conversation context.
 
 ## Process
 

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -30,7 +30,7 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Research team**: 2 parallel subagents. Comm-pivot ✗ (read-only), disjoint ✓, parallel ✓, payoff ≥3×. Fallback: sequential subagents.
 - **Standard definition team**: sequential subagents (architecture → design). Comm-pivot ✗ (strictly ordered), disjoint n/a (sequential), parallel ✗, payoff <3×. Fallback: n/a — no flag dependency.

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -43,7 +43,7 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Standard session**: domain researcher subagent + analyst lead-inline. Comm-pivot ✗ (one-shot handoff), disjoint n/a (sequential), parallel ✗ (analyst interactive), payoff <3×. Model: domain researcher uses `model: "sonnet"` (reading code and extracting patterns) — only lead analyst needs `opus` for interactive problem discovery. Fallback: n/a — no flag dependency.
 - **Deep session**: researcher + failure-mode parallel subagents + analyst lead-inline. Comm-pivot ✗, disjoint ✓, parallel ✓ for subagent pair, payoff <3× total. Model: domain researcher and failure-mode analyst both use `model: "sonnet"` (research and analysis) — only lead analyst needs `opus` for interactive discovery. Fallback: sequential subagents.

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -7,6 +7,15 @@ effortLevel: high
 
 You are leading a product discovery team. Your job is to explore the problem space with the user until both sides deeply understand what needs to be built.
 
+## Specialist mode
+
+When invoked by `/discovery` with a `<seed-brief>` block, skip:
+- internal prior-art search (the prior-art brief already contains this; declared below in Input)
+
+Always keep: Product Pressure Test, grill-me interactions — these are discovery-phase reasoning, not state verification.
+
+Without a seed brief, run all steps as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Input
 
 Optional: when invoked as a specialist from `/discovery`, may receive a **prior-art brief** as seed context (from the Prior-Art Scout). When a brief is provided, skip any internal prior-art search and incorporate the brief into the Product Pressure Test and problem statement synthesis. Without a brief, proceed as described below.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -12,6 +12,15 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Design session**: researcher subagent → proposer lead-inline (grill-me) → a11y subagent. Comm-pivot ✗ (sequential handoff), disjoint n/a (sequential), parallel ✗ (interactive grill-me), payoff <3×. Model: UX researcher and accessibility reviewer both use `model: "haiku"` (pattern search and accessibility checklist validation are systematic, not creative) — reserve `sonnet` for the design proposer lead session (interactive, requires design judgment). Fallback: n/a — no flag dependency.
 
+## Specialist mode
+
+When invoked by `/define` with a `<seed-brief>` block, skip:
+- design-space research subagent dispatch (the research brief covers existing UI patterns)
+
+Always keep: the interactive design session (grill-me + a11y review) — design judgment and accessibility evaluation require live interaction.
+
+Without a seed brief, run all steps as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Input
 
 A GitHub issue with architecture decisions (from /define).

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -27,7 +27,7 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Standard team**: describe lead-inline + scout parallel subagent + specify sequential subagent. Comm-pivot ✗ (async handoff), disjoint ✓, parallel ✓ scout-only, payoff <3×. Fallback: sequential subagents (scout → describe → specify).
 - **Deep team**: TeamCreate. Comm-pivot ✓ (adversarial questioner reacts live), disjoint ✓, parallel ✓, payoff ≥3× cross-module/security. Gate: Deep scope. Fallback: sequential subagents.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -14,7 +14,7 @@ A GitHub issue number (with architecture/design decisions from /define) and any 
 
 Classify the work before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the right-sizing rationale.
 
-1. **Trivial** — single-file fix, typo, docstring, rename, config tweak; AC list has 1–2 items; no logic changes.
+1. **Lightweight** — single-file fix, typo, docstring, rename, config tweak; AC list has 1–2 items; no logic changes.
    - Run `/build` inline (no implementation team); skip `/review` as a separate team; run a single inline AC check in place of `/verify`.
 2. **Standard** — typical multi-file feature with acceptance criteria spanning one module.
    - Full build → review → verify cycle with the default team widths each sub-skill picks.
@@ -23,7 +23,7 @@ Classify the work before dispatching. See `${CLAUDE_PLUGIN_ROOT}/_shared/composi
 
 Decision tree:
 
-1. Diff will be under ~50 lines with no logic changes? → Trivial
+1. Diff will be under ~50 lines with no logic changes? → Lightweight
 2. Touches auth/security, migrations, public APIs, or performance-critical paths? → Deep
 3. Otherwise → Standard
 
@@ -31,16 +31,20 @@ Decision tree:
 
 Once you've assessed the scope as **Standard** or **Deep**, inspect the GitHub issue body for a `## Implementation plan` section containing architecture and design decisions from `/define`. If absent:
 - **Pause** and prompt: _"No architecture/design decisions recorded on this issue. Run `/define` first, or confirm this is a trivial enough change to skip the gate."_
-- If the user confirms this is trivial enough (typo, single-line fix, etc.), downgrade to **Trivial** scope and proceed.
+- If the user confirms this is trivial enough (typo, single-line fix, etc.), downgrade to **Lightweight** scope and proceed.
 - Otherwise, wait for the user to run `/define`.
 
 Skip this gate for **Lightweight** scope.
+
+## Pre-flight
+
+Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` once at entry. Run `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` if the file list is 3 or more files. Pass `preflight_verified: true` in every seed brief issued to specialists — they skip their own preflight when this flag is set.
 
 ## Process
 
 **Autonomy contract**: inside a single `/implement` invocation, run build → review → verify → fix cycles back-to-back without asking the user between sub-skills. The only user-interrupt point is after the PR is opened and the cycle has either (a) passed clean, (b) exhausted 3 cycles with findings remaining, or (c) hit a blocker the sub-skill cannot resolve. Status updates during the loop are informational only — do **not** end them with a question.
 
-### Trivial
+### Lightweight
 
 1. Auto-run `/build` — lead codes inline in the worktree, no team spawn, TDD only for logic-heavy snippets.
 2. Auto-run an inline AC self-check — walk every acceptance criterion against the diff and the running code; skip the `/review` and `/verify` team spawns.
@@ -48,9 +52,24 @@ Skip this gate for **Lightweight** scope.
 
 ### Standard / Deep — autonomous cycle: build → review → verify
 
-1. Auto-run `/build` — spawns implementation team (or runs inline per `/build`'s own Scope Assessment), codes against the issue.
-2. Auto-run `/review` — spawns review team; Deep scope triggers `/review`'s Deep mode (all specialists, `opus`).
-3. Auto-run `/verify` — spawns QA team, verifies every acceptance criterion.
+Construct a seed brief for each specialist at spawn time:
+
+```
+<seed-brief>
+preflight_verified: true
+scope_class: <Lightweight|Standard|Deep>
+repo: <owner/repo>
+branch: <feat/slug>
+active_issue: <N>
+payload:
+  type: <fix|research>
+  # type-specific fields per _shared/composition.md
+</seed-brief>
+```
+
+1. Auto-run `/build` — spawns implementation team (or runs inline per `/build`'s own Scope Assessment), codes against the issue. Pass a seed brief with `type: research` and the issue's architectural context.
+2. Auto-run `/review` — spawns review team; Deep scope triggers `/review`'s Deep mode (all specialists, `opus`). Pass a seed brief with `type: research` (diff + AC).
+3. Auto-run `/verify` — spawns QA team, verifies every acceptance criterion. Pass a seed brief with `type: research` (diff + AC + test commands).
 4. **Evaluate findings** (no user prompt):
    - **Clean pass** (`/review` and `/verify` both return no issues) → exit loop, fall through to **PR creation**.
    - **Findings present** and cycle count < 3 → package a **fix brief** (failing criteria + reviewer findings as `file:line` + prior architectural decisions; no review/verify session history), auto-feed it to `/build`, auto-re-run `/review` and `/verify`. Do not ask the user to confirm the next iteration.
@@ -62,39 +81,53 @@ Progress reporting during the loop: emit one status line per cycle (`Cycle N/3 �
 
 Run these steps automatically, without asking:
 
-1. Push the branch to remote.
-2. Open a draft PR (`gh pr create --draft`).
-3. Link to the issue:
+1. Read `<worktree-root>/.claude/NOTES.md` if it exists. Harvest `## Decisions made this session` and `## Open questions` — these flow into the PR body's `## Notes` section.
+2. Push the branch to remote.
+3. Open a draft PR (`gh pr create --draft`) with the body shape below. Link to the issue:
    - `Closes #<issue>` — if this is the only/final PR for the issue.
    - `Related to #<issue>` — if this is a partial implementation.
-4. PR description must include:
-   - Summary of changes.
-   - **Manual testing** section with concrete repro steps someone can follow.
-   - **Outstanding findings** section when the loop exhausted 3 cycles — list each as `file:line — severity — description`.
-5. Use superpowers:finishing-a-development-branch for PR finalization.
+
+**PR body shape:**
+
+```markdown
+## Summary
+<1-2 sentences: what was implemented, why, ACs satisfied>
+
+## Testing notes
+<repro steps, env setup, expected behavior — concrete enough that a reviewer can verify locally>
+
+## Notes
+<free-form prose, with bullet lists where natural; absorbs assumptions, uncertainties, follow-ups, outstanding findings from NOTES.md harvest and any exhausted-exit findings>
+```
+
+`## Notes` is omitted entirely when there is nothing to note (no NOTES.md content, no outstanding findings).
+
+4. Run `/compound` — autonomous, reads the cycle context and any remaining NOTES.md content, files durable learnings to the wiki via `claude-obsidian:save` when the plugin is installed (otherwise returns the note inline).
+5. Delete `<worktree-root>/.claude/NOTES.md`.
+6. Exit with PR URL and any outstanding findings.
 
 ### Finalize
 
 One deterministic finalize block follows PR creation. Branch on the loop's exit state:
 
-- **Clean exit** (no remaining findings) → auto-run `/compound`, then auto-run `/wrap-up`. Present the PR URL and the `/wrap-up` handoff draft to the user as the final message. `/wrap-up` still asks before editing the issue body per its own contract — that prompt is the user's first interrupt point in the entire flow.
+- **Clean exit** (no remaining findings) → present the PR URL to the user. `/compound` has already run autonomously.
 - **Exhausted exit** (3 cycles consumed, findings remain) → present the PR URL plus the outstanding findings to the user and ask a single binary question: **"Continue the implementation loop, or accept this PR and close out?"**
-  - **Accept / close** → auto-run `/compound`, then auto-run `/wrap-up`.
-  - **Continue** → run one more build → review → verify cycle, then return to this finalize block. Each continuation is a new escalation — log it explicitly in the PR description under **Outstanding findings** before re-entering the loop.
-
-`/compound` drafts a structured note from the cycle's debugging, edge cases, and architectural surprises, and files it via `claude-obsidian:save` when the plugin is installed (otherwise it returns the note inline). `/wrap-up` produces the end-of-session assumptions audit and offers to patch the issue body. Both run without asking `/implement` for permission — their own contracts govern any remaining prompts.
+  - **Accept / close** → `/compound` has already run autonomously. Done.
+  - **Continue** → run one more build → review → verify cycle, then return to this finalize block. Each continuation is a new escalation — log it explicitly in the PR description under `## Notes` before re-entering the loop.
 
 ## Output
 
-A draft PR linking the issue (`Closes #N` or `Related to #N`) with acceptance criteria met (or with an explicit **Outstanding findings** block if the user accepted an exhausted exit), a Manual testing section with concrete repro steps, `/compound` run (filed or inline), and `/wrap-up` run (draft shown, issue body updated per the user's decision). No handoff artifact beyond the PR and issue body — this is the terminal phase.
+A draft PR linking the issue (`Closes #N` or `Related to #N`) with acceptance criteria met (or with an explicit outstanding findings block in `## Notes` if the user accepted an exhausted exit), a Testing notes section with concrete repro steps, and `/compound` run (filed or inline). No handoff artifact beyond the PR — this is the terminal phase.
 
 ## Rules
 
-- **Never prompt between sub-skills.** Build → review → verify → fix cycles and the PR / `/compound` / `/wrap-up` finalize chain all run without asking. The only permitted user-interrupt is the single binary question after an **exhausted exit** (3 cycles with findings remaining).
-- Do not open a PR until both /review and /verify pass clean (Standard/Deep) **or** the cycle has exhausted 3 iterations with findings attached. Trivial scope opens the PR after the inline AC self-check.
-- Maximum 3 build→review→verify cycles before escalating; escalation is the one-question finalize prompt, not per-cycle approval. Trivial never cycles — if it fails the inline check, upgrade to Standard and restart.
+- **Never prompt between sub-skills.** Build → review → verify → fix cycles and the PR / `/compound` finalize chain all run without asking. The only permitted user-interrupt is the single binary question after an **exhausted exit** (3 cycles with findings remaining).
+- Run repo-preflight once at entry; pass `preflight_verified: true` to every specialist via seed brief.
+- Do not open a PR until both /review and /verify pass clean (Standard/Deep) **or** the cycle has exhausted 3 iterations with findings attached. Lightweight scope opens the PR after the inline AC self-check.
+- Maximum 3 build→review→verify cycles before escalating; escalation is the one-question finalize prompt, not per-cycle approval. Lightweight never cycles — if it fails the inline check, upgrade to Standard and restart.
 - Each cycle must address **all** findings from the previous cycle; partial fixes do not count as a cycle.
 - Emit one status line per cycle for user visibility (`Cycle N/3 — …`). Status lines are informational and must never end with a question.
-- `/compound` and `/wrap-up` run automatically after PR creation on both clean and user-accepted exits. They own their own prompts; `/implement` does not wrap them in additional confirmations.
-- The GitHub issue body is the handoff artifact across phases; every sub-skill reads from and updates it in place. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
-- In-phase state lives in `./.claude/NOTES.md` (read by `/build` on resume) and in the issue body (cross-phase). Do not re-issue instructions already captured in either.
+- `/compound` runs automatically after PR creation. It owns its own prompts; `/implement` does not wrap it in additional confirmations.
+- Do not call `/wrap-up`. It is a user-invoked utility — the user invokes it when ready to clean up the worktree and branch.
+- In-phase state lives in `./.claude/NOTES.md` (read by `/build` on resume) and in the issue body (cross-phase). See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
+- The issue body after `/implement` contains only `## Requirements` (from `/discovery`) and `## Implementation plan` (from `/define`). Do not write a `## Session handoff` block.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -8,7 +8,7 @@ You are leading the PR feedback resolution process. Your job is to systematicall
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Fix team**: TeamCreate at ≥3 file groups, else parallel subagents. Comm-pivot ✓ at scale (cross-thread regressions), disjoint ✓ (mapped pre-dispatch), parallel ✓, payoff ≥3× at ≥3 groups. Gate: ≥3 non-overlapping file groups. Fallback: parallel subagents or sequential.
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -7,6 +7,15 @@ effortLevel: high
 
 You are leading the review phase. Your goal is to thoroughly review the implementation and produce actionable findings.
 
+## Specialist mode
+
+When invoked by `/implement` with a `<seed-brief>` block, skip:
+- repo-preflight (already run by the orchestrator; `preflight_verified: true` is in the brief)
+
+Always keep: severity/finding-depth gates — rigor of review is not delegated to the orchestrator.
+
+Without a seed brief, run all prompts as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Input
 
 A branch with commits (reviewed via `git diff main...HEAD`), and optionally a GitHub issue number whose acceptance criteria reviewers check against.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -53,7 +53,7 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset. Model tiers: see **Configuration** section.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. Model tiers: see **Configuration** section.
 
 - **Standard**: TeamCreate with `model: "sonnet"` at ≥3 active reviewers, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
 - **Deep**: TeamCreate with `model: "opus"`. All four ✓ across 4 review axes; opus premium justified by criticality. Fallback: sequential subagents.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -12,6 +12,16 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Requirements (happy-path + edge-case)**: sequential grill-me passes in lead session. Comm-pivot ✗ (analysts contend for the same user input channel), disjoint n/a (sequential), parallel ✗ (interactive), payoff <3×. Fallback: n/a — no flag dependency.
 
+## Specialist mode
+
+When invoked by `/discovery` or `/define` with a `<seed-brief>` block, skip:
+- scope-class confirmation (scope class is in the brief as `scope_class`)
+- file-scope confirmation (already verified by the orchestrator)
+
+Always keep: AC derivation gates — the quality of acceptance criteria is not delegated to the orchestrator.
+
+Without a seed brief, run all prompts as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Input
 
 A problem statement from /describe, or a user-provided feature description.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -6,6 +6,15 @@ model: haiku
 
 You are leading the verification phase. Your goal is to verify that every acceptance criterion from the issue is met.
 
+## Specialist mode
+
+When invoked by `/implement` with a `<seed-brief>` block, skip:
+- repo-preflight (already run by the orchestrator; `preflight_verified: true` is in the brief)
+
+Always keep: AC verification rigor — pass/fail evidence is never delegated to the orchestrator.
+
+Without a seed brief, run all prompts as described below. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ## Input
 
 A branch with commits and a GitHub issue number whose acceptance criteria will be verified against the running code.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -51,7 +51,7 @@ Decision tree:
 
 ### Spawn justification
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. `Fallback:` applies when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is unset.
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 - **Standard/Deep QA**: TeamCreate at ≥4 AC, else parallel subagents. Comm-pivot ✓ (cross-verify findings), disjoint ✓, parallel ✓, payoff ≥3× at ≥4 AC. Model: dispatch QA workers with `model: "haiku"` — QA verification is highly structured (AC-based pass/fail with evidence collection); haiku handles this capably and matches the lead agent's model tier. Gate: ≥4 acceptance criteria. Fallback: sequential subagents.
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -1,63 +1,80 @@
 ---
 name: wrap-up
-description: End-of-session assumptions audit. Surfaces assumptions, uncertain decisions, and follow-ups from the current session. Harvests ./.claude/NOTES.md and updates the active GitHub issue body so it survives session reset. Use before ending long or complex sessions.
+description: Clean up local state after a PR is open — remove the worktree, delete the branch, and clear NOTES.md. User-invoked utility; run when ready to discard the feature worktree.
 model: sonnet
 ---
 
-You are performing an end-of-session audit. Review what happened in this session and surface anything the user should know before context is lost.
+You are cleaning up local state after a PR has been opened. Your job is to safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md — confirming before destructive actions and refusing outright when the operation would destroy protected state.
 
 ## Input
 
-The current conversation history and `./.claude/NOTES.md` if present; optionally an active GitHub issue number whose body receives the audit update.
+The current worktree path and branch. Optionally, an open PR linked to the active issue (used to verify unpushed-commit safety).
 
 ## Process
 
-1. Review the conversation history and identify:
-   - **Assumptions** — decisions you made based on inference rather than explicit user instruction
-   - **Uncertainties** — places where you were unsure and chose one path over alternatives
-   - **Scope changes** — anything you did beyond or short of what was originally asked
-   - **Follow-ups** — work that remains, was deferred, or needs human verification
+### Step 1 — Detect state
 
-   Resolve the worktree root with `git rev-parse --show-toplevel` and check for `<root>/.claude/NOTES.md`. If it exists, read it first — it is the authoritative worklog for this phase. Merge its **Decisions made this session** and **Open questions** into the audit so nothing is lost on reset. See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` for the file's section shape and lifecycle rules.
+Gather:
 
-2. For each item, note:
-   - What the assumption/decision was
-   - Why you made that choice
-   - What the alternative would have been
-   - Risk level (low/medium/high) if the assumption is wrong
+1. **Worktree path** — `git rev-parse --show-toplevel` from the current directory, or use the path the user provides.
+2. **Branch name** — `git rev-parse --abbrev-ref HEAD`.
+3. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD --short` (strips `origin/`). Fall back to checking the list `['main', 'master', 'develop']` only when the symbolic-ref lookup fails; log which method was used.
+4. **Worktree membership** — `git worktree list --porcelain`. Confirm the worktree path appears in this list.
+5. **Working-tree cleanliness** — `git status --short` and `git log @{u}..HEAD --oneline` (unpushed commits not in the PR).
+6. **PR state** — if the user provided a PR number, run `gh pr view <N> --json state,headRefName` to confirm it is open and points to the current branch.
 
-3. **Determine the active issue.** Check the git branch name for an issue reference, or run `gh issue list --search <branch-slug>`, or ask the user directly. The audit must be tied to a specific issue — this is the handoff artifact for the next phase. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for the shape.
+### Step 2 — Apply state machine
 
-4. **Draft the body update.** Produce the audit in the Output format below. Fetch the current issue body (`gh issue view N --json body -q .body`), append or replace a `## Session handoff` section, and show the proposed new body to the user with: `Update issue #N body? (y/n)`. On yes, run `gh issue edit N --body-file -` with the new body. **Never auto-update** — wrong issue, leaked assumptions, or duplicate sections on replay all have real blast radius. Keep the draft visible in the terminal even if the user declines, so they can copy it manually.
+| Condition | Outcome |
+|-----------|---------|
+| Branch matches the default branch | **Refuse outright.** No proceed-anyway prompt. |
+| Worktree path not in `git worktree list --porcelain` | **Refuse outright.** Out-of-tree paths are never managed by `/wrap-up`. |
+| Worktree is dirty (uncommitted changes, or unpushed commits not in the PR) | **Show state + proceed-anyway prompt** (see Step 3). |
+| Worktree is clean, feature branch, worktree in-tree | **Single confirmation** (see Step 4). |
+
+### Step 3 — Dirty worktree: proceed-anyway prompt
+
+Show what is dirty (uncommitted files, unpushed commit list). Then ask:
+
+> The worktree has unsaved state (shown above). Proceed with removal anyway?
+> On yes, I will use `git branch -D` (force-delete) if unpushed commits would be lost.
+
+Wait for explicit confirmation. Do not proceed on silence.
+
+### Step 4 — Single confirmation (clean or dirty-with-override)
+
+Show the exact actions that will run:
+
+> I will:
+> - `git worktree remove <path>` (removes the worktree directory and its contents, including `.claude/NOTES.md` if present)
+> - `git branch -d <branch>` (or `-D` if commits would be lost)
+>
+> Proceed?
+
+Wait for explicit confirmation. Do not proceed on silence.
+
+### Step 5 — Execute and report
+
+On confirm:
+
+1. `git worktree remove <path>` — removes the worktree directory. NOTES.md, if still present inside it, is removed implicitly.
+2. `git branch -d <branch>` (or `git branch -D <branch>` when the dirty-worktree path was confirmed and commits would be lost).
+3. Report what was removed: worktree path, branch name, whether NOTES.md was present.
 
 ## Output
 
-Present the audit as an indented code block (four-space indent) so the user can copy it even if they decline the auto-update prompt. Print the label `paste into issue #N body — handoff artifact` (with the actual issue number substituted) on the line immediately above the block.
+A one-line summary per removed artifact:
 
-Example (for issue #42):
-
-    paste into issue #42 body — handoff artifact
-
-        ## Session handoff
-
-        ### Assumptions Made
-        - [assumption] — [why] — [risk if wrong]
-
-        ### Uncertain Decisions
-        - [decision] — [alternatives considered] — [why this one]
-
-        ### Scope Notes
-        - [what changed from original ask]
-
-        ### Follow-ups
-        - [what remains or needs verification]
+```
+Removed worktree: <path>
+Deleted branch: <branch>
+NOTES.md removed with worktree (was present / was already absent)
+```
 
 ## Rules
 
-- Be honest about uncertainty — this is a self-audit, not a sales pitch
-- Include assumptions even if you are fairly confident — the user decides what matters
-- Omit subsections with nothing to report (Assumptions Made, Uncertain Decisions, Scope Notes, Follow-ups) — a missing subsection means zero items. Never write "None" or other placeholder text.
-- The audit is not complete until it is written into the issue body or the user has explicitly declined
-- Update the issue **body** in place — never post the audit as a comment. See `${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`.
-- Never auto-update without user confirmation — show the draft and ask first
-- After a successful update, leave `./.claude/NOTES.md` in place; the next session will read it on resume. Do not delete it automatically.
+- Refuse outright (no proceed-anyway) when the branch is the default branch or the worktree path is not in `git worktree list --porcelain`.
+- Use `git branch -D` only when the dirty-worktree override was explicitly confirmed by the user.
+- Single confirmation covers all removals — do not ask separately for each artifact.
+- Do not write to the GitHub issue body. This skill has no handoff artifact.
+- Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time. NOTES.md removal here is incidental (it goes with the worktree directory).


### PR DESCRIPTION
## Summary

Implements issue #23: a cohesive end-to-end fix for `/implement`'s lifecycle across four tightly-coupled changes. Creates the specialist-mode contract that enables autonomous build→review→verify loops, migrates audit content from the issue body to the PR body, shrinks the handoff-artifact contract to two phase-boundary skills, and repurposes `/wrap-up` as a user-invoked cleanup utility.

Closes #23

## Testing notes

This codebase is LLM-skill markdown — there is no running test suite. Verification is by inspection against the acceptance criteria:

1. **Specialist-mode contract**: Open `_shared/specialist-mode.md` and confirm it documents detection (`<seed-brief>` XML sentinel), transport (YAML inside XML), required fields (`preflight_verified`, `scope_class`, `repo`, `branch`, `active_issue`, `payload`), and per-specialist skip-lists. Grep `_shared/repo-preflight.md`, `_shared/scope-preflight.md`, and `_shared/composition.md` for "specialist-mode.md" cross-links.

2. **Specialist subsections**: Open any of `skills/build/SKILL.md`, `skills/review/SKILL.md`, `skills/verify/SKILL.md`, `skills/describe/SKILL.md`, `skills/specify/SKILL.md`, `skills/architecture/SKILL.md`, `skills/design/SKILL.md` and confirm each has a `## Specialist mode` section near the top naming skipped and kept prompts.

3. **`/implement` PR body shape**: Open `skills/implement/SKILL.md`, look at the PR creation block — confirm the three-section template (Summary / Testing notes / Notes), the NOTES.md harvest step before push, and the NOTES.md deletion after `/compound`. Confirm `/wrap-up` is **not** called anywhere.

4. **Handoff-artifact cleanup**: Open `_shared/handoff-artifact.md` — confirm `/wrap-up` and `/implement` are not listed as phase-boundary skills, the heading table has only `/discovery` and `/define`, and the file notes `/implement` as terminal.

5. **`/wrap-up` repurposing**: Open `skills/wrap-up/SKILL.md` — confirm it contains no audit-generation or issue-body-update logic. Confirm the state machine table (refuse/proceed-anyway/single-confirm) and the default-branch detection step.

## Notes

- Architecture decisions A1–A10 from the issue were followed verbatim. The one correction: the scope class taxonomy is `Lightweight|Standard|Deep` (matching `composition.md`) — the issue body used `Trivial` in some sections, which A3 explicitly calls out as a correction target.
- Existing issues with `## Session handoff` blocks are left in place per A10 (backward-compatible historical records, not migrated).
- The "design gate" in `/build` is kept live even in specialist mode per A4 — architecture decisions are cross-phase verified regardless of whether the orchestrator seeded the brief.
- `/compound` NOTES.md reading happens when invoked from `/implement`; standalone `/compound` invocations are unaffected.
- **Post-implementation addendum (A11)**: bundled a small hygiene pass into the same PR. Removed the redundant `Fallback: applies when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 is unset` boilerplate from 8 skill headers (composition.md already documents the env-var prerequisite). Added a Spawn justification template to `_templates/AUTHORING.md` codifying the canonical block shape and the three `Fallback:` wording variants. Per-bullet role-specific `Fallback:` clauses untouched. Surfaced during a `/architecture` design discussion; see issue #23 §A11 for rationale.
