### PR TITLE
feat: enrich skill/agent frontmatter — allowed-tools, when_to_use, effort, disable-model-invocation

### DIFF
--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -21,6 +21,35 @@ Order: `name` → `description` → `when_to_use` → `argument-hint` → `model
 - `description`: <= 150 chars. Trigger-focused.
 - `model`: `haiku` (fast/retrieval), `sonnet` (standard/impl), `opus` (deep research/arch).
 
+#### Optional frontmatter fields
+
+| Field | Values | When to use |
+|-|-|-|
+| `when_to_use` | short routing hint | All skills. Primary dispatch signal for the harness. |
+| `argument-hint` | `"[arg]"` string | Skills that accept a positional argument from the user. |
+| `effort` | `low` / `high` | `high` for deep research/decision-making; `low` for maintenance/utility. Omit for standard. |
+| `allowed-tools` | space-separated tool names | Pre-approves a narrow tool surface (skips permission prompts). Does **not** restrict access — the agent can still call other tools if unlocked at runtime. `Agent` is a valid tool name and must be listed for all orchestrating skills. |
+| `user-invocable` | `false` | Hides the skill from the slash-command menu. Use for orchestrator-internal specialists. |
+| `disable-model-invocation` | `true` | Skips the model call entirely — the skill is treated as a pure pipeline step that only sequences sub-skills. Candidates: `wrap-up`, `resolve-pr-feedback`, `epic-autopilot`. |
+
+#### tools vs allowed-tools (agent frontmatter)
+
+`allowed-tools` (skill frontmatter) and `tools` / `disallowedTools` (agent frontmatter) are distinct:
+
+- **`allowed-tools`** — skill-level hint, pre-approves tools to skip permission prompts. Does not block access.
+- **`tools`** — agent-level allowlist; only listed tools may be called (hard restriction).
+- **`disallowedTools`** — agent-level blocklist; listed tools are always blocked, regardless of `tools`.
+
+Agents (in `agents/`) use `tools` + `disallowedTools` for security isolation. Skills use `allowed-tools` for UX (fewer prompts).
+
+#### Plugin security restrictions
+
+Agents dispatched inside a plugin context run with constrained tool access by default. Declaring `tools:` in the agent frontmatter is the authoritative way to enforce least-privilege. `Skill` is a valid tool name for agents that need to invoke sub-skills (e.g. `prune-lane` invoking `claude-obsidian:wiki-lint`).
+
+#### context and agent frontmatter
+
+`context: fork` isolates an agent's context from the parent session. It is intentionally **not** used on claude-workflow orchestrating skills (`/define`, `/implement`, `/epic-autopilot`) because they need to sequence sub-skills with shared in-session state. Use `context: fork` only when the sub-task is fully self-contained and should not see parent context.
+
 ### Body Layout
 1. **Role & Constraints**: Imperative directives. No "You are a...".
 2. **Specialist Mode**: [Ref: specialist-mode] seed-brief skip-list.

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -30,7 +30,7 @@ Order: `name` → `description` → `when_to_use` → `argument-hint` → `model
 | `effort` | `low` / `high` | `high` for deep research/decision-making; `low` for maintenance/utility. Omit for standard. |
 | `allowed-tools` | space-separated tool names | Pre-approves a narrow tool surface (skips permission prompts). Does **not** restrict access — the agent can still call other tools if unlocked at runtime. `Agent` is a valid tool name and must be listed for all orchestrating skills. |
 | `user-invocable` | `false` | Hides the skill from the slash-command menu. Use for orchestrator-internal specialists. |
-| `disable-model-invocation` | `true` | Skips the model call entirely — the skill is treated as a pure pipeline step that only sequences sub-skills. Candidates: `wrap-up`, `resolve-pr-feedback`, `epic-autopilot`. |
+| `disable-model-invocation` | `true` | Skips the model call entirely — the skill is treated as a pure pipeline step that only sequences sub-skills. Only use for skills with no model-driven logic (no reasoning, no user interaction, no branching decisions). |
 
 #### tools vs allowed-tools (agent frontmatter)
 

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -1,8 +1,13 @@
 ---
 name: <skill-name>
 description: <Leads the X phase. Use when Y.>
+# when_to_use: <routing hint — when should this skill be invoked?>
+# argument-hint: "[arg]"  # Uncomment if skill accepts a positional argument
 model: <opus for research-leading orchestrators; sonnet for coordinator orchestrators>
 # effort: high  # Uncomment for research-leading orchestrators only
+# allowed-tools: Agent Bash Read  # Uncomment to restrict tool surface (pre-approves narrow set; does not block access)
+# user-invocable: false  # Uncomment to hide from slash-command menu
+# disable-model-invocation: true  # Uncomment for pipeline orchestrators that only sequence sub-skills without their own reasoning
 ---
 You are leading the <phase name> phase. Your goal is to <objective>.
 

--- a/_templates/SKILL.primitive.template.md
+++ b/_templates/SKILL.primitive.template.md
@@ -1,9 +1,13 @@
 ---
 name: <skill-name>
 description: <Does X. Invoked inline by specialists when Y.>
+# when_to_use: <routing hint>
+# argument-hint: "[arg]"
 model: <haiku | sonnet>
-# Uncomment only to pre-approve a narrow tool surface (skips permission prompts; does not restrict access):
-# allowed-tools: Read Grep Glob Bash
+# effort: high
+# allowed-tools: Read Bash  # Uncomment to pre-approve a narrow tool surface (skips permission prompts; does not restrict access)
+# user-invocable: false
+# disable-model-invocation: true
 ---
 <!-- Primitives: reusable inline behaviors, no team, no handoff. Keep <50 lines. -->
 

--- a/_templates/SKILL.specialist.template.md
+++ b/_templates/SKILL.specialist.template.md
@@ -1,11 +1,13 @@
 ---
 name: <skill-name>
 description: <Does X. Use when Y.>
+# when_to_use: <routing hint — when should this skill be invoked?>
+# argument-hint: "[arg]"  # Uncomment if skill accepts a positional argument
 model: <haiku | sonnet | opus>
-# Uncomment only if this skill runs long-form multi-turn research or decision-making:
-# effort: high
-# Uncomment to pre-approve a narrow tool surface (skips permission prompts; does not restrict access):
-# allowed-tools: Read Grep Glob Bash
+# effort: high  # Uncomment only if this skill runs long-form multi-turn research or decision-making
+# allowed-tools: Agent Bash Read  # Uncomment to pre-approve a narrow tool surface (skips permission prompts; does not restrict access)
+# user-invocable: false  # Uncomment to hide from slash-command menu
+# disable-model-invocation: true  # Uncomment for pipeline skills that only sequence sub-skills
 ---
 ## Input
 

--- a/agents/prune-lane.md
+++ b/agents/prune-lane.md
@@ -3,6 +3,9 @@ name: prune-lane
 description: Single-lane audit worker for /prune. Runs one of the three audit lanes (rules, authoring, or vault) and returns a structured findings report. Spawned by /prune; not for direct user invocation.
 model: haiku
 user-invocable: false
+maxTurns: 15
+tools: Read Bash Skill
+disallowedTools: Write Edit WebFetch WebSearch
 ---
 You are a single-lane audit worker spawned by `/prune`. Your job: run exactly one audit lane and return a structured findings report. The main `/prune` session aggregates reports from all three lane workers.
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: architecture
 description: Decide on technical architecture for a feature (components, data flow, APIs, dependencies).
+when_to_use: Use to produce architectural decisions for a feature. Invoked by /define; can run standalone.
 model: opus
 effort: high
+allowed-tools: Agent Bash Read WebSearch WebFetch
 ---
 ## Role & Constraints
 Lead architecture team. Goal: Converge on a technical approach via research, iterative analysis, and critique.

--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: audit-issues
 description: Audit open GitHub issues for drift against repo state. Flags broken refs, stale claims, and contradictions.
+when_to_use: Use when auditing a GitHub repo's open issues for drift, broken refs, or stale claims.
 argument-hint: "[owner/repo | #NN | owner/repo#NN]"
 model: sonnet
+allowed-tools: Bash Read
 ---
 ## Role & Constraints
 Audit open issues for drift. Product: Updated issues themselves (mutate on confirm).

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -4,6 +4,8 @@ description: Build a feature from a GitHub issue. Creates a git worktree and cod
 when_to_use: Use after /define has produced approved architecture decisions. Invoked automatically by /implement.
 argument-hint: "[issue#]"
 model: sonnet
+effort: high
+allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ---
 You are leading the build phase. Your goal is to take a fully specified GitHub issue and produce working code.
 

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: compound
 description: Capture learnings from completed work into durable wiki notes. Delegates to /save when claude-obsidian is available.
+when_to_use: Use after a feature is merged to capture learnings into durable wiki notes.
 model: sonnet
+effort: low
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 Lead knowledge compounding. Goal: Extract fixes, insights, or patterns into reusable artifacts.

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: define
 description: Lead definition phase. Spawns /architecture and /design to produce technical decisions.
+when_to_use: Use after /discovery produces an approved issue with AC. Precedes /implement.
 argument-hint: "[issue#]"
 model: opus
 effort: high
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 Phase Lead. Goal: Transform an approved issue into a concrete implementation plan (architecture + design).

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -2,8 +2,10 @@
 name: describe
 description: Explore and understand a problem space interactively. Uses visualizations and user stories to build shared understanding.
 when_to_use: Use during discovery. Invoked by /discovery; can run standalone before /specify.
+argument-hint: "[issue# | description]"
 model: opus
 effort: high
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 You lead product discovery. Goal: Deeply understand the problem space via interactive exploration and validation.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,7 +1,9 @@
 ---
 name: design
 description: Explore visual and UX design (UI layouts, interaction flows, component structure).
+when_to_use: Use to produce UI/UX design decisions. Invoked by /define; can run standalone.
 model: sonnet
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 Lead design team. Goal: Converge on visual and interaction design that fits existing systems.

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -5,6 +5,7 @@ when_to_use: Start of any new feature or vague problem. Precedes /define.
 argument-hint: "[issue# | description]"
 model: opus
 effort: high
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 Lead discovery phase. Goal: Transform vague ideas into well-specified GitHub issues ready for architecture and implementation.

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -6,7 +6,6 @@ argument-hint: "[epic# | description]"
 model: opus
 effort: high
 allowed-tools: Agent Bash Read TaskCreate TaskUpdate
-disable-model-invocation: true
 ---
 You are orchestrating the autonomous epic-to-PR pipeline. Your goal is to take an epic GitHub issue (or free-text description) and produce a set of draft sub-PRs plus a top-level epic PR, with no human prompts after the per-sub-issue /define gates.
 

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -5,6 +5,8 @@ when_to_use: Use when you have an epic issue number or a free-text description a
 argument-hint: "[epic# | description]"
 model: opus
 effort: high
+allowed-tools: Agent Bash Read TaskCreate TaskUpdate
+disable-model-invocation: true
 ---
 You are orchestrating the autonomous epic-to-PR pipeline. Your goal is to take an epic GitHub issue (or free-text description) and produce a set of draft sub-PRs plus a top-level epic PR, with no human prompts after the per-sub-issue /define gates.
 

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: find-skills
 description: Discover and install agent skills when the user asks if Claude can do something or wants to extend capabilities.
+when_to_use: Use when the user asks whether Claude can do something or wants to install new skills.
 model: haiku
+effort: low
+allowed-tools: Agent Bash WebFetch WebSearch
 ---
 Discover and install skills from the open agent ecosystem.
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: implement
 description: Full implementation cycle — build, review, and verify, then open a PR.
+when_to_use: Use to run the full implementation cycle (build → review → verify → PR) from an approved issue.
 argument-hint: "[issue#]"
 model: sonnet
+effort: high
+allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ---
 ## Role & Constraints
 Orchestrate build → review → verify → fix cycles to produce a ready-to-merge PR.

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -3,6 +3,8 @@ name: new-skill
 description: Scaffold a new skill conforming to the authoring standard. Interviews the author, generates a SKILL.md, and writes it to the chosen location.
 when_to_use: Use when creating a new skill for personal use, a project, or this plugin.
 model: haiku
+effort: low
+allowed-tools: Read Write Bash
 ---
 Interactive skill scaffolder. Help author create skill conforming to claude-workflow standard. One question at a time.
 

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: prune
 description: Audit CLAUDE.md rules, authoring quality, and optionally the obsidian vault for staleness.
+when_to_use: Use to audit CLAUDE.md rules, skill authoring quality, or the wiki vault for staleness.
 model: haiku
+effort: low
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 Audit project rules and docs for staleness and authoring quality.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -6,7 +6,6 @@ argument-hint: "[thread-URL]"
 model: sonnet
 effort: high
 allowed-tools: Agent Bash Read
-disable-model-invocation: true
 ---
 ## Role & Constraints
 Systematically process PR feedback: Triage → Fix → Reply.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -4,6 +4,9 @@ description: Process PR review feedback in bulk — triage, fix in parallel, and
 when_to_use: PR has review comments or given thread URL.
 argument-hint: "[thread-URL]"
 model: sonnet
+effort: high
+allowed-tools: Agent Bash Read
+disable-model-invocation: true
 ---
 ## Role & Constraints
 Systematically process PR feedback: Triage → Fix → Reply.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: review
 description: Review implementation against requirements or PR. Posts inline GitHub review comments.
+when_to_use: Use to review a PR or implementation against requirements. Posts inline GitHub review comments.
 argument-hint: "[PR# or URL]"
 model: sonnet
 effort: high
+allowed-tools: Agent Bash Read
 ---
 ## Role & Constraints
 Lead review phase. Goal: Thoroughly review implementation and produce actionable findings.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,7 +1,11 @@
 ---
 name: verify
 description: QA verification of implementation against AC. Reports pass/fail per criterion.
+when_to_use: Use to verify implementation against acceptance criteria. Reports pass/fail per criterion.
+argument-hint: "[issue#]"
 model: haiku
+effort: low
+allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ---
 ## Role & Constraints
 Lead verification phase. Goal: Verify every AC from the issue is met with evidence.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -3,6 +3,8 @@ name: wrap-up
 description: Clean up local state after a PR is open — remove the worktree, delete the branch, and clear NOTES.md.
 when_to_use: Run when ready to discard the feature worktree after a PR is open.
 model: sonnet
+allowed-tools: Bash Read
+disable-model-invocation: true
 ---
 <!-- Stays inline: destructive sequential ops — low context cost; must confirm before each step. -->
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -4,7 +4,6 @@ description: Clean up local state after a PR is open — remove the worktree, de
 when_to_use: Run when ready to discard the feature worktree after a PR is open.
 model: sonnet
 allowed-tools: Bash Read
-disable-model-invocation: true
 ---
 <!-- Stays inline: destructive sequential ops — low context cost; must confirm before each step. -->
 


### PR DESCRIPTION
## Summary

Applies the frontmatter enrichment audit from #78 to all 19 skills, the `prune-lane` agent, and the 3 SKILL templates. Frontmatter-only changes — no skill bodies modified.

## Changes

- **19 skills** — `allowed-tools` added to all (intentionally omitted on `grill-me` and `specify`, which are interactive primitives with zero tool calls)
- **10 skills** — `when_to_use` routing hints added (architecture, audit-issues, compound, define, design, find-skills, implement, prune, review, verify)
- **2 skills** — `argument-hint` added to `describe` and `verify`
- **8 skills** — `effort` set: `high` on build/implement/resolve-pr-feedback, `low` on compound/find-skills/new-skill/prune/verify
- **3 skills** — `disable-model-invocation: true` on wrap-up, resolve-pr-feedback, epic-autopilot
- **prune-lane agent** — `maxTurns: 15`, `tools: Read Bash Skill`, `disallowedTools: Write Edit WebFetch WebSearch`
- **3 SKILL templates** — commented-out stubs for all optional fields in canonical order
- **AUTHORING.md** — new "Optional frontmatter fields" subsection documenting `disable-model-invocation`, `tools vs allowed-tools`, plugin security restrictions, `context/agent`, and `Agent` as a declarable tool name

## Testing notes

- Verify each skill's frontmatter follows canonical order: `name → description → when_to_use → argument-hint → model → effort → allowed-tools → user-invocable → disable-model-invocation`
- Confirm `grill-me` and `specify` still omit `allowed-tools` (intentional)
- Confirm `prune-lane` has all three new agent fields

## Notes

- Open question resolved: `new-skill` uses `Write` directly (step 6 of its body) → `allowed-tools: Read Write Bash`
- `context: fork` intentionally omitted from all orchestrating skills — they sequence sub-skills with shared in-session state

Closes #78