### PR TITLE
fix(implement): compact context between build→review→verify cycles

### DIFF
--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -77,7 +77,7 @@ payload:
 3. Auto-run `/verify` — spawns QA team, verifies every acceptance criterion. Pass a seed brief with `type: research` (diff + AC + test commands).
 4. **Evaluate findings** (no user prompt):
    - **Clean pass** (`/review` and `/verify` both return no issues) → exit loop, fall through to **PR creation**.
-   - **Findings present** and cycle count < 3 → package a **fix brief** (failing criteria + reviewer findings as `file:line` + prior architectural decisions; no review/verify session history), auto-feed it to `/build`, auto-re-run `/review` and `/verify`. Do not ask the user to confirm the next iteration.
+   - **Findings present** and cycle count < 3 → package a **fix brief** (failing criteria + reviewer findings as `file:line` + prior architectural decisions; no review/verify session history). Before re-entering `/build`, write the fix brief to `./.claude/NOTES.md` and follow `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md` — context editing first (clear cycle N tool outputs already acted on), sub-agent delegation second, `/compact` last resort. After compaction, resume from the fix brief in NOTES.md. Then auto-feed to `/build`, auto-re-run `/review` and `/verify`. Do not ask the user to confirm the next iteration.
    - **Findings present** and cycle count = 3 → exit loop with findings attached; fall through to **PR creation** and surface the remaining findings in the finalize step.
 
 Progress reporting during the loop: emit one status line per cycle (`Cycle N/3 — /build <state>, /review <n findings>, /verify <n failures>`) so the user can follow along, but never pause for input.


### PR DESCRIPTION
## Context

Multi-cycle `/implement` runs (build → review → verify → fix → repeat) accumulate tool outputs from each cycle in the conversation history. By cycle 2 or 3, the context contains superseded diffs, stale test results, and prior review findings that dilute attention and inflate token cost — exactly the context rot pattern described in `_shared/compaction-protocol.md`.

The protocol was already applied in `/build` step 7, but `/implement`'s cycle transition had no equivalent checkpoint.

## Acceptance Criteria

- Before re-entering `/build` on a findings-present cycle transition, the skill instructs Claude to write the fix brief to `./.claude/NOTES.md` and follow the compaction protocol (context editing → sub-agent delegation → `/compact`)
- The autonomous contract is preserved — no user prompt is added; compaction happens between cycles, not instead of the cycle
- NOTES.md is written before any compaction so the fix brief survives the context reset

## Testing

The change is a skill instruction update — no executable code. Verify by running `/implement` on a Standard-scope issue that produces review findings on cycle 1 and confirming that context editing (or `/compact` if needed) fires before cycle 2 begins.