### PR TITLE
feat: epic-autopilot skill — autonomous epic-to-PR pipeline

### DIFF
--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -144,6 +144,7 @@ Orchestrators may nest: `/discovery` delegates to `/describe` and `/specify`; `/
 - Maximum two levels of orchestration. Deeper nesting creates brittle context chains.
 - Each level owns its own handoff boundary — do not skip levels.
 - Sub-orchestrators do not inherit the parent's handoff artifact. Seed them with a brief.
+- Task sub-agents are fresh roots; the 2-level cap applies within each sub-agent's lineage, not across the parent's spawn graph.
 
 ## Handoff vs. seed brief
 

--- a/_shared/specialist-mode.md
+++ b/_shared/specialist-mode.md
@@ -25,6 +25,7 @@ scope_class: Lightweight|Standard|Deep
 repo: owner/repo
 branch: feat/branch-name
 active_issue: 42
+autonomous: false  # optional — see field table below
 payload:
   type: fix|research|prior-art
   # type-specific fields per _shared/composition.md
@@ -43,6 +44,7 @@ The XML tag marks the boundary; the YAML is parseable without a fence. The `payl
 | `branch` | string | yes | `feat/<slug>` — verified against `git rev-parse --abbrev-ref HEAD` |
 | `active_issue` | integer | yes | Ties the brief to its GitHub issue |
 | `payload` | object | yes | `{ type: fix|research|prior-art, ... }` — type-specific fields per `_shared/composition.md` |
+| `autonomous` | boolean | no | Default `false`. When `true`, suppresses `/implement`'s exhausted-exit prompt; only consumed by `/implement`. Do not set from non-autopilot orchestrators — default `false` preserves the rigor gate. |
 
 When verification fails (wrong repo, wrong branch, missing required field), the specialist rejects the brief and falls back to standalone behavior with full prompts. Log which check failed.
 
@@ -59,6 +61,7 @@ Confirmations that verify *state* are skipped when seeded; confirmations that dr
 | `/specify` | scope-class + file-scope confirmation | AC derivation gates |
 | `/architecture` | codebase-research / patterns-research subagent dispatches | architecture session (grill-me + devil's advocate) |
 | `/design` | design-space research subagents | interactive design session |
+| `/implement` | _(none — orchestrator role; preflights run at entry)_ | exhausted-exit prompt (rigor gate — suppressed only when `autonomous: true` in seed brief) |
 
 Each specialist documents a "Specialist mode" subsection in its own SKILL.md naming which prompts it skips.
 

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -29,11 +29,7 @@ Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 
 ### Stage 0 — Resume detection
 
-On every invocation, read the epic issue body first. Detect prior phase completion from markers:
-
-- `## Implementation plan` present in body → /discovery and epic-level /define already done. Jump to **Stage 3** (per-sub-issue /define) for any sub-issues not yet defined, or to **Stage 4** (autonomous phase) if all sub-issues have a linked PR or branch (per resume logic in Stage 4).
-- `## Requirements` present but no `## Implementation plan` → /discovery done, epic /define needed. Jump to **Stage 2**.
-- Neither present (or free-text input) → start from **Stage 1**.
+On every invocation, read the epic issue body and any sub-issue bodies first; consult the **Resume logic** table at the bottom of this skill to decide which stage to enter.
 
 ### Stage 1 — Discovery gate
 
@@ -135,25 +131,18 @@ The PR base for the sub-task is **not** carried in the brief — it is communica
 
 3. Wait for all sub-agents in the tier to settle before dispatching the next tier.
 
-#### 4d. Sub-task failure handling
+#### 4d. Sub-task settlement and failure handling
 
-Each sub-agent runs `/implement` end-to-end and attempts to open a draft PR. If a sub-agent **aborts** (returns an error or fails to open a PR):
+Each sub-agent runs `/implement` end-to-end and attempts to open a draft PR. The `autonomous: true` flag in the seed brief suppresses `/implement`'s exhausted-exit prompt, so a draft PR (even exhausted-accepted with findings) settles successfully.
 
-- **Attempt 1**: retry the sub-agent once with the same seed brief.
-  - Emit: `[sub-issue #<M>] RETRYING (attempt 2/2)`
-- **Attempt 2**: if the retry also aborts, mark the sub-task FAILED and continue sibling sub-tasks.
-  - Emit: `[sub-issue #<M>] FAILED — second retry exhausted`
-
-A sub-task that produces a draft PR (even exhausted-accepted with findings) is considered settled successfully. The `/implement` `autonomous: true` flag ensures no prompt is emitted even on exhausted exit.
-
-#### 4e. Settlement status lines
-
-For each sub-task that settles (after awaiting its Task sub-agent):
+After each sub-task settles, emit one status line:
 - Clean exit: `[sub-issue #<M>] PR opened: <url> (cycles:<N>)`
 - Exhausted-accepted: `[sub-issue #<M>] PR opened: <url> (cycles:3 [exhausted-accepted])`
 - FAILED: `[sub-issue #<M>] FAILED — second retry exhausted`
 
-#### 4f. Epic PR creation
+If a sub-agent **aborts** (returns an error or fails to open a PR), retry exactly once with the same seed brief (emit `[sub-issue #<M>] RETRYING (attempt 2/2)`); if the retry also aborts, mark FAILED and continue sibling sub-tasks.
+
+#### 4e. Epic PR creation
 
 After every sub-task across all tiers has settled (PR open or FAILED):
 
@@ -214,15 +203,9 @@ A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be 
 ## Rules
 
 - Require explicit user approval at each gate (Stage 1, Stage 2, and each Stage 3 sub-issue). Silence is not approval.
-- Autonomous phase (Stage 4 onward) emits no human prompts. The only output is status lines and, at exit, the PR summary.
 - The user must not modify the epic issue body or any sub-issue body during Stage 4. Sub-agents read at spawn time and do not re-fetch mid-run.
-- The epic branch (`feat/epic-<N>`) must be created and pushed before any sub-task spawns — this is non-negotiable.
 - Sub-issue branch and worktree names follow the pattern `feat/epic-<N>-sub-<M>` exactly. M is the GitHub sub-issue number (globally unique), so names are collision-safe across parallel spawns.
-- Each tier's sub-agents dispatch in a single message (parallel Task calls). Tier T+1 does not start until every tier-T agent has settled.
-- Sub-task retry policy: retry exactly once on abort; FAILED on second abort; siblings continue regardless.
-- `/implement` receives `autonomous: true` in its seed brief for all sub-tasks — this suppresses its exhausted-exit prompt and auto-accepts the PR. Do not pass `autonomous: true` outside sub-task spawns.
-- The multi-parent branch base is the parent with the lowest tier number (most foundational); if multiple parents share the lowest tier, the lowest-numbered sub-issue among them wins. Other parents are documented as manual merge steps in the sub-PR `## Notes`.
-- The epic PR body must include the sub-issue/sub-PR table, merge-order advisory, and `Closes #<N>`.
+- `autonomous: true` in the seed brief is reserved for sub-task spawns from this skill. Do not pass it from any other orchestrator — the default `false` preserves `/implement`'s exhausted-exit rigor gate.
 - `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the `autonomous` seed-brief field contract.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the orchestration-depth and Task sub-agent rules.

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -93,16 +93,18 @@ Read each sub-issue body's `## Implementation plan` to extract the dependency gr
 5. Ties within a tier: break by ascending sub-issue number.
 ```
 
-**Cycle handling**: if Kahn's algorithm detects a back-edge (cycle), identify the pair with the higher-numbered sub-issue and remove that back-edge. Log to stdout:
-```
-Cycle broken: removed dep #<higher> → #<lower>
-```
-Continue Kahn's on the acyclic graph.
+**Cycle handling**: Kahn's algorithm detects a cycle when the worklist of zero-in-degree nodes empties while one or more nodes still have non-zero in-degree (i.e., not every node has been emitted into a tier). When this happens, break a cycle deterministically:
+
+1. Among the remaining (non-zero in-degree) nodes, pick the **highest-numbered** sub-issue `H` — this is the dependent that will be detached.
+2. Among the dependencies declared by `H`, pick the **lowest-numbered** dependency `L`.
+3. Drop `H`'s `depends on #L` declaration (decrement `H`'s in-degree by one).
+4. Log to stdout: `Cycle broken: removed dep #<H> → #<L>` (where `→` reads as "depends on", matching how the relationship was declared in `H`'s `## Implementation plan`).
+5. Resume Kahn's on the modified graph. Repeat the cycle-break step if another cycle remains, until every node is assigned a tier.
 
 **Branch base per sub-issue**:
 - Tier-1 → base is `feat/epic-<N>`.
 - Single-parent sub-issue → base is that parent's branch (`feat/epic-<N>-sub-<parentM>`).
-- Multi-parent sub-issue → base is the parent with the lowest tier number (most foundational). Document remaining parents in the sub-PR `## Notes` as manual merge steps.
+- Multi-parent sub-issue → base is the parent with the lowest tier number (most foundational); if multiple parents share the lowest tier, break the tie by choosing the **lowest-numbered** sub-issue among them (matches the ascending-issue-number tie-break used in tier computation, so base selection is deterministic across runs). Document remaining parents in the sub-PR `## Notes` as manual merge steps.
 
 #### 4c. Parallel Task dispatch — per tier
 
@@ -111,8 +113,8 @@ For each tier, in ascending tier order:
 1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
 2. Dispatch all sub-tasks in the current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M in the tier:
    - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
-   - Create the worktree and branch: `git worktree add .worktrees/feat/epic-<N>-sub-<M> feat/epic-<N>-sub-<M> --track origin/<base-branch>` (or create branch if not yet on remote, branching from the base computed in 4b).
-   - Pass the following seed brief to the sub-agent's `/implement` invocation:
+   - Create the worktree and branch from the base computed in 4b, with upstream tracking set so `/implement` can resolve the PR base later: `git worktree add .worktrees/feat/epic-<N>-sub-<M> -b feat/epic-<N>-sub-<M> <base-branch>`, then in the worktree run `git branch --set-upstream-to=origin/<base-branch>` (or push and `--track`-equivalent — the upstream must reflect the base, not `main`).
+   - Pass the following seed brief to the sub-agent's `/implement` invocation. Fields under `payload` follow the canonical **research brief** in `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` — only the fields epic-autopilot can populate are emitted; the others are intentionally omitted (`/implement` reads the rest from the sub-issue body it loads at startup):
 
 ```
 <seed-brief>
@@ -124,10 +126,12 @@ active_issue: <M>
 autonomous: true
 payload:
   type: research
-  architectural_context: <summary of sub-issue #M's ## Implementation plan>
-  parent_branch: <base-branch>
+  prior_art: "Sub-issue #<M>'s ## Implementation plan in its issue body (architecture and design decisions from /define)"
+  open_questions: "<any unresolved constraints surfaced during /define for sub-issue #<M>, or empty>"
 </seed-brief>
 ```
+
+The PR base for the sub-task is **not** carried in the brief — it is communicated via the worktree's git upstream. `/implement` detects it with `git rev-parse --abbrev-ref --symbolic-full-name @{u}` and passes `--base <detected>` to `gh pr create`. This keeps the brief schema aligned with `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`'s research-brief contract.
 
 3. Wait for all sub-agents in the tier to settle before dispatching the next tier.
 
@@ -217,7 +221,7 @@ A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be 
 - Each tier's sub-agents dispatch in a single message (parallel Task calls). Tier T+1 does not start until every tier-T agent has settled.
 - Sub-task retry policy: retry exactly once on abort; FAILED on second abort; siblings continue regardless.
 - `/implement` receives `autonomous: true` in its seed brief for all sub-tasks — this suppresses its exhausted-exit prompt and auto-accepts the PR. Do not pass `autonomous: true` outside sub-task spawns.
-- The multi-parent branch base is the parent with the lowest tier number (most foundational); other parents are documented as manual merge steps in the sub-PR `## Notes`.
+- The multi-parent branch base is the parent with the lowest tier number (most foundational); if multiple parents share the lowest tier, the lowest-numbered sub-issue among them wins. Other parents are documented as manual merge steps in the sub-PR `## Notes`.
 - The epic PR body must include the sub-issue/sub-PR table, merge-order advisory, and `Closes #<N>`.
 - `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the `autonomous` seed-brief field contract.

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: epic-autopilot
+description: Autonomous epic-to-PR pipeline. Chains /discovery → /define → /implement end-to-end for each sub-issue, opening draft PRs. Use when you have an epic issue number or a free-text description and want the full cycle automated.
+model: opus
+effortLevel: high
+---
+
+You are orchestrating the autonomous epic-to-PR pipeline. Your goal is to take an epic GitHub issue (or a free-text description) and produce a set of draft sub-PRs plus a top-level epic PR, with no human prompts after the per-sub-issue /define gates.
+
+## Input
+
+A single argument — either:
+
+- **Positive integer** → treated as an existing GitHub epic issue number. Parse: `int(arg) > 0`.
+- **Any other string** → treated as a free-text description; `/discovery` will create the epic issue from it.
+
+## Scope Assessment
+
+Always **Deep** — this is a fanout orchestrator. No inline path exists; the skill always spawns sub-agents.
+
+### Spawn justification
+
+Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
+
+- **Per-sub-issue /define gate**: sequential single-subagent per sub-issue (one at a time). Comm-pivot ✗ (no mid-task coordination), disjoint n/a, parallel ✗ (user approval required between each), payoff n/a. Model: sonnet. Fallback: n/a — no flag dependency.
+- **Autonomous phase — parallel Task sub-agents per tier**: one Task sub-agent per sub-issue within a tier, dispatched in a single message. Comm-pivot ✗ (sub-issues are disjoint; lead aggregates at settle), disjoint ✓ (each sub-agent works on a separate branch and sub-issue), parallel ✓ (tier-independent sub-issues), payoff ≥3× (wall-clock on ≥3 sub-issues). Model: opus per sub-agent (inherits from `/implement`'s own model). Fallback: sequential subagents.
+
+## Process
+
+### Stage 0 — Resume detection
+
+On every invocation, read the epic issue body first. Detect prior phase completion from markers:
+
+- `## Implementation plan` present in body → /discovery and epic-level /define already done. Jump to **Stage 3** (per-sub-issue /define) for any sub-issues not yet defined, or to **Stage 4** (autonomous phase) if all sub-issues have a linked PR or branch (per resume logic in Stage 4).
+- `## Requirements` present but no `## Implementation plan` → /discovery done, epic /define needed. Jump to **Stage 2**.
+- Neither present (or free-text input) → start from **Stage 1**.
+
+### Stage 1 — Discovery gate
+
+If input is a positive integer and the epic issue has a well-formed `## Requirements` section (non-empty, at least 3 acceptance criteria), skip /discovery and go to Stage 2.
+
+Otherwise:
+1. Run `/discovery` on the epic (or free-text description). This is interactive — /discovery will interview the user and write the issue body.
+2. **Pause for explicit user approval.** Present: "Discovery complete. Review the issue body above. Approve to continue to /define, or provide feedback."
+3. Wait for explicit approval before proceeding. Silence is not approval.
+
+### Stage 2 — Epic-level /define gate
+
+1. Run `/define` on the epic issue. This is interactive — /define will produce architecture decisions, create sub-issues with linked-issue relationships, and update the issue body.
+2. **Pause for explicit user approval.** Present: "Epic /define complete. Review the sub-issues and implementation plan above. Approve to continue to per-sub-issue /define, or provide feedback."
+3. Wait for explicit approval before proceeding.
+
+After approval, read the epic issue body and extract the list of sub-issues (GitHub issue numbers). If `/define` produced **≤1 sub-issue**:
+- Print: `Decomposition produced ≤1 sub-issue — running /implement directly on #<N>`
+- Invoke `/implement` on the epic in the lead session (interactive, no `autonomous: true`, no epic branch).
+- Exit. Do not proceed to Stage 3.
+
+### Stage 3 — Per-sub-issue /define gate
+
+For each sub-issue in order (ascending issue number):
+
+1. Check if this sub-issue already has `## Implementation plan` in its body. If yes, skip (already defined in a prior run).
+2. Spawn a fresh subagent to run `/define` on this sub-issue. The subagent must finish completely before the next sub-issue's gate runs — these are sequential, not parallel.
+3. After the subagent returns, **pause for explicit user approval.** Present: "Sub-issue #<M> /define complete. Review the implementation plan above. Approve to continue to the next sub-issue, or provide feedback."
+4. Wait for explicit approval before moving to the next sub-issue.
+
+Once every sub-issue has an approved `## Implementation plan`, proceed to **Stage 4 — Autonomous phase**. No further human prompts are emitted until exit.
+
+### Stage 4 — Autonomous phase
+
+**No human prompts from this point forward until exit.**
+
+#### 4a. Epic branch creation
+
+```
+git checkout main && git pull
+git checkout -b feat/epic-<N>
+git commit --allow-empty -m "chore: open epic #<N>"
+git push -u origin feat/epic-<N>
+```
+
+The epic branch must exist and be pushed before any sub-task spawns.
+
+#### 4b. Dependency-tier computation
+
+Read each sub-issue body's `## Implementation plan` to extract the dependency graph (which sub-issues each sub-issue depends on). Build tiers using **Kahn's topological sort**:
+
+```
+1. Build adjacency: for each sub-issue M, parse its /define output for "depends on #<X>" references.
+2. Compute in-degree for each node.
+3. Tier 1 = nodes with in-degree 0. Assign to tier 1.
+4. Remove tier-1 nodes; recompute in-degree. Tier 2 = new zero-in-degree nodes. Repeat until empty.
+5. Ties within a tier: break by ascending sub-issue number.
+```
+
+**Cycle handling**: if Kahn's algorithm detects a back-edge (cycle), identify the pair with the higher-numbered sub-issue and remove that back-edge. Log to stdout:
+```
+Cycle broken: removed dep #<higher> → #<lower>
+```
+Continue Kahn's on the acyclic graph.
+
+**Branch base per sub-issue**:
+- Tier-1 → base is `feat/epic-<N>`.
+- Single-parent sub-issue → base is that parent's branch (`feat/epic-<N>-sub-<parentM>`).
+- Multi-parent sub-issue → base is the parent with the lowest tier number (most foundational). Document remaining parents in the sub-PR `## Notes` as manual merge steps.
+
+#### 4c. Parallel Task dispatch — per tier
+
+For each tier, in ascending tier order:
+
+1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
+2. Dispatch all sub-tasks in the current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M in the tier:
+   - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
+   - Create the worktree and branch: `git worktree add .worktrees/feat/epic-<N>-sub-<M> feat/epic-<N>-sub-<M> --track origin/<base-branch>` (or create branch if not yet on remote, branching from the base computed in 4b).
+   - Pass the following seed brief to the sub-agent's `/implement` invocation:
+
+```
+<seed-brief>
+preflight_verified: true
+scope_class: Deep
+repo: <owner/repo>
+branch: feat/epic-<N>-sub-<M>
+active_issue: <M>
+autonomous: true
+payload:
+  type: research
+  architectural_context: <summary of sub-issue #M's ## Implementation plan>
+  parent_branch: <base-branch>
+</seed-brief>
+```
+
+3. Wait for all sub-agents in the tier to settle before dispatching the next tier.
+
+#### 4d. Sub-task failure handling
+
+Each sub-agent runs `/implement` end-to-end and attempts to open a draft PR. If a sub-agent **aborts** (returns an error or fails to open a PR):
+
+- **Attempt 1**: retry the sub-agent once with the same seed brief.
+  - Emit: `[sub-issue #<M>] RETRYING (attempt 2/2)`
+- **Attempt 2**: if the retry also aborts, mark the sub-task FAILED and continue sibling sub-tasks.
+  - Emit: `[sub-issue #<M>] FAILED — second retry exhausted`
+
+A sub-task that produces a draft PR (even exhausted-accepted with findings) is considered settled successfully. The `/implement` `autonomous: true` flag ensures no prompt is emitted even on exhausted exit.
+
+#### 4e. Settlement status lines
+
+For each sub-task that settles (after awaiting its Task sub-agent):
+- Clean exit: `[sub-issue #<M>] PR opened: <url> (cycles:<N>)`
+- Exhausted-accepted: `[sub-issue #<M>] PR opened: <url> (cycles:3 [exhausted-accepted])`
+- FAILED: `[sub-issue #<M>] FAILED — second retry exhausted`
+
+#### 4f. Epic PR creation
+
+After every sub-task across all tiers has settled (PR open or FAILED):
+
+1. Push `feat/epic-<N>` to remote (the empty commit was pushed in 4a; push is a no-op if already up-to-date).
+2. Open a draft epic PR:
+
+```
+gh pr create --draft \
+  --base main \
+  --head feat/epic-<N> \
+  --title "feat: epic #<N> — <epic title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<1–3 sentences: what the epic delivers, which sub-issues are included>
+
+## Sub-issues and sub-PRs
+
+| Sub-issue | PR | Status |
+|-----------|-----|--------|
+| #<M> <title> | <PR url or FAILED> | <clean / exhausted-accepted / FAILED> |
+...
+
+## Merge order
+
+Merge sub-PRs before the epic PR, in tier order: tier-1 → tier-2 → … → epic.
+**GitHub does not auto-update child PR bases after a parent squash/rebase merge** — after each parent PR merges, update dependent branches manually (`git rebase` or `git merge`).
+
+## Follow-ups
+<any FAILED sub-tasks, outstanding findings, or deferred work>
+
+Closes #<N>
+EOF
+)"
+```
+
+3. Print the epic PR URL and the full sub-issue/sub-PR summary table to stdout.
+
+### Stage 5 — Exit
+
+Print exit summary to stdout and exit. The run is complete when all sub-PRs have been opened (clean / exhausted-accepted / FAILED) and the epic PR is open. Merging is left to humans.
+
+## Resume logic
+
+On re-invocation with the same epic issue number, epic-autopilot detects prior state and skips completed phases:
+
+| State detected | Action |
+|----------------|--------|
+| No `## Requirements` in epic body | Re-run from Stage 1 |
+| `## Requirements` but no `## Implementation plan` | Re-run from Stage 2 |
+| `## Implementation plan` present | Skip Stages 1–2; check sub-issues |
+| Sub-issue has `## Implementation plan` | Skip per-sub-issue /define for that sub-issue |
+| Sub-issue has open PR on its branch | Sub-task settled; skip |
+| Sub-issue has branch but no open PR | Re-run `/implement` in the existing worktree for that sub-issue |
+| Sub-issue has neither branch nor PR | Fresh sub-task spawn |
+
+A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be re-attempted on every resume. To skip it permanently, manually delete the branch and mark the sub-issue with a `skip` label before re-invoking.
+
+## Rules
+
+- Require explicit user approval at each gate (Stage 1, Stage 2, and each Stage 3 sub-issue). Silence is not approval.
+- Autonomous phase (Stage 4 onward) emits no human prompts. The only output is status lines and, at exit, the PR summary.
+- The user must not modify the epic issue body or any sub-issue body during Stage 4. Sub-agents read at spawn time and do not re-fetch mid-run.
+- The epic branch (`feat/epic-<N>`) must be created and pushed before any sub-task spawns — this is non-negotiable.
+- Sub-issue branch and worktree names follow the pattern `feat/epic-<N>-sub-<M>` exactly. M is the GitHub sub-issue number (globally unique), so names are collision-safe across parallel spawns.
+- Each tier's sub-agents dispatch in a single message (parallel Task calls). Tier T+1 does not start until every tier-T agent has settled.
+- Sub-task retry policy: retry exactly once on abort; FAILED on second abort; siblings continue regardless.
+- `/implement` receives `autonomous: true` in its seed brief for all sub-tasks — this suppresses its exhausted-exit prompt and auto-accepts the PR. Do not pass `autonomous: true` outside sub-task spawns.
+- The multi-parent branch base is the parent with the lowest tier number (most foundational); other parents are documented as manual merge steps in the sub-PR `## Notes`.
+- The epic PR body must include the sub-issue/sub-PR table, merge-order advisory, and `Closes #<N>`.
+- `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the `autonomous` seed-brief field contract.
+- See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for the orchestration-depth and Task sub-agent rules.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -85,7 +85,8 @@ Run these steps automatically, without asking:
 
 1. Read `<worktree-root>/.claude/NOTES.md` if it exists. Harvest `## Decisions made this session` and `## Open questions` — these flow into the PR body's `## Notes` section.
 2. Push the branch to remote.
-3. Open a draft PR (`gh pr create --draft`) with the body shape below. Link to the issue:
+3. Resolve the PR base. Run `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null` — if it returns an upstream like `origin/<base>`, strip the `origin/` prefix and use `<base>` as the PR base. If no upstream is configured (standalone invocation in a fresh feature branch), default to the repo's default branch (typically `main`). Stacked-branch orchestrators (e.g. `/epic-autopilot`) pre-set the upstream so the sub-PR targets the correct parent branch.
+4. Open a draft PR (`gh pr create --draft --base <resolved-base>`) with the body shape below. Link to the issue:
    - `Closes #<issue>` — if this is the only/final PR for the issue.
    - `Related to #<issue>` — if this is a partial implementation.
 
@@ -104,9 +105,9 @@ Run these steps automatically, without asking:
 
 `## Notes` is omitted entirely when there is nothing to note (no NOTES.md content, no outstanding findings).
 
-4. Run `/compound` — autonomous, reads the cycle context and any remaining NOTES.md content, files durable learnings to the wiki via `claude-obsidian:save` when the plugin is installed (otherwise returns the note inline).
-5. Delete `<worktree-root>/.claude/NOTES.md`.
-6. Exit with PR URL and any outstanding findings.
+5. Run `/compound` — autonomous, reads the cycle context and any remaining NOTES.md content, files durable learnings to the wiki via `claude-obsidian:save` when the plugin is installed (otherwise returns the note inline).
+6. Delete `<worktree-root>/.claude/NOTES.md`.
+7. Exit with PR URL and any outstanding findings.
 
 ### Finalize
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -44,6 +44,8 @@ Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` once at entry. Run `${CLAU
 
 **Autonomy contract**: inside a single `/implement` invocation, run build → review → verify → fix cycles back-to-back without asking the user between sub-skills. The only user-interrupt point is after the PR is opened and the cycle has either (a) passed clean, (b) exhausted 3 cycles with findings remaining, or (c) hit a blocker the sub-skill cannot resolve. Status updates during the loop are informational only — do **not** end them with a question.
 
+**Seed-brief handling**: when invoked by an orchestrator (e.g. `/epic-autopilot`) with a `<seed-brief>` block, read the `autonomous` field at startup — default `false` when absent or when no seed brief is present. This flag affects only the Finalize block; all build→review→verify cycles run identically regardless. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
 ### Lightweight
 
 1. Auto-run `/build` — lead codes inline in the worktree, no team spawn, TDD only for logic-heavy snippets.
@@ -111,9 +113,11 @@ Run these steps automatically, without asking:
 One deterministic finalize block follows PR creation. Branch on the loop's exit state:
 
 - **Clean exit** (no remaining findings) → present the PR URL to the user. `/compound` has already run autonomously.
-- **Exhausted exit** (3 cycles consumed, findings remain) → present the PR URL plus the outstanding findings to the user and ask a single binary question: **"Continue the implementation loop, or accept this PR and close out?"**
-  - **Accept / close** → `/compound` has already run autonomously. Done.
-  - **Continue** → run one more build → review → verify cycle, then return to this finalize block. Each continuation is a new escalation — log it explicitly in the PR description under `## Notes` before re-entering the loop.
+- **Exhausted exit** (3 cycles consumed, findings remain):
+  - If `autonomous: true` (from seed brief) → skip the prompt; execute the Accept / close branch unconditionally; emit one status line: `autonomous accept: 3 cycles, <N> findings flowed into PR body ## Notes`. `/compound` has already run autonomously. Done.
+  - If `autonomous: false` (default) → present the PR URL plus the outstanding findings to the user and ask a single binary question: **"Continue the implementation loop, or accept this PR and close out?"**
+    - **Accept / close** → `/compound` has already run autonomously. Done.
+    - **Continue** → run one more build → review → verify cycle, then return to this finalize block. Each continuation is a new escalation — log it explicitly in the PR description under `## Notes` before re-entering the loop.
 
 ## Output
 
@@ -121,7 +125,7 @@ A draft PR linking the issue (`Closes #N` or `Related to #N`) with acceptance cr
 
 ## Rules
 
-- **Never prompt between sub-skills.** Build → review → verify → fix cycles and the PR / `/compound` finalize chain all run without asking. The only permitted user-interrupt is the single binary question after an **exhausted exit** (3 cycles with findings remaining).
+- **Never prompt between sub-skills.** Build → review → verify → fix cycles and the PR / `/compound` finalize chain all run without asking. The only permitted user-interrupt is the single binary question after an **exhausted exit** (3 cycles with findings remaining) — suppressed when `autonomous: true` is set in the seed brief.
 - Run repo-preflight once at entry; pass `preflight_verified: true` to every specialist via seed brief.
 - Do not open a PR until both /review and /verify pass clean (Standard/Deep) **or** the cycle has exhausted 3 iterations with findings attached. Lightweight scope opens the PR after the inline AC self-check.
 - Maximum 3 build→review→verify cycles before escalating; escalation is the one-question finalize prompt, not per-cycle approval. Lightweight never cycles — if it fails the inline check, upgrade to Standard and restart.


### PR DESCRIPTION
## Summary

Adds the `epic-autopilot` skill that chains `/discovery → /define → /implement` end-to-end for each sub-issue of an epic, opening draft sub-PRs and a top-level epic PR with no human prompts after the per-sub-issue `/define` gates. Also extends the seed-brief schema with an `autonomous` flag that suppresses `/implement`'s exhausted-exit prompt when invoked by the orchestrator.

## Changes

### New: `skills/epic-autopilot/SKILL.md`
Five-stage orchestrator (`opus`, `effortLevel: high`):
- **Stage 0** — resume detection from epic issue body markers
- **Stage 1** — discovery gate (runs `/discovery`; pauses for approval)
- **Stage 2** — epic `/define` gate (creates sub-issues; pauses for approval; ≤1 sub-issue falls back to `/implement` directly)
- **Stage 3** — per-sub-issue `/define` gate (sequential fresh subagents; pauses after each)
- **Stage 4** — autonomous phase: empty-commit epic branch, Kahn's topological sort for dependency tiers, parallel `Task` dispatch per tier, retry-once failure isolation, epic PR creation with merge-order advisory
- **Resume logic** table covering all intermediate states

### Modified: `_shared/specialist-mode.md`
- Adds `autonomous: <bool>` (optional, default `false`) to the seed-brief schema and transport-format example
- Documents the field in the required-fields table
- Adds `/implement` row to the specialist skip-list (exhausted-exit prompt is the rigor gate — suppressed only when `autonomous: true` is explicitly set)

### Modified: `_shared/composition.md`
- One-line addendum to Hierarchical decomposition: Task sub-agents are fresh roots; the 2-level cap applies within each sub-agent's lineage, not across the parent spawn graph

### Modified: `skills/implement/SKILL.md`
- **Seed-brief handling** paragraph: read `autonomous` at startup (default `false`)
- **Finalize block**: on exhausted-exit + `autonomous: true`, skip the binary prompt, accept unconditionally, emit status line `autonomous accept: 3 cycles, <N> findings flowed into PR body ## Notes`
- Updated Rules bullet to document the suppression condition

## Manual testing

1. **`autonomous` flag in isolation** — drive `/implement` with a seed brief containing `autonomous: true`; force a 3-cycle exhausted exit. Verify: no prompt is emitted; PR opens draft; findings appear in PR body `## Notes`.
2. **Free-text input** — invoke `/epic-autopilot "Add a CSV export button"`. Verify: runs `/discovery`, pauses for approval, then continues through the gate chain.
3. **Issue input with thin requirements** — invoke `/epic-autopilot 99` where issue #99 has no `## Requirements`. Verify: `/discovery` runs before `/define`.
4. **Happy path 3-sub-issue** — epic with 3 independent tier-1 sub-issues. Verify: 3 sub-branches targeting `feat/epic-<N>`, 3 draft sub-PRs, 1 epic PR draft targeting `main`, stdout dispatch+settle line per sub-issue.
5. **Single sub-issue fallback** — `/define` produces 1 sub-issue. Verify: fallback message printed; `/implement` runs interactively on the epic; no epic branch.
6. **Cycle break** — inject cycle (sub-1 → sub-2, sub-2 → sub-1). Verify: stdout logs `Cycle broken: removed dep #<higher> → #<lower>`; both sub-issues compute tiers.
7. **Resume mid-run** — complete Stage 3, interrupt before Stage 4. Re-invoke. Verify: Stages 1–3 skipped; autonomous phase proceeds from Stage 4.

## Notes

- `_shared/specialist-mode.md` validation rules: a brief with `autonomous: true` but `preflight_verified: false` is still rejected — the `autonomous` field does not bypass required-field validation.
- The multi-parent branch base (AC13) uses the lowest-tier parent as the foundation; tied-tier parents use the lowest sub-issue number as a tiebreaker (consistent with the Kahn's tie-break convention throughout the skill).
- `/compound` and `/wrap-up` are intentionally not called by `epic-autopilot` — they remain user-invoked utilities.

Closes #25