### PR TITLE
fix(marketplace): use self-reference source to fix broken updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,11 +11,7 @@
   "plugins": [
     {
       "name": "claude-workflow",
-      "source": {
-        "source": "github",
-        "repo": "misiekhardcore/claude-workflow",
-        "ref": "main"
-      },
+      "source": "./",
       "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discovery → /define → /implement. 17 skills, shared protocols, authoring standard, /new-skill scaffolder.",
       "version": "1.0.1",
       "author": {


### PR DESCRIPTION
## Context

Plugin updates have been failing silently for this repo since at least v0.7.0 → v1.0.0. After running \`/plugin update claude-workflow\`, \`installed_plugins.json\` records the new version and a fresh \`lastUpdated\` timestamp, but:

- the cache directory \`~/.claude/plugins/cache/claude-workflow/\` does not exist on disk at all, and
- \`gitCommitSha\` in the install record never advances past the v0.7.0 commit (\`2e3bc32\`), even after bumps to 1.0.0 and 1.0.1.

Cause: \`marketplace.json\` declared \`source\` as a github-ref object:

\`\`\`json
"source": { "source": "github", "repo": "misiekhardcore/claude-workflow", "ref": "main" }
\`\`\`

For a single-plugin-single-repo marketplace, this forces the loader to perform a *second* clone (separate from the marketplace clone) into a versioned cache directory. That second clone has been failing silently. Other working single-repo plugins (claude-obsidian, claude-hud, worktrunk) all declare \`"source": "./"\`, which points the loader at the marketplace clone itself and removes the redundant step.

## Acceptance Criteria

- \`marketplace.json\` declares \`"source": "./"\` for the single plugin entry.
- After release + \`/plugin update\`, the cache directory under \`~/.claude/plugins/cache/claude-workflow/claude-workflow/<version>/\` is populated, and \`gitCommitSha\` in \`installed_plugins.json\` matches the release tag's commit.

## Testing

- Merge, then run the \`Release\` workflow to cut a patch (e.g. v1.0.2).
- Run \`/plugin update claude-workflow\` and verify the cache directory exists and contains the expected \`skills/\`, \`_shared/\`, etc.
- Confirm that previously-broken slash commands (\`/discovery\`, \`/define\`, \`/implement\`, …) appear in the picker and load.

Users on a broken pre-fix install may need to remove the \`claude-workflow@claude-workflow\` entry from \`~/.claude/plugins/installed_plugins.json\` and reinstall once, since the existing entry points at a non-existent cache.