### PR TITLE
docs: refresh skill table, /wrap-up shape, and add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,152 @@
+# Changelog
+
+All notable changes to the **claude-workflow** plugin are recorded here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/).
+
+GitHub Releases (with auto-generated notes and source tarballs) remain the canonical artifact: <https://github.com/misiekhardcore/claude-workflow/releases>. This file mirrors them in repo so changes are visible without leaving the source tree.
+
+## [Unreleased]
+
+_No changes yet._
+
+## [1.0.0] — 2026-05-03
+
+First major release. Locks in the specialist-mode contract that lets orchestrators drive the build → review → verify loop autonomously, repurposes `/wrap-up` from an audit step into a worktree-cleanup utility, and adds two new skills: `/epic-autopilot` (autonomous epic-to-PR pipeline) and `/audit-issues` (drift-check for open GitHub issues).
+
+### Added
+
+- **`/audit-issues`** skill — drift-checks open GitHub issues in a target repo against the current local working tree. Five detectors (file-path-existence, numeric-claim-drift, version-reference-staleness, resolved-open-question, cross-issue-contradiction), a verdict taxonomy (`unverifiable` > `premise-shifted` > `superseded by #N` > `contradicted` > `stale` > `valid`), and per-issue interactive `[e]dit / [c]lose / [s]kip` actions. Mutates only after explicit confirmation. Requires a local clone at `~/Projects/<repo>`. (#61)
+- **`/epic-autopilot`** skill — five-stage orchestrator that chains `/discovery → /define → /implement` end-to-end for each sub-issue of an epic. Human gates after `/discovery`, after the epic-level `/define`, and after each per-sub-issue `/define`; afterwards the autonomous phase opens the epic branch, computes a Kahn topological sort of dependencies, dispatches per-tier `Task` subagents in parallel, retries-once on failure, and opens draft sub-PRs plus a top-level epic PR. Resumable from any stage via markers in the epic issue body. (#60)
+- **`/review`** can now accept a PR number or URL as input (in addition to the existing branch-only mode) and post findings as inline GitHub comments + summary review, idempotent via fingerprint markers. Two new conditional personas: docs consistency and architecture / scope-creep. The fix-brief path inside `/implement` is unchanged. (#59)
+- **`autonomous: true`** seed-brief flag — when an orchestrator passes it, `/implement` skips the exhausted-exit prompt and accepts unconditionally, surfacing findings into the PR body's `## Notes`. Used by `/epic-autopilot`'s autonomous phase. (#60)
+
+### Changed — breaking
+
+- **`/wrap-up` repurposed** as a user-invoked cleanup utility: removes the feature worktree, deletes the branch, clears NOTES.md. State machine refuses outright on the default branch or out-of-tree paths; on a dirty worktree, surfaces unpushed/uncommitted state and requires a proceed-anyway confirmation. **No longer drafts an audit block** — that responsibility moved into `/implement`'s PR-body harvest. (#58)
+- **`_shared/handoff-artifact.md`** trimmed to two phase-boundary skills (`/discovery`, `/define`); `/implement` and `/wrap-up` are no longer phase-boundary skills. (#58)
+
+### Changed
+
+- **`/implement` end-to-end refactor** — introduced the `_shared/specialist-mode.md` contract (seed-brief detection, transport format, required fields, per-specialist skip-list) so orchestrators can drive `/build`, `/review`, `/verify`, `/describe`, `/specify`, `/architecture`, `/design` autonomously without re-running preflight per specialist. Audit content (assumptions, uncertainties, follow-ups, outstanding findings) is now harvested from `./.claude/NOTES.md` into the PR body's `## Notes` section before the PR opens — `/implement` is the terminal phase, its output is the PR, not an issue body update. (#58)
+
+### Documentation
+
+- README skill table refreshed with `/audit-issues` and `/epic-autopilot`; `/wrap-up` description updated; flowchart adjusted (epic-autopilot in Other tools, audit-issues alongside it).
+- `docs/workflow.md` Step 6 rewritten for the new `/wrap-up` shape; added Maintenance section for `/audit-issues` and an Autonomous-variant section for `/epic-autopilot`; PR-body wording table now documents the `## Summary / ## Testing notes / ## Notes` template and the NOTES.md harvest.
+- New `CHANGELOG.md` mirroring GitHub Releases history in-repo.
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.7.0...v1.0.0)
+
+## [0.7.0] — 2026-04-27
+
+### Added
+
+- **`_shared/repo-preflight.md`** extracted from inline 4-step stanzas in `/build` and `/resolve-pr-feedback`; wired into `/discovery` (before `gh issue create`) and `/define` (before issue body update / sub-issue creation), closing the wrong-repo-mutation gap. (#55)
+- **`_shared/scope-preflight.md`** with trigger conditions (≥3 files or audit/refactor/normalize/sweep/propagate/extract/rename verbs) and file-list confirmation/refusal templates; wired into `/build` and `/resolve-pr-feedback`. (#55)
+
+### Changed
+
+- **`/resolve-pr-feedback`** now resolves PR review threads via GraphQL `resolveReviewThread` for `fixed`, `fixed-differently`, and `not-addressing` verdicts; leaves `needs-human` and `replied` unresolved. (#56)
+- **`/specify`** requires fetch-and-confirm before treating any URL or external claim as authoritative; prohibits pasting unverified citations into spec/issue bodies. (#56)
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.6.0...v0.7.0)
+
+## [0.6.0] — 2026-04-26
+
+### Added
+
+- **`docs/token-budgets.md`** — per-artifact and per-phase token budgets, the context-rot threshold (~12% of window), CLAUDE.md placement and `@`-import syntax, and the skill-invocation duplication anti-pattern. Cross-referenced from `README.md`, `CLAUDE.md`, `_shared/composition.md`, `_shared/notes-md-protocol.md`, `docs/context-hygiene.md`, and `docs/cross-plugin.md`. (#52)
+- **`docs/cross-plugin.md`** — ecosystem coordination guide covering MCP scope (shared vs. plugin-bundled), inter-plugin dependency declarations, and CLAUDE.md layering across `~/.claude/CLAUDE.md`, `./CLAUDE.md`, and `./CLAUDE.local.md`. Documents the decision to keep `claude-obsidian` optional via runtime detection. (#50)
+- **`${CLAUDE_PLUGIN_DATA}`** documented in `_templates/AUTHORING.md` for persistent plugin state that survives updates, with the diff-then-install pattern for dependency caching. (#48)
+
+### Changed
+
+- **Spawn-site audit** across all skills against the TeamCreate rubric in `_shared/composition.md`. Most spawn sites collapsed from `TeamCreate` to subagent fan-out where mid-task communication wasn't needed; remaining `TeamCreate` invocations now carry explicit justifications. (#47)
+- **Specialist spawn-site model tiers** — `/describe`, `/architecture`, `/design`, `/verify`, `/review` now name explicit `model:` per spawn site (sonnet for research/analysis, haiku for structured QA, opus reserved for lead-interactive and critical work). (#49)
+- **`_templates/AUTHORING.md`** — added "Parallelism decision" section linking to the composition rubric; orchestrator and specialist templates now require a Scope Assessment + Parallelism choice / spawn justification block. `/new-skill` interview asks an explicit parallelism question (no-parallelism / subagents / TeamCreate) before writing the skill. Added "Progressive disclosure via `references/`" section with a worked split rule. (#51)
+- **`/find-skills`** and **`/compound`** split out reference material into `references/` subdirectories per the new progressive-disclosure pattern, reducing main SKILL.md footprints by ~30%. (#51)
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.5.0...v0.6.0)
+
+## [0.5.0] — 2026-04-25
+
+### Added
+
+- **TeamCreate decision rubric** in `_shared/composition.md` — cost model (~7× tokens per Anthropic /en/costs), criteria for choosing `TeamCreate` over sub-agents (≥3 genuinely parallel sub-tasks with disjoint files and ≥3× wall-clock payoff), and worked examples. (#46)
+
+### Changed
+
+- **Skill descriptions trimmed to ≤150 chars** across the plugin so they fit in `claude plugin list` output without truncation. (#45)
+- **Release workflow** — version lockstep documented: `.claude-plugin/plugin.json` and both `metadata.version` + `plugins[0].version` in `.claude-plugin/marketplace.json` must agree, bumped together by the `Release` workflow. (#44)
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.4.0...v0.5.0)
+
+## [0.4.0] — 2026-04-23
+
+### Added
+
+- **Release workflow** (`.github/workflows/release.yml`) — `workflow_dispatch` with `patch | minor | major` bump; computes version, updates `plugin.json` + `marketplace.json` in lockstep, commits, tags, and creates a GitHub release with auto-generated notes and a source tarball. (#38)
+- **`/implement` design-before-build gate** — for `Standard` and `Deep` scope, `/implement` requires architecture decisions to be cross-phase verified before `/build` runs; design gate stays live even in specialist mode. (#20)
+- **`/build` and `/resolve-pr-feedback` repo pre-flight echo** — explicit confirmation step before any `git` or `gh` mutation, gating against wrong-repo writes. (#21)
+- **Final-pass checklist** in `_shared/handoff-artifact.md` — last-mile checklist for the handoff author. (#22)
+
+### Changed
+
+- **Issue/PR sections use human-readable headings** (e.g. "Acceptance criteria") instead of machine-style placeholders. (#32)
+- **Empty handoff sections omitted** rather than rendered with `None` placeholders, keeping bodies clean. (#28)
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.3.0...v0.4.0)
+
+## [0.3.0] — 2026-04-20
+
+### Added
+
+- **`_shared/composition.md`** — four composition patterns (linear / branch / loop / parallel), three skill roles (orchestrator / specialist / primitive), and three structured briefs (research / prior-art / fix) with contracts and failure modes.
+- **Role-specific templates** — `SKILL.template.md` split into `SKILL.orchestrator.template.md`, `SKILL.specialist.template.md`, `SKILL.primitive.template.md`, each under 50 lines.
+- **`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`** prerequisite documented in `README.md` and `CLAUDE.md` for parallel composition.
+
+### Changed
+
+- **`/specify`** and **`/design`** document optional prior-art and research brief inputs.
+- **`/new-skill`** asks about role and routes to the appropriate role-specific template.
+- **`AUTHORING.md`** gains a skill-types table and composition-patterns subsection.
+- **`docs/workflow.md`** cross-links to `composition.md`.
+- Stale references fixed in `docs/workflow.md`, `SKILL.template.md` frontmatter, and several skill files. (#12)
+
+Closes #13, #11.
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.2.0...v0.3.0)
+
+## [0.2.0] — 2026-04-17
+
+### Changed — breaking
+
+- **Decoupled from the vault path.** All 36 hardcoded `memory/wiki/` references removed across 9 files. Skills now speak `claude-obsidian`'s vocabulary (vault, hot cache, log, concept/entity/source notes, session archive) instead of filesystem paths.
+- **`/compound`** drafts a structured note and files it via `claude-obsidian:save` when the plugin is available; otherwise emits the note inline.
+- **`/prune`** splits into a CLAUDE.md+auto-memory lane that always runs, and a vault lane delegated to `wiki-lint` when `claude-obsidian` is installed.
+- **`/architecture`** and **`/define`** query the vault for prior patterns via `wiki-query` when available.
+
+### Added
+
+- **`docs/context-hygiene.md`** — the "Context Hygiene Between Workflow Phases" rationale moved into the plugin so it travels with the workflow regardless of whether any vault is installed.
+- **README**: "Optional: claude-obsidian integration" section.
+
+### Migration
+
+No migration is needed if you don't have `claude-obsidian` — skills just skip the vault lanes. To opt in, install `claude-obsidian` and run `/wiki` once to bootstrap a vault; the delegation kicks in automatically.
+
+Closes #9.
+
+[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.1.0...v0.2.0)
+
+## [0.1.0] — 2026-04-17
+
+First tagged public release.
+
+### Added
+
+- **17 workflow skills**: `/discovery`, `/define`, `/architecture`, `/design`, `/describe`, `/specify`, `/implement`, `/build`, `/review`, `/verify`, `/wrap-up`, `/compound`, `/prune`, `/find-skills`, `/grill-me`, `/resolve-pr-feedback`, `/new-skill`.
+- **4 shared protocols** under `_shared/`: `handoff-artifact.md`, `interviewing-rules.md`, `notes-md-protocol.md`, `compaction-protocol.md`.
+- **Authoring standard**: `_templates/SKILL.template.md`, `_templates/AUTHORING.md`, and the interactive `/new-skill` scaffolder.
+- **Self-marketplace**: `.claude-plugin/marketplace.json` + `plugin.json` shipped in-repo so the repo installs via a single `marketplace add`.
+
+[v0.1.0 release tag](https://github.com/misiekhardcore/claude-workflow/releases/tag/v0.1.0)

--- a/README.md
+++ b/README.md
@@ -36,15 +36,17 @@ flowchart TB
         Discovery -->|create issue body| Define
         Define -->|issue body| Implement
         Implement --> PR([draft PR])
-        PR --> WrapUp["/wrap-up — harvest NOTES.md"]
         PR --> Compound["/compound — capture learnings"]
         PR --> ResolvePR["/resolve-pr-feedback — batch review responses"]
+        PR --> WrapUp["/wrap-up — remove worktree + branch"]
 
         subgraph Meta["Other tools"]
             direction LR
+            EpicAutopilot["/epic-autopilot — autonomous epic→PR"]
             NewSkill["/new-skill"]
             FindSkills["/find-skills"]
             Prune["/prune — audit memory"]
+            AuditIssues["/audit-issues — drift-check open issues"]
             GrillMe["/grill-me"]
         end
 
@@ -75,7 +77,7 @@ flowchart TB
     class Canvas canvas
     class Discovery,Define,Implement orch
     class D_Describe,D_Specify,D_Scout,Df_Arch,Df_Design,I_Build,I_Review,I_Verify spec
-    class GrillMe,NewSkill,FindSkills,Prune,WrapUp,Compound,ResolvePR,Save,WikiQuery,WikiLint meta
+    class GrillMe,NewSkill,FindSkills,Prune,AuditIssues,WrapUp,Compound,ResolvePR,EpicAutopilot,Save,WikiQuery,WikiLint meta
     class Obsidian ext
 ```
 
@@ -109,8 +111,9 @@ Without this flag, `TeamCreate` is unavailable. Skills detect its absence and fa
 | `/discovery`           | Explore a problem and produce a GitHub issue with acceptance criteria                                            |
 | `/define`              | Plan architecture and design; produces the implementation handoff                                                |
 | `/implement`           | Full build→review→verify cycle, ends with a draft PR                                                             |
+| `/epic-autopilot`      | Autonomous epic→PR pipeline; chains `/discovery → /define → /implement` per sub-issue with gated approvals       |
 | `/build`               | Code against an issue's acceptance criteria using TDD                                                            |
-| `/review`              | Review an implementation; correctness, standards, and conditional specialists                                    |
+| `/review`              | Review an implementation or external PR; correctness, standards, and conditional specialists                     |
 | `/verify`              | QA verification of every acceptance criterion                                                                    |
 | `/describe`            | Explore and understand a problem space interactively                                                             |
 | `/specify`             | Turn a problem statement into testable acceptance criteria                                                       |
@@ -118,8 +121,9 @@ Without this flag, `TeamCreate` is unavailable. Skills detect its absence and fa
 | `/design`              | Visual and UX design decisions — layouts, interaction flows                                                      |
 | `/grill-me`            | Relentless interviewing to stress-test a plan or design                                                          |
 | `/compound`            | Capture learnings as structured wiki notes; files via `claude-obsidian` when installed, otherwise reports inline |
-| `/wrap-up`             | End-of-session audit; harvests NOTES.md into the issue body                                                      |
+| `/wrap-up`             | Post-PR cleanup utility: remove the feature worktree, delete the branch, clear NOTES.md                          |
 | `/prune`               | Audit CLAUDE.md for staleness; delegates vault audit to `wiki-lint` when `claude-obsidian` is installed          |
+| `/audit-issues`        | Drift-check open GitHub issues against the current repo state; offers per-issue edit / close / skip              |
 | `/find-skills`         | Discover and install skills from the ecosystem                                                                   |
 | `/resolve-pr-feedback` | Process PR review feedback in bulk                                                                               |
 | `/new-skill`           | Scaffold a new skill conforming to this authoring standard                                                       |
@@ -176,6 +180,8 @@ Shared protocols live at `_shared/`:
 ## Releasing
 
 Versions in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (both `metadata.version` and `plugins[0].version`) must agree — the marketplace listing and distribution tooling depend on it. Trigger the **Release** workflow (`.github/workflows/release.yml`) via `workflow_dispatch` to bump all three in lockstep, commit, tag, and publish. Do not hand-edit; if you must, update all three fields in the same commit.
+
+Per-release notes (with full diffs) live on [GitHub Releases](https://github.com/misiekhardcore/claude-workflow/releases). A mirrored, in-repo summary is at [`CHANGELOG.md`](CHANGELOG.md).
 
 ## License
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -159,6 +159,8 @@ Not posted: per-commit updates, per-fix-cycle-iteration noise, internal reviewer
 | PR delivers the full epic         | `Closes #<epic>`  |
 | PR delivers one sub-issue of many | `Part of #<epic>` |
 
+The PR body uses a fixed three-section template — **Summary** / **Testing notes** / **Notes**. Before pushing, `/implement` reads `./.claude/NOTES.md` and harvests `## Decisions made this session` and `## Open questions` into the `## Notes` section, then deletes NOTES.md after `/compound` runs. The `## Notes` section is omitted entirely when there is nothing to record. This is why `/wrap-up` no longer drafts an audit block — the audit lives in the PR body, not the issue.
+
 ---
 
 ## Step 4 — `/compound` (Sonnet)
@@ -202,12 +204,12 @@ Fixed in abc1234 — replaced the N+1 loop with a single JOIN (benchmarks in com
 
 ---
 
-## Step 6 — `/wrap-up` (Sonnet) — _optional, end of session_
+## Step 6 — `/wrap-up` (Sonnet) — _optional, after the PR is open_
 
 - **File:** `skills/wrap-up/SKILL.md`
-- **When:** End of a long or complex session, or when transitioning between phases mid-work.
-- **What it does:** Reads `./.claude/NOTES.md`, identifies assumptions, uncertain decisions, scope changes, and follow-ups, then drafts an update to the active issue body (never auto-applies).
-- **Outcome:** An audit block the user can paste into the issue — Assumptions Made / Uncertain Decisions / Scope Notes / Follow-ups.
+- **When:** After a draft PR is open and the feature worktree is no longer needed (typically after merge).
+- **What it does:** Removes the feature worktree, deletes the branch, and clears `./.claude/NOTES.md`. Refuses outright on the default branch or out-of-tree paths; on a dirty worktree it surfaces unpushed/uncommitted state and requires an explicit proceed-anyway confirmation. **Not** an audit utility — assumptions, uncertainties, and follow-ups are harvested into the PR body's `## Notes` section by `/implement` before the PR opens.
+- **Outcome:** The worktree directory is gone, the branch is deleted (force-deleted if dirty and the user confirmed), and NOTES.md is removed.
 
 ---
 
@@ -255,3 +257,21 @@ Four tiers, no overlap:
 - **File:** `skills/prune/SKILL.md`
 - **When:** Monthly, or after major refactors.
 - **What it does:** Audits `CLAUDE.md` and auto-memory files for stale / superseded / unclear entries (semantic staleness). When `claude-obsidian` is installed, delegates the vault audit to `wiki-lint` (structural health — orphans, broken wikilinks, missing frontmatter) and folds the findings in. Without `claude-obsidian`, the vault lane is skipped with a one-line note. Never auto-deletes — produces recommendations for user approval.
+
+---
+
+## Maintenance — `/audit-issues` (Sonnet)
+
+- **File:** `skills/audit-issues/SKILL.md`
+- **When:** Periodically, or after a refactor that may have invalidated open issues.
+- **What it does:** Audits open GitHub issues in a target repo against the current local working tree. Runs five drift detectors — file-path-existence, numeric-claim-drift, version-reference-staleness, resolved-open-question, cross-issue-contradiction — and assigns a verdict (`unverifiable` > `premise-shifted` > `superseded by #N` > `contradicted` > `stale` > `valid`). Offers per-issue interactive `[e]dit / [c]lose / [s]kip` actions, mutating only after explicit confirmation. Requires a local clone at `~/Projects/<repo>`.
+- **Outcome:** Issue bodies edited or closed where the user approved; a stdout summary of findings.
+
+---
+
+## Autonomous variant — `/epic-autopilot` (Opus, high effort)
+
+- **File:** `skills/epic-autopilot/SKILL.md`
+- **When:** Large epics where you want the full `/discovery → /define → /implement` chain to run end-to-end with minimal supervision.
+- **What it does:** Five-stage orchestrator with explicit human gates after `/discovery`, after the epic-level `/define`, and after each per-sub-issue `/define`. Once all sub-issues are gated through, the autonomous phase opens the epic branch, computes a Kahn topological sort of the sub-issue dependency graph, dispatches `/implement` per tier as parallel `Task` subagents (with retry-once isolation on failure), and opens draft sub-PRs plus a top-level epic PR. Suppresses `/implement`'s exhausted-exit prompt via the seed-brief `autonomous: true` flag. Resumable from any stage via markers in the epic issue body.
+- **Outcome:** A draft epic PR targeting `main` and one draft sub-PR per sub-issue, each `Part of #<epic>`, with merge-order advisory in the epic PR body.


### PR DESCRIPTION
## Summary

The README skill table and lifecycle diagram had drifted since v0.7.0 (2026-04-27): they were missing `/audit-issues` (#61) and `/epic-autopilot` (#60), and still described `/wrap-up` as the NOTES.md-harvesting issue auditor it was before #58 repurposed it into a worktree+branch cleanup utility. There was also no in-repo CHANGELOG — release notes lived only on GitHub Releases.

### README

- Add `/audit-issues` and `/epic-autopilot` rows to the skill table.
- Rewrite the `/wrap-up` row (it's a post-PR cleanup utility now, not an end-of-session audit).
- Update the `/review` row to mention that it now accepts external PRs (#59).
- Mermaid flowchart: drop the stale "harvest NOTES.md" wrap-up label, place `/epic-autopilot` and `/audit-issues` in the *Other tools* subgraph, refresh the `meta` classDef.
- Link the new `CHANGELOG.md` from the *Releasing* section.

### docs/workflow.md

- Rewrite **Step 6 — `/wrap-up`**: it removes the worktree, deletes the branch, and clears NOTES.md. Refuses on the default branch and out-of-tree paths; surfaces dirty state and requires a proceed-anyway confirmation. The audit block lives in the PR body now, not the issue.
- Augment the Step 3 **PR body wording** table with the fixed `## Summary / ## Testing notes / ## Notes` template and `/implement`'s NOTES.md harvest (#58).
- Add a new **Maintenance — `/audit-issues`** section (drift detectors + verdict taxonomy + interactive edit/close/skip; #61).
- Add a new **Autonomous variant — `/epic-autopilot`** section (five-stage orchestrator with human gates and an autonomous Kahn-topological dispatch phase; #60).

### CHANGELOG.md (new)

A repo-side mirror of GitHub Releases v0.1.0 through v0.7.0 plus an `Unreleased` section covering #58, #59, #60, #61. Per-release notes are still authoritative on GitHub; this file makes the history visible without leaving the source tree.

## Test plan

- [ ] Render `README.md` on GitHub and confirm the Mermaid diagram renders without warnings; new `/epic-autopilot` and `/audit-issues` nodes appear in *Other tools*; `/wrap-up` label reads `remove worktree + branch`.
- [ ] Confirm the skill-table rows for `/audit-issues`, `/epic-autopilot`, `/wrap-up`, and `/review` match what the actual SKILL.md files do.
- [ ] Render `docs/workflow.md` on GitHub and confirm Step 6 describes the cleanup utility, the PR-body wording paragraph below the table reads coherently, and the new Maintenance/Autonomous-variant sections are at the bottom.
- [ ] Confirm `CHANGELOG.md` links resolve (Releases page, per-version compare diffs, Keep a Changelog spec).
- [ ] `grep -r "harvest NOTES.md\|harvests NOTES.md into the issue body" docs README.md` returns no matches (modulo this PR description).