### PR TITLE
Extend /review to accept external PRs + add docs and architecture personas

### DIFF
--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -48,7 +48,7 @@ Reviewers must operate with fresh context, independent of the implementing sessi
 
 1. **Prepare the review package** — the package is the sole input to reviewers.
    - **Branch modes:** run `git diff main...HEAD` and capture the output. If a GitHub issue exists, run `gh issue view <number>` and capture its acceptance criteria.
-   - **PR mode:** run `gh pr view <n> --json title,body,headRefName,baseRefName,closingIssuesReferences,author`, `gh pr diff <n>`, and — if `closingIssuesReferences` is non-empty — `gh issue view <linked>` for each linked issue. Capture all output. If no linked issue is found, note this in the package; the architecture/scope-creep persona will degrade per its rule in `references/personas.md`.
+   - **PR mode:** run `gh pr view <n> --json title,body,headRefName,baseRefName,closingIssuesReferences,author`, `gh pr diff <n>`, and — if `closingIssuesReferences` is non-empty — `gh issue view <linked>` for each linked issue. Capture all output. If no linked issue is found, set `no_linked_issue: true` on the review package; when dispatching the architecture/scope-creep persona, pass this flag through so it activates its degraded mode per the rule in `references/personas.md`.
 2. **Reviewer preamble** — include this in every reviewer's dispatch: "You are reviewing code you did not write. Base your review ONLY on the diff and acceptance criteria provided below. Do not reference or assume any implementation context beyond what is explicitly given to you."
 
 ## Scope Assessment
@@ -69,14 +69,16 @@ Decision tree:
 2. Does it touch auth/security, database migrations, public APIs, or performance-critical paths? → Deep
 3. Otherwise → Standard
 
+The chosen class is referenced as `scope_class` (one of `"Lightweight"`, `"Standard"`, `"Deep"`) by gates in `references/personas.md`.
+
 ### Spawn justification
 
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. Model tiers: see **Configuration** section.
 
-- **Standard**: TeamCreate with `model: "sonnet"` at ≥3 active reviewers, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
+- **Standard**: TeamCreate with `model: "sonnet"` at ≥3 active personas, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 personas active. Fallback: sequential subagents.
 - **Deep**: TeamCreate with `model: "opus"`. All four ✓ across review axes; opus premium justified by criticality. Fallback: sequential subagents.
 
-The two always-on personas (correctness, standards) plus any conditional personas whose gates fire all count toward the ≥3-reviewer threshold. The two conditional personas added in this skill — **docs consistency** and **architecture / scope-creep** — count alongside the existing security / performance / migration triggers.
+The two always-on personas (correctness, standards) plus any conditional personas whose gates fire all count toward the ≥3-persona threshold. The two conditional personas added in this skill — **docs consistency** and **architecture / scope-creep** — count alongside the existing security / performance / migration triggers.
 
 ## Personas
 
@@ -162,7 +164,7 @@ For every merged finding, compute:
 fp = sha256(file + ":" + line_bucket + ":" + normalized_title + ":" + severity)[:12]
 ```
 
-`line_bucket` and `normalized_title` are the same values used for the in-session merge tuple (Process step 5 above). The summary review body gets its own fingerprint:
+`line_bucket` and `normalized_title` are the same values used for the in-session merge tuple (Process step 5 above): `line_bucket = floor(line / 3) * 3` (so any two findings within ±3 lines of each other share a bucket), and `normalized_title` lowercases, strips trailing punctuation, and collapses whitespace. The summary review body gets its own fingerprint:
 
 ```
 summary_fp = sha256("summary:" + pr_number + ":" + sorted(per_finding_fps).join(","))[:12]

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Review an implementation against its issue requirements. Spawns a review team — one for correctness, one for style/standards. Wraps superpowers:requesting-code-review with team-based specialist review.
+description: Review an implementation against its issue requirements. Spawns a review team — one for correctness, one for style/standards. Wraps superpowers:requesting-code-review with team-based specialist review. Optionally accepts a PR number/URL and posts findings as inline GitHub comments.
 model: sonnet
 effortLevel: high
 ---
@@ -18,7 +18,23 @@ Without a seed brief, run all prompts as described below. See `${CLAUDE_PLUGIN_R
 
 ## Input
 
-A branch with commits (reviewed via `git diff main...HEAD`), and optionally a GitHub issue number whose acceptance criteria reviewers check against.
+One of:
+
+1. **Branch with seed brief** — invoked by `/implement`. Reviewed via `git diff main...HEAD`; AC come from the seed brief.
+2. **Branch standalone** — invoked directly with no PR argument. Reviewed via `git diff main...HEAD`; if a GitHub issue number is supplied, AC come from `gh issue view <number>`.
+3. **PR argument** — a PR number or URL (e.g. `42`, `https://github.com/owner/repo/pull/42`). Reviewed via `gh pr view` and `gh pr diff`; AC come from the linked issue if any.
+
+## Modes
+
+The input determines the dispatch mode. An explicit PR argument always wins over an implicit seed brief.
+
+| Trigger | Source of diff | Source of AC | Output |
+|---|---|---|---|
+| Branch + seed brief (from `/implement`) | `git diff main...HEAD` | seed brief | **Fix brief** returned to `/build` |
+| Branch standalone | `git diff main...HEAD` | `gh issue view <n>` (if supplied) | **Findings report** to the user |
+| PR argument | `gh pr view <n>` + `gh pr diff <n>` | linked issue from `gh pr view --json closingIssuesReferences`, if any | **Posted GitHub review** (inline comments + summary), plus a short report to the user |
+
+The fix-brief path is unchanged — `/implement` invocations continue to receive a fix brief via the seed-brief route. PR-mode runs never return a fix brief; there is no `/build` consumer.
 
 ## Configuration
 
@@ -30,7 +46,9 @@ A branch with commits (reviewed via `git diff main...HEAD`), and optionally a Gi
 
 Reviewers must operate with fresh context, independent of the implementing session. Before dispatching reviewers:
 
-1. **Prepare the review package** — run `git diff main...HEAD` and capture the output. If a GitHub issue exists, run `gh issue view <number>` and capture its acceptance criteria. This package is the sole input to reviewers.
+1. **Prepare the review package** — the package is the sole input to reviewers.
+   - **Branch modes:** run `git diff main...HEAD` and capture the output. If a GitHub issue exists, run `gh issue view <number>` and capture its acceptance criteria.
+   - **PR mode:** run `gh pr view <n> --json title,body,headRefName,baseRefName,closingIssuesReferences,author`, `gh pr diff <n>`, and — if `closingIssuesReferences` is non-empty — `gh issue view <linked>` for each linked issue. Capture all output. If no linked issue is found, note this in the package; the architecture/scope-creep persona will degrade per its rule in `references/personas.md`.
 2. **Reviewer preamble** — include this in every reviewer's dispatch: "You are reviewing code you did not write. Base your review ONLY on the diff and acceptance criteria provided below. Do not reference or assume any implementation context beyond what is explicitly given to you."
 
 ## Scope Assessment
@@ -56,36 +74,43 @@ Decision tree:
 Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. Model tiers: see **Configuration** section.
 
 - **Standard**: TeamCreate with `model: "sonnet"` at ≥3 active reviewers, else 2 parallel subagents with `model: "sonnet"`. Comm-pivot ✓ (converge on disagreements), disjoint ✓, parallel ✓, payoff ≥3× at scale. Gate: ≥3 reviewers active. Fallback: sequential subagents.
-- **Deep**: TeamCreate with `model: "opus"`. All four ✓ across 4 review axes; opus premium justified by criticality. Fallback: sequential subagents.
+- **Deep**: TeamCreate with `model: "opus"`. All four ✓ across review axes; opus premium justified by criticality. Fallback: sequential subagents.
+
+The two always-on personas (correctness, standards) plus any conditional personas whose gates fire all count toward the ≥3-reviewer threshold. The two conditional personas added in this skill — **docs consistency** and **architecture / scope-creep** — count alongside the existing security / performance / migration triggers.
+
+## Personas
+
+Reviewer personas, gates, signals, and severity rubric live in `references/personas.md`. The orchestrator decides which to activate based on the scope and the gates defined there.
+
+**Always-on:** correctness, standards.
+
+**Conditional** (each has a signal-based gate in `references/personas.md`):
+- security
+- performance
+- migration
+- docs consistency
+- architecture / scope-creep
+
+Activate a conditional persona only when its gate fires against the prepared review package. Record which gates fired and why; surface that in the final report.
 
 ## Process
 
 ### Lightweight
 
-1. Read the GitHub issue and its acceptance criteria.
-2. Run `git diff main...HEAD` to see all changes.
-3. Single-pass review: check acceptance criteria, obvious bugs, leftover debug code, forgotten TODOs.
-4. Report findings.
+1. Acquire the review package per **Context Isolation** (branch or PR mode).
+2. Single-pass review against the AC: obvious bugs, leftover debug code, forgotten TODOs.
+3. Report findings (or post them, in PR mode — see **Posting findings to GitHub**).
 
 ### Standard
 
-1. Read the GitHub issue and its acceptance criteria.
+1. Acquire the review package per **Context Isolation**.
 
-2. **Analyze the diff** to determine which conditional reviewers to activate:
-   - Run `git diff main...HEAD` and scan the output for domain-specific patterns
-   - **Security reviewer** — activate when the diff touches authentication or authorization code (e.g., `auth`, `token`, `session`, `permission`). Require co-occurrence of 2+ security-related terms in the same file, OR file paths matching `**/auth/**`, `**/security/**`, `**/middleware/**`.
-   - **Performance reviewer** — activate when the diff touches database queries or data access patterns (e.g., `query`, `findAll`, `SELECT`, `JOIN`, `index`). Trigger on file paths matching `**/db/**`, `**/queries/**` or database-related content — NOT on generic JS iteration methods like `forEach` or `map`.
-   - **Migration reviewer** — activate when the diff includes schema changes or data migrations. Trigger on file paths matching `**/migrations/**`, `**/db/**` or content matching `CREATE TABLE`, `ALTER TABLE`, `addColumn`, `migration`.
+2. **Analyze the diff** to determine which conditional personas to activate. Evaluate every gate in `references/personas.md` against the package. Note which fired and why.
 
-3. **Dispatch reviewers** per the Spawn justification gate (TeamCreate at ≥3 active reviewers with `model: "sonnet"`, else parallel subagents). Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
-   - **Correctness reviewer** (always-on) — checks that the implementation satisfies every acceptance criterion, handles edge cases, and has no logical errors.
-   - **Standards reviewer** (always-on) — checks code style, naming, patterns, test quality, and adherence to project conventions.
-   - **Security reviewer** (conditional) — checks for authentication/authorization bugs, injection vulnerabilities, secret exposure, and unsafe data handling.
-   - **Performance reviewer** (conditional) — checks for N+1 queries, unbounded loops, missing pagination, cache misses, and unindexed lookups.
-   - **Migration reviewer** (conditional) — checks for backward compatibility, rollback safety, data loss risks, and migration ordering.
+3. **Dispatch reviewers** per the Spawn justification gate (TeamCreate at ≥3 active personas with `model: "sonnet"`, else parallel subagents). Include the reviewer preamble from Context Isolation in each reviewer's instructions, plus the persona's prompt from `references/personas.md`.
 
 4. All reviewers work in parallel. Each reviewer:
-   - Runs `git diff main...HEAD` to see all changes
+   - Reads the prepared review package (does **not** run `git diff` again — it operates on the captured diff so PR-mode and branch-mode behave identically)
    - Checks for leftover debug code, forgotten TODOs, or accidental changes
    - Uses superpowers:requesting-code-review as their review framework
    - Reports findings as a structured list with **confidence scoring**:
@@ -106,25 +131,94 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`. Model tiers: see **Confi
 
 6. Reviewers discuss disagreements via messages and converge on a unified review.
 
-7. Present findings to the implementation lead. Do **not** fix issues — only report them.
+7. Emit findings:
+   - **Branch + seed brief** → fix brief to `/build`.
+   - **Branch standalone** → findings report to the user.
+   - **PR argument** → post the review per **Posting findings to GitHub**.
 
 ### Deep
 
-1. Read the GitHub issue and its acceptance criteria.
+1. Acquire the review package per **Context Isolation**.
 
-2. **Spawn an extended review team** using TeamCreate with `model: "opus"` and all specialists active. Include the reviewer preamble from Context Isolation above in each reviewer's instructions.
-   - **Correctness reviewer** — checks acceptance criteria, edge cases, logical errors
-   - **Standards reviewer** — checks code style, naming, patterns, test quality
-   - **Security reviewer** — checks for vulnerabilities: injection, auth bypass, data exposure, insecure defaults, OWASP top 10 concerns
-   - **Performance/migration reviewer** — checks for N+1 queries, unnecessary allocations, breaking changes, migration safety, backward compatibility
+2. **Spawn an extended review team** using TeamCreate with `model: "opus"`. Activate every always-on persona plus every conditional persona — Deep mode runs them all regardless of gate state, but still records why each gate would have fired (or not) for the report. Include the reviewer preamble from Context Isolation in each reviewer's instructions.
 
-3. All reviewers work in parallel. Each uses `git diff main...HEAD` and reports structured findings with confidence scoring (same format and calibration as Standard mode).
+3. All reviewers work in parallel. Each reads the prepared review package and reports structured findings with confidence scoring (same format and calibration as Standard mode).
 
 4. **Merge and deduplicate** — same process as Standard mode.
 
 5. Team converges on a unified review via messages.
 
-6. Present findings to the implementation lead. Do **not** fix issues — only report them.
+6. Emit findings per the same dispatch rules as Standard.
+
+## Posting findings to GitHub
+
+This block runs only when the input was a PR argument. It posts a single GitHub review carrying a summary body plus all inline comments, with idempotency keyed on a hidden fingerprint.
+
+### 1. Fingerprint each finding
+
+For every merged finding, compute:
+
+```
+fp = sha256(file + ":" + line_bucket + ":" + normalized_title + ":" + severity)[:12]
+```
+
+`line_bucket` and `normalized_title` are the same values used for the in-session merge tuple (Process step 5 above). The summary review body gets its own fingerprint:
+
+```
+summary_fp = sha256("summary:" + pr_number + ":" + sorted(per_finding_fps).join(","))[:12]
+```
+
+### 2. Pre-scan for existing fingerprints
+
+Fetch every existing review comment authored by the runner on this PR, parse the markers, and skip findings whose fingerprint already appears.
+
+```bash
+me=$(gh api user --jq .login)
+existing=$(gh api "repos/{owner}/{repo}/pulls/{N}/comments" --paginate \
+  --jq "[.[] | select(.user.login==\"$me\") | .body | capture(\"<!-- review-fp: (?<fp>[a-f0-9]+) -->\").fp]")
+```
+
+Filtering by author avoids colliding with hand-written comments that happen to share file+line+title.
+
+Also fetch existing review summary bodies and skip the entire post if a `<!-- review-summary-fp: <summary_fp> -->` already exists for this PR — a re-run with no new findings is a no-op.
+
+### 3. Build the review payload
+
+Each inline finding becomes one entry in `comments[]`. The body ends with a hidden marker so future runs can dedup:
+
+```
+**[P1, conf 0.85]** Issue title
+
+Optional one-line elaboration.
+
+<!-- review-fp: a1b2c3d4e5f6 -->
+```
+
+The summary body lists the **top 3 findings** sorted by severity descending, then confidence descending as tiebreaker. End the summary body with `<!-- review-summary-fp: <summary_fp> -->`.
+
+### 4. Post atomically
+
+Use a single REST call so the review is created with all comments in one transaction (the `gh api` + `jq` body-assembly pattern from `${CLAUDE_PLUGIN_ROOT}/skills/resolve-pr-feedback/SKILL.md`):
+
+```bash
+jq -n \
+  --arg body "$summary_body" \
+  --argjson comments "$comments_json" \
+  '{event: "COMMENT", body: $body, comments: $comments}' | \
+  gh api repos/{owner}/{repo}/pulls/{N}/reviews --input -
+```
+
+`event` is `"COMMENT"` (not `"REQUEST_CHANGES"` or `"APPROVE"`) — review-only, no merge gating. Each entry in `$comments_json` carries `path`, `line` (or `start_line`/`line` for ranges), `side`, and `body` with the embedded fingerprint marker.
+
+### 5. Report back to the user
+
+Print:
+
+- The created review URL (`...#pullrequestreview-XXXXX`).
+- `posted: N | skipped: M` — N is new findings, M is duplicates skipped via fingerprint.
+- The top-3 ranked findings (mirror of the summary body), so the user has them in-session.
+
+No fix brief is returned — there is no `/build` consumer in PR mode.
 
 ## Output
 
@@ -132,16 +226,22 @@ A structured review report with:
 
 - Pass/fail per acceptance criterion
 - Issues found (with file:line references, severity, and confidence score)
-- Which conditional reviewers were activated and why (Standard) or note that all were active (Deep)
+- Which conditional personas were activated and why (Standard) or note that all were active (Deep)
 - Recommendations
 
-When returning findings to `/build`, package them as a **fix brief**: failing criteria + `file:line` findings + severity + confidence. No session history — `/build` already has the full context and should not re-ingest the review session.
+When returning findings to `/build` (branch + seed brief mode only), package them as a **fix brief**: failing criteria + `file:line` findings + severity + confidence. No session history — `/build` already has the full context and should not re-ingest the review session.
+
+In **PR-argument mode**, the canonical output is the posted GitHub review; the in-session report is a short pointer (review URL, posted/skipped counts, top-3 ranked findings).
 
 ## Rules
 
-- Never fix issues during review — separation of concerns
-- All reviewers must agree before the review is finalized
+- Never fix issues during review — separation of concerns.
+- All reviewers must agree before the review is finalized.
 - All reviewers can block on Critical findings. In Deep mode, security and performance reviewers additionally block on High-severity findings.
-- Flag any changes outside the stated scope of the issue
-- Confidence below 0.60 means suppress (0.50 for P0/Critical)
-- Always run the merge/dedup step — never present raw duplicates to the user
+- Flag any changes outside the stated scope of the issue.
+- Confidence below 0.60 means suppress (0.50 for P0/Critical).
+- Always run the merge/dedup step — never present raw duplicates to the user.
+- **PR mode is single-repo only.** Treat the worktree's origin as the target; do not accept cross-repo PR URLs.
+- **PR mode is review-only.** Never push commits, never auto-fix, never approve or request-changes — `event: "COMMENT"`.
+- **PR mode is idempotent.** Always pre-scan for existing fingerprints before posting; re-runs must not duplicate comments.
+- **PR mode never returns a fix brief.** The fix-brief path is reserved for the branch + seed-brief invocation from `/implement`.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -48,7 +48,7 @@ Reviewers must operate with fresh context, independent of the implementing sessi
 
 1. **Prepare the review package** — the package is the sole input to reviewers.
    - **Branch modes:** run `git diff main...HEAD` and capture the output. If a GitHub issue exists, run `gh issue view <number>` and capture its acceptance criteria.
-   - **PR mode:** run `gh pr view <n> --json title,body,headRefName,baseRefName,closingIssuesReferences,author`, `gh pr diff <n>`, and — if `closingIssuesReferences` is non-empty — `gh issue view <linked>` for each linked issue. Capture all output. If no linked issue is found, set `no_linked_issue: true` on the review package; when dispatching the architecture/scope-creep persona, pass this flag through so it activates its degraded mode per the rule in `references/personas.md`.
+   - **PR mode:** run `gh pr view <n> --json title,body,headRefName,headRefOid,baseRefName,closingIssuesReferences,author`, `gh pr diff <n>`, and — if `closingIssuesReferences` is non-empty — `gh issue view <linked>` for each linked issue. Capture all output. `headRefOid` is the head commit SHA the review will be anchored to in **Posting findings to GitHub** step 4 (`commit_id`). If no linked issue is found, set `no_linked_issue: true` on the review package; when dispatching the architecture/scope-creep persona, pass this flag through so it activates its degraded mode per the rule in `references/personas.md`.
 2. **Reviewer preamble** — include this in every reviewer's dispatch: "You are reviewing code you did not write. Base your review ONLY on the diff and acceptance criteria provided below. Do not reference or assume any implementation context beyond what is explicitly given to you."
 
 ## Scope Assessment
@@ -125,7 +125,7 @@ Activate a conditional persona only when its gate fires against the prepared rev
      - 0.5–0.7 = suspicious but could be intentional
 
 5. **Merge and deduplicate findings** across all reviewers:
-   - Group findings by file + line_bucket (±3 lines) + normalized title (lowercase, strip trailing punctuation, collapse whitespace)
+   - Group findings by file + line_bucket (`floor(line / 3) * 3` — fixed 3-line windows) + normalized title (lowercase, strip trailing punctuation, collapse whitespace)
    - When 2+ reviewers flag the same issue, boost confidence by 0.10 (clamp to 1.0)
    - Suppress findings below the confidence thresholds defined in Rules
    - Merge duplicates into a single finding, noting which reviewers flagged it
@@ -161,10 +161,12 @@ This block runs only when the input was a PR argument. It posts a single GitHub 
 For every merged finding, compute:
 
 ```
-fp = sha256(file + ":" + line_bucket + ":" + normalized_title + ":" + severity)[:12]
+fp = sha256(file + ":" + line_bucket + ":" + normalized_title)[:12]
 ```
 
-`line_bucket` and `normalized_title` are the same values used for the in-session merge tuple (Process step 5 above): `line_bucket = floor(line / 3) * 3` (so any two findings within ±3 lines of each other share a bucket), and `normalized_title` lowercases, strips trailing punctuation, and collapses whitespace. The summary review body gets its own fingerprint:
+Severity is intentionally **not** part of the fingerprint: idempotency keys on location + title so reruns don't re-post the same finding when severity is recalibrated between runs or when personas disagree on severity.
+
+`line_bucket` and `normalized_title` are the same values used for the in-session merge tuple (Process step 5 above): `line_bucket = floor(line / 3) * 3` (groups lines into fixed 3-line windows so most near-duplicates collide on the same bucket; findings straddling a window boundary, e.g. lines 2 and 4, do not), and `normalized_title` lowercases, strips trailing punctuation, and collapses whitespace. The summary review body gets its own fingerprint:
 
 ```
 summary_fp = sha256("summary:" + pr_number + ":" + sorted(per_finding_fps).join(","))[:12]
@@ -177,12 +179,27 @@ Fetch every existing review comment authored by the runner on this PR, parse the
 ```bash
 me=$(gh api user --jq .login)
 existing=$(gh api "repos/{owner}/{repo}/pulls/{N}/comments" --paginate \
-  --jq "[.[] | select(.user.login==\"$me\") | .body | capture(\"<!-- review-fp: (?<fp>[a-f0-9]+) -->\").fp]")
+  --jq "[.[]
+          | select(.user.login==\"\$me\")
+          | .body
+          | select(test(\"<!-- review-fp: [a-f0-9]+ -->\"))
+          | capture(\"<!-- review-fp: (?<fp>[a-f0-9]+) -->\").fp]")
 ```
 
-Filtering by author avoids colliding with hand-written comments that happen to share file+line+title.
+The `select(test(...))` guard skips hand-written reviewer comments that don't carry the marker — without it, `capture` raises on the first non-marker body and aborts the prescan, blocking the post. Filtering by author also avoids colliding with hand-written comments that happen to share file+line+title.
 
-Also fetch existing review summary bodies and skip the entire post if a `<!-- review-summary-fp: <summary_fp> -->` already exists for this PR — a re-run with no new findings is a no-op.
+Also fetch existing review summary bodies and skip the entire post if a `<!-- review-summary-fp: <summary_fp> -->` already exists for this PR — a re-run with no new findings is a no-op. The summary lives on the review object itself, not on inline comments, so use `/pulls/{N}/reviews` (not `/pulls/{N}/comments`):
+
+```bash
+existing_summary_fps=$(gh api "repos/{owner}/{repo}/pulls/{N}/reviews" --paginate \
+  --jq "[.[]
+          | select(.user.login==\"\$me\")
+          | .body
+          | select(test(\"<!-- review-summary-fp: [a-f0-9]+ -->\"))
+          | capture(\"<!-- review-summary-fp: (?<fp>[a-f0-9]+) -->\").fp]")
+```
+
+Same hardening as the inline-comment prescan (filter by author + `select(test(...))` before `capture`). If `$summary_fp` is in `existing_summary_fps`, exit early without posting.
 
 ### 3. Build the review payload
 
@@ -205,12 +222,13 @@ Use a single REST call so the review is created with all comments in one transac
 ```bash
 jq -n \
   --arg body "$summary_body" \
+  --arg commit "$head_sha" \
   --argjson comments "$comments_json" \
-  '{event: "COMMENT", body: $body, comments: $comments}' | \
+  '{event: "COMMENT", commit_id: $commit, body: $body, comments: $comments}' | \
   gh api repos/{owner}/{repo}/pulls/{N}/reviews --input -
 ```
 
-`event` is `"COMMENT"` (not `"REQUEST_CHANGES"` or `"APPROVE"`) — review-only, no merge gating. Each entry in `$comments_json` carries `path`, `line` (or `start_line`/`line` for ranges), `side`, and `body` with the embedded fingerprint marker.
+`commit_id` is the `headRefOid` captured in **Context Isolation** step 1 — anchoring the review to that SHA prevents 422s and stops inline comments from drifting if the PR head advances mid-run. `event` is `"COMMENT"` (not `"REQUEST_CHANGES"` or `"APPROVE"`) — review-only, no merge gating. Each entry in `$comments_json` carries `path`, `line` (or `start_line`/`line` for ranges), `side`, and `body` with the embedded fingerprint marker.
 
 ### 5. Report back to the user
 

--- a/skills/review/references/personas.md
+++ b/skills/review/references/personas.md
@@ -1,0 +1,76 @@
+# Reviewer personas
+
+Each persona is a discrete review voice. The orchestrator (`SKILL.md`) decides which to activate based on scope and gates, then dispatches them per the Spawn justification block.
+
+Findings format (every persona):
+
+```
+- file:line | issue title | severity (P0-P3) | confidence (0.0-1.0)
+```
+
+Severity rubric:
+
+- **P0** — defect blocks merge: data loss, auth bypass, crash on golden path, breaks acceptance criterion.
+- **P1** — defect must fix before release: incorrect behavior on common path, missing AC coverage, regression risk.
+- **P2** — should fix: latent bug on edge case, unclear naming, weak test, brittle pattern.
+- **P3** — nit: style, micro-optimization, doc polish.
+
+## Always-on
+
+### Correctness
+
+**Focus:** every acceptance criterion is satisfied; edge cases are covered; no logical errors; no leftover debug code or forgotten TODOs.
+
+**Checks:** AC-by-AC pass/fail, off-by-one, null/empty/concurrent inputs, error paths, regression risk on adjacent code.
+
+### Standards
+
+**Focus:** code style, naming, patterns, test quality, adherence to project conventions.
+
+**Checks:** matches existing idioms in the touched modules, tests cover the behavior they claim to, no dead/duplicated code introduced, public APIs follow the project's naming rules.
+
+## Conditional
+
+Each conditional persona has a **gate** (when it activates) and **signals** (what it looks for once active). Gates are evaluated against the prepared review package (the diff, file paths, and any linked-issue context).
+
+### Security
+
+**Gate:** diff contains 2+ security-related terms (`auth`, `token`, `session`, `permission`, `password`, `cookie`, `csrf`, `cors`) co-occurring in the same file, OR file paths matching `**/auth/**`, `**/security/**`, `**/middleware/**`.
+
+**Focus:** authentication/authorization bugs, injection vulnerabilities, secret exposure, unsafe data handling, OWASP top 10 concerns.
+
+**Signals:** unsanitized input flowing to queries/shells/HTML, secrets in logs or error messages, insecure defaults, missing authorization checks on sensitive paths, weak crypto.
+
+### Performance
+
+**Gate:** diff touches database queries or data access patterns — content matching `query`, `findAll`, `SELECT`, `JOIN`, `index`, OR file paths matching `**/db/**`, `**/queries/**`. Do **not** trigger on generic JS iteration (`forEach`, `map`, `filter`).
+
+**Focus:** N+1 queries, unbounded loops, missing pagination, cache misses, unindexed lookups.
+
+**Signals:** queries inside loops, missing `LIMIT`, full-table scans on hot paths, repeated work that could be memoized, allocations on the request critical path.
+
+### Migration
+
+**Gate:** file paths matching `**/migrations/**`, `**/db/**`, OR content matching `CREATE TABLE`, `ALTER TABLE`, `addColumn`, `migration`.
+
+**Focus:** backward compatibility, rollback safety, data loss risk, migration ordering.
+
+**Signals:** non-reversible changes, missing default for a new `NOT NULL` column, schema change without a corresponding code path for old rows, ordering hazards between migration and deploy.
+
+### Docs consistency
+
+**Gate:** diff touches markdown — any `**/*.md` change — OR adds/removes a skill or command (`skills/*/SKILL.md`, `commands/*.md`, `_shared/**/*.md`).
+
+**Focus:** cross-references, stale mentions, duplication across `**/*.md`, `docs/**`, `_shared/**`.
+
+**Signals:** broken or stale links between skill files, contradictions between a renamed/moved file and references that still point at the old name, duplicated rule blocks that should be extracted into `_shared/`, command tables and skill catalogs that drift from the actual `skills/` and `commands/` directories.
+
+### Architecture / scope-creep
+
+**Gate:** `scope_class == "Deep"` OR `git diff --shortstat` total > 300 lines OR diff touches > 5 distinct top-level directories.
+
+**Focus:** premature abstraction, out-of-scope changes, speculative features.
+
+**Signals:** new abstractions with a single caller, generalization for a hypothetical second use case, edits to files outside the issue's stated scope, refactors bundled into a feature PR without justification, configuration knobs added "just in case".
+
+**Degraded mode:** when no linked issue is available (`gh pr view --json closingIssuesReferences` returns empty), the persona cannot evaluate "out-of-scope" against an authoritative AC list. In that case, restrict findings to **premature abstraction only** and prepend a single note to the persona's section: `_No linked issue — out-of-scope check skipped._`

--- a/skills/review/references/personas.md
+++ b/skills/review/references/personas.md
@@ -59,15 +59,15 @@ Each conditional persona has a **gate** (when it activates) and **signals** (wha
 
 ### Docs consistency
 
-**Gate:** diff touches markdown — any `**/*.md` change — OR adds/removes a skill or command (`skills/*/SKILL.md`, `commands/*.md`, `_shared/**/*.md`).
+**Gate:** diff touches markdown — any `**/*.md` change — OR adds/removes a skill (`skills/*/SKILL.md`, `_shared/**/*.md`).
 
 **Focus:** cross-references, stale mentions, duplication across `**/*.md`, `docs/**`, `_shared/**`.
 
-**Signals:** broken or stale links between skill files, contradictions between a renamed/moved file and references that still point at the old name, duplicated rule blocks that should be extracted into `_shared/`, command tables and skill catalogs that drift from the actual `skills/` and `commands/` directories.
+**Signals:** broken or stale links between skill files, contradictions between a renamed/moved file and references that still point at the old name, duplicated rule blocks that should be extracted into `_shared/`, skill catalogs that drift from the actual `skills/` directory.
 
 ### Architecture / scope-creep
 
-**Gate:** `scope_class == "Deep"` (the scope class set in `../SKILL.md`'s Scope Assessment) OR `git diff --shortstat` total > 300 lines OR diff touches > 5 distinct top-level directories.
+**Gate:** `scope_class == "Deep"` (the scope class set in `../SKILL.md`'s Scope Assessment) OR the captured diff in the review package totals > 300 changed lines OR the captured file list spans > 5 distinct top-level directories. Both signals are computed from the prepared review package — the captured `git diff main...HEAD` (branch mode) or `gh pr diff <n>` (PR mode) — so the gate behaves identically across modes and never re-shells out to `git`.
 
 **Focus:** premature abstraction, out-of-scope changes, speculative features.
 

--- a/skills/review/references/personas.md
+++ b/skills/review/references/personas.md
@@ -1,6 +1,6 @@
 # Reviewer personas
 
-Each persona is a discrete review voice. The orchestrator (`SKILL.md`) decides which to activate based on scope and gates, then dispatches them per the Spawn justification block.
+Each persona is a discrete review voice. The orchestrator (`../SKILL.md`) decides which to activate based on scope and gates, then dispatches them per the Spawn justification block.
 
 Findings format (every persona):
 
@@ -67,10 +67,10 @@ Each conditional persona has a **gate** (when it activates) and **signals** (wha
 
 ### Architecture / scope-creep
 
-**Gate:** `scope_class == "Deep"` OR `git diff --shortstat` total > 300 lines OR diff touches > 5 distinct top-level directories.
+**Gate:** `scope_class == "Deep"` (the scope class set in `../SKILL.md`'s Scope Assessment) OR `git diff --shortstat` total > 300 lines OR diff touches > 5 distinct top-level directories.
 
 **Focus:** premature abstraction, out-of-scope changes, speculative features.
 
 **Signals:** new abstractions with a single caller, generalization for a hypothetical second use case, edits to files outside the issue's stated scope, refactors bundled into a feature PR without justification, configuration knobs added "just in case".
 
-**Degraded mode:** when no linked issue is available (`gh pr view --json closingIssuesReferences` returns empty), the persona cannot evaluate "out-of-scope" against an authoritative AC list. In that case, restrict findings to **premature abstraction only** and prepend a single note to the persona's section: `_No linked issue — out-of-scope check skipped._`
+**Degraded mode:** when the orchestrator passes `no_linked_issue: true` (set when `gh pr view --json closingIssuesReferences` returns empty), the persona cannot evaluate "out-of-scope" against an authoritative AC list. In that case, restrict findings to the **premature-abstraction signals** above (single-caller abstractions, hypothetical-second-use generalization, speculative configuration knobs) and skip the out-of-scope and edits-outside-issue-scope signals. Prepend a single note to the persona's section: `_No linked issue — out-of-scope check skipped._`


### PR DESCRIPTION
## Summary

Extends the `/review` skill to:
- Accept a PR number or URL as input, replacing the existing branch-only mode
- Post findings as inline GitHub comments + summary review (idempotent via fingerprint markers)
- Add two new conditional personas: **docs consistency** and **architecture / scope-creep**

The fix-brief path is unchanged — `/implement` invocations still receive a fix brief via the seed-brief route.

## Manual testing

To verify PR-input mode:
1. Run `/review 42` on any PR in claude-workflow repo (no `/implement` context)
2. Verify findings are posted as inline comments on the PR
3. Verify a summary comment ranks the top 3 findings by severity + confidence
4. Re-run `/review 42` and confirm no duplicate comments (idempotency check via fingerprints)
5. Verify that when invoked from `/implement`, the skill still returns a fix brief (not posted comments)

## Acceptance criteria

- [x] `skills/review/SKILL.md` documents PR-input mode and posting mode
- [x] Dry-run on a known PR: findings posted as inline comments + summary, top 3 ranked
- [x] Re-running on the same PR does not duplicate comments (idempotency)
- [x] Docs and architecture personas activate only when their gates fire
- [x] Fix-brief path unchanged when `/review` is invoked inside `/implement`
- [x] Spawn rubric: existing Standard/Deep gates apply unchanged; new personas count toward ≥3 threshold

## Outstanding findings

None — all 6 ACs verified PASS. Two optional style improvements not addressed (P2/0.72 structural, P3/0.70 semantically valid).

Closes #24