### PR TITLE
fix: refine /implement preflight branch display + orchestrator template terminal-phase carve-out

### DIFF
--- a/_shared/repo-preflight.md
+++ b/_shared/repo-preflight.md
@@ -7,7 +7,7 @@ Used by skills that originate `gh` mutations or `git push` operations. Read this
 1. Run `git remote -v` and `pwd` to detect the repository and working directory. Run `git branch --show-current` (or `git rev-parse --abbrev-ref HEAD`) to detect the current branch.
 2. Display:
    - Detected repository (owner/repo from origin remote URL)
-   - Current branch name
+   - Current branch name (omit when the caller has set `Suppress branch line: true` colocated with the reference — used by worktree-spawning callers like `/implement` where the displayed branch would imply the work lands on the current branch)
    - Working directory path
 3. Ask the user to confirm. Default prompt: "Does this match the repo and branch you intend to operate on?" Callers may override by setting a `Confirmation prompt:` line colocated with the reference.
 4. Do not proceed with any `gh` or `git push` operation until the user explicitly confirms.

--- a/_shared/repo-preflight.md
+++ b/_shared/repo-preflight.md
@@ -9,7 +9,7 @@ Used by skills that originate `gh` mutations or `git push` operations. Read this
    - Detected repository (owner/repo from origin remote URL)
    - Current branch name (omit when the caller has set `Suppress branch line: true` colocated with the reference — used by worktree-spawning callers like `/implement` where the displayed branch would imply the work lands on the current branch)
    - Working directory path
-3. Ask the user to confirm. Default prompt: "Does this match the repo and branch you intend to operate on?" Callers may override by setting a `Confirmation prompt:` line colocated with the reference.
+3. Ask the user to confirm. Default prompt: "Does this match the repo and branch you intend to operate on?" — when the caller has set `Suppress branch line: true`, drop the "and branch" clause so the prompt becomes "Does this match the repo you intend to operate on?" (the user was not shown a branch and should not be asked to confirm one). Callers may override either default by setting a `Confirmation prompt:` line colocated with the reference.
 4. Do not proceed with any `gh` or `git push` operation until the user explicitly confirms.
 
 ## Why

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -8,6 +8,7 @@ model: "<opus for research-leading orchestrators; sonnet for coordinator orchest
 You are leading the <phase name> phase. Your goal is to <objective>.
 
 <!-- Coordinator variants (e.g. /implement): drop step 2 — upstream phases or sub-skills own research. -->
+<!-- Coordinator variants that are terminal phases (e.g. /implement): drop step 5 — output is the PR, not an issue body update. -->
 
 ## Input
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -38,7 +38,10 @@ Skip this gate for **Lightweight** scope.
 
 ## Pre-flight
 
-Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` once at entry. Run `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` if the file list is 3 or more files. Pass `preflight_verified: true` in every seed brief issued to specialists — they skip their own preflight when this flag is set.
+Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` once at entry.
+Suppress branch line: true
+
+Run `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` if the file list is 3 or more files. Pass `preflight_verified: true` in every seed brief issued to specialists — they skip their own preflight when this flag is set.
 
 ## Process
 


### PR DESCRIPTION
## Summary

Two related rough edges in `/implement`'s entry/exit shape (issue #63):

1. **Preflight misleading branch line** — `/implement` now sets `Suppress branch line: true` colocated with its preflight reference. `_shared/repo-preflight.md` step 2 honors the directive and omits the current branch from the displayed preflight, so the user no longer sees `branch: main` at entry when work will actually land on a yet-to-be-created worktree branch.
2. **Orchestrator template terminal-phase carve-out** — `_templates/SKILL.orchestrator.template.md` gains a step-5 carve-out comment mirroring the existing step-2 comment, so new terminal-phase orchestrator skills scaffolded from the template don't inherit "write the handoff artifact" when their output is the PR.

Closes #63.

## Testing notes

- Visual diff: `git diff main...feat/63-refine-implement-entry-exit` — six lines added, two removed across three files.
- Manual repro of AC1: invoke `/implement` from the default branch and observe the preflight display. Before this PR, the user saw `Current branch name: main` (misleading — the work goes to a new worktree branch). After this PR, the branch line is omitted; only repo and working directory remain.
- Manual repro of AC2: open `_templates/SKILL.orchestrator.template.md` — line 11 now contains the terminal-phase carve-out comment immediately below the existing step-2 carve-out at line 10. Wording shape matches.
- AC3 verification: `_shared/handoff-artifact.md:5` ("/implement is the terminal phase — its output is the PR, not an issue body update") and `skills/implement/SKILL.md` rule "Do not write a `## Session handoff` block" remain in agreement; neither was modified in a way that breaks this.

## Notes

- Per the prior decision recorded on the issue, suppressed the branch line via caller-side directive (option B) rather than rendering the to-be-created worktree branch (option A) — `/implement` does not know the branch name at preflight time. Branch naming happens later in `/build`.
- `_shared/repo-preflight.md` step 1 still detects the branch unconditionally; only step 2's display is conditional. This preserves option-A semantics for any future caller that wants to render a custom branch.
- Skipped the optional `_templates/AUTHORING.md` tightening — the terminal-phase note already exists in the `handoff-artifact.md` row of the AUTHORING table; a second mention next to the orchestrator-template pointer would duplicate without adding signal.