### PR TITLE
fix(implement): run PR creation commands from within the worktree

### DIFF
--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -86,6 +86,8 @@ Progress reporting during the loop: emit one status line per cycle (`Cycle N/3 �
 
 Run these steps automatically, without asking:
 
+**All git and `gh` commands in this block must run from within the worktree root** (`cd <worktree-root>` before the first command if the shell's CWD is not already there). Running from the main repo directory fails because `gh pr create` uses the current directory's branch, which would be `main`.
+
 1. Read `<worktree-root>/.claude/NOTES.md` if it exists. Harvest `## Decisions made this session` and `## Open questions` — these flow into the PR body's `## Notes` section.
 2. Push the branch to remote.
 3. Resolve the PR base. Run `git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null` — if it returns an upstream like `origin/<base>`, strip the `origin/` prefix and use `<base>` as the PR base. If no upstream is configured (standalone invocation in a fresh feature branch), default to the repo's default branch (typically `main`). Stacked-branch orchestrators (e.g. `/epic-autopilot`) pre-set the upstream so the sub-PR targets the correct parent branch.


### PR DESCRIPTION
## Context

`gh pr create` determines which branch to open a PR from using the current directory's git context. When `/implement` runs the PR creation block with the shell's CWD still pointing at the main repo directory (on `main`), the command fails with a misleading error: _"must be on a branch named differently than 'main'"_ — even though the feature branch exists and has been pushed.

This adds an explicit instruction at the top of the PR creation block requiring all `git` and `gh` commands to run from within the worktree root. The note also explains _why_, so the failure mode is recognisable if it recurs.

## Testing

Before: running `gh pr create` from the main repo dir (on `main`) after `/build` produces the confusing error above.

After: the explicit `cd <worktree-root>` note ensures the commands target the feature branch, and the error message in the note makes the root cause immediately identifiable if the CWD slips again.