### PR TITLE
Improve skill authoring quality: conditional when_to_use, modularity, paired prohibitions

### DIFF
--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -16,29 +16,22 @@ All skills map to one of these five roles (extending the [Ref: composition] mode
 ## Structure & Density
 **Goal**: Maximize info-density. Replace narrative with constraints.
 
+### Modularity
+- **Entry-point cap**: Keep skill bodies ≤150 lines. Push stable reference material (schemas, syntax tables, field lists) into `skills/<name>/references/<file>.md`.
+- **`_shared/` promotion**: Promote a doc to `_shared/` when ≥3 skills reference it. Otherwise keep under `skills/<name>/references/`.
+- **On-demand loading**: Never preload `_shared/` files at skill start. Reference via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` only where needed in the Process steps.
+- **`[Ref: name]` shorthand**: In space-constrained bodies use `[Ref: name]` as shorthand for `${CLAUDE_PLUGIN_ROOT}/_shared/name.md`.
+
 ### Frontmatter
-Order: `name` → `description` → `scope` → `when_to_use` → `argument-hint` → `model` → `effort` → `allowed-tools` → `user-invocable` → `disable-model-invocation`.
+Order: `name` → `description` → `when_to_use` → `argument-hint` → `model` → `effort` → `allowed-tools` → `user-invocable` → `disable-model-invocation`.
 - `description`: <= 150 chars. Trigger-focused.
+- `when_to_use`: <= 1,536 chars combined with `description`. Include only when mis-routing is plausible: add explicit exclusions ("Does NOT X — use /Y"), sequence preconditions, or disambiguation from similar skills. Omit when `description` alone is unambiguous.
 - `model`: `haiku` (fast/retrieval), `sonnet` (standard/impl), `opus` (deep research/arch).
-
-#### Required: `scope:`
-Declares what the skill is allowed to operate on. Allowed values:
-
-| Value | Operates on |
-|-|-|
-| `plugin-authoring` | The plugin's own SKILL/template/`_shared` files. |
-| `user-codebase` | The user's project files. |
-| `cross-plugin` | Files in other installed plugins. |
-| `mixed` | Multiple lanes. **Requires** a `## Scope` section in the SKILL.md body enumerating scope per lane. Non-`mixed` skills do not need the body section. |
-
-- **Don't** omit `scope:` — without it, contributors mis-route checks across plugin boundaries (see claude-obsidian#105).
-- **Do** set `scope:` on every SKILL.md and a first-line hint on every `_shared/*.md`.
 
 #### Optional frontmatter fields
 
 | Field | Values | When to use |
 |-|-|-|
-| `when_to_use` | short routing hint | All skills. Primary dispatch signal for the harness. |
 | `argument-hint` | `"[arg]"` string | Skills that accept a positional argument from the user. |
 | `effort` | `low` / `high` | `high` for deep research/decision-making; `low` for maintenance/utility. Omit for standard. |
 | `allowed-tools` | space-separated tool names | Pre-approves a narrow tool surface (skips permission prompts). Does **not** restrict access — the agent can still call other tools if unlocked at runtime. `Agent` is a valid tool name and must be listed for all orchestrating skills. |
@@ -83,12 +76,6 @@ Do not preload. Reference on-demand via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md
 
 `[Ref: name]` is shorthand for `${CLAUDE_PLUGIN_ROOT}/_shared/name.md`. Skills use it for compact inline references in space-constrained skill bodies.
 
-`_shared/*.md` files have no frontmatter. Declare scope as a first-line comment hint:
-```
-<!-- scope: plugin-authoring -->
-# interviewing-rules.md
-```
-
 ## Compaction Checklist
 Before declaring any compaction (density pass, context-hygiene trim) complete:
 - All gates and numeric thresholds preserved verbatim (no approximation).
@@ -111,3 +98,6 @@ Before declaring any compaction (density pass, context-hygiene trim) complete:
 - **Surgical**: One short comment line max.
 - **Dense**: No filler, no preamble, no "The skill does X".
 - **Rational**: Pair every "Don't" with a "Do" (Augment Code study).
+- **Numbered workflows**: Step-by-step processes outperform prose (+25% correctness per Augment study).
+- **Decision tables**: Resolve routing ambiguity before coding (+25% best-practices adherence).
+- **Code snippets**: 3–10 lines from real production use (+20% pattern reuse).

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -17,9 +17,22 @@ All skills map to one of these five roles (extending the [Ref: composition] mode
 **Goal**: Maximize info-density. Replace narrative with constraints.
 
 ### Frontmatter
-Order: `name` → `description` → `when_to_use` → `argument-hint` → `model` → `effort` → `allowed-tools` → `user-invocable` → `disable-model-invocation`.
+Order: `name` → `description` → `scope` → `when_to_use` → `argument-hint` → `model` → `effort` → `allowed-tools` → `user-invocable` → `disable-model-invocation`.
 - `description`: <= 150 chars. Trigger-focused.
 - `model`: `haiku` (fast/retrieval), `sonnet` (standard/impl), `opus` (deep research/arch).
+
+#### Required: `scope:`
+Declares what the skill is allowed to operate on. Allowed values:
+
+| Value | Operates on |
+|-|-|
+| `plugin-authoring` | The plugin's own SKILL/template/`_shared` files. |
+| `user-codebase` | The user's project files. |
+| `cross-plugin` | Files in other installed plugins. |
+| `mixed` | Multiple lanes. **Requires** a `## Scope` section in the SKILL.md body enumerating scope per lane. Non-`mixed` skills do not need the body section. |
+
+- **Don't** omit `scope:` — without it, contributors mis-route checks across plugin boundaries (see claude-obsidian#105).
+- **Do** set `scope:` on every SKILL.md and a first-line hint on every `_shared/*.md`.
 
 #### Optional frontmatter fields
 
@@ -69,6 +82,12 @@ Do not preload. Reference on-demand via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md
 - `composition.md`: Team/sub-agent cost and shape.
 
 `[Ref: name]` is shorthand for `${CLAUDE_PLUGIN_ROOT}/_shared/name.md`. Skills use it for compact inline references in space-constrained skill bodies.
+
+`_shared/*.md` files have no frontmatter. Declare scope as a first-line comment hint:
+```
+<!-- scope: plugin-authoring -->
+# interviewing-rules.md
+```
 
 ## Compaction Checklist
 Before declaring any compaction (density pass, context-hygiene trim) complete:

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -99,9 +99,9 @@ A feature branch in a worktree with all acceptance criteria implemented, tests p
 - Use `superpowers:test-driven-development` for the TDD workflow.
 - Use `git worktree add` / `git worktree remove` for worktree management.
 - Pick the spawn primitive per the Scope Assessment. Lightweight codes inline.
-- Do not ask the user whether to use teams — pick the scope and go.
+- Do not ask the user whether to use teams — pick the scope and go. Pick inline / subagent / team based on the Scope Assessment table above.
 - Do not open a PR — that happens after /implement completes the full cycle.
 - Always run the 5-question verification check before marking a task done.
 - Consolidation scans are lightweight — spend seconds, not minutes.
-- Context hygiene is a build-time responsibility — trigger on concept shifts, not percentages, and never let auto-compact run unattended.
+- Context hygiene is a build-time responsibility — trigger on concept shifts, not percentages, and never let auto-compact run unattended. Trigger `/compact` automatically at concept shifts; delegate bulk I/O to sub-agents before context overruns.
 - `./.claude/NOTES.md` is authoritative for in-flight state; if your recall disagrees, trust the file.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -103,5 +103,5 @@ A feature branch in a worktree with all acceptance criteria implemented, tests p
 - Do not open a PR — that happens after /implement completes the full cycle.
 - Always run the 5-question verification check before marking a task done.
 - Consolidation scans are lightweight — spend seconds, not minutes.
-- Context hygiene is a build-time responsibility — trigger on concept shifts, not percentages, and never let auto-compact run unattended. Trigger `/compact` automatically at concept shifts; delegate bulk I/O to sub-agents before context overruns.
+- Context hygiene is a build-time responsibility — trigger on concept shifts, not percentages. Trigger `/compact` automatically at concept shifts; delegate bulk I/O to sub-agents before context overruns.
 - `./.claude/NOTES.md` is authoritative for in-flight state; if your recall disagrees, trust the file.

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -24,7 +24,9 @@ A brief statement from the author of what the skill should do — or nothing, in
 
    b. **Description** — plain prompt: "In one or two sentences: what does this skill do, and when should it trigger?" Frame as "Does X. Use when Y." This is the primary trigger mechanism — specificity matters more than elegance. If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
 
-   c. **Role** — `AskUserQuestion` with `header: "Role"`, question: "Which role does this skill fill?". Options (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
+   c. **Mis-routing** — plain prompt: "Is mis-routing plausible — could another skill be invoked instead? If yes, describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). If no, type 'skip' — `when_to_use` will be omitted." Only generate `when_to_use` frontmatter when the author identifies an actual disambiguation need; omit otherwise.
+
+   d. **Role** — `AskUserQuestion` with `header: "Role"`, question: "Which role does this skill fill?". Options (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
    - **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
    - **Specialist** — executes a bounded task; receives a seed brief from an orchestrator (e.g. `/build`, `/review`, `/architecture`)
    - **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
@@ -41,31 +43,31 @@ A brief statement from the author of what the skill should do — or nothing, in
    - **No (Recommended)** — omit `user-invocable` (skill appears in menu; default)
    - **Yes** — add `user-invocable: false` (hides from menu; use for orchestrator-internal specialists not meant for direct user invocation)
 
-   d. **Model** — `AskUserQuestion` with `header: "Model"`, question: "Which model fits?". Options:
+   e. **Model** — `AskUserQuestion` with `header: "Model"`, question: "Which model fits?". Options:
    - **sonnet** — standard multi-step workflows, implementation, review
    - **haiku** — fast lookup, formatting, retrieval, light verification
    - **opus** — deep research, architecture, high-stakes decisions
 
-   e. **effort** — `AskUserQuestion` with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?". Options:
+   f. **effort** — `AskUserQuestion` with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?". Options:
    - **Standard** — omit `effort` (default)
    - **High** — add `effort: high` to frontmatter
 
-   f. **argument-hint** — ask: "Does this skill accept a positional argument from the user? If yes, enter the hint text (e.g. `[issue#]`, `[PR# or URL]`). Type 'no' to skip." Store as `argument-hint` when provided; omit when skipped.
+   g. **argument-hint** — ask: "Does this skill accept a positional argument from the user? If yes, enter the hint text (e.g. `[issue#]`, `[PR# or URL]`). Type 'no' to skip." Store as `argument-hint` when provided; omit when skipped.
 
-   g. **allowed-tools** — `AskUserQuestion` with `header: "Tools"`, question: "Should the skill have access to all tools, or a restricted subset?". Options:
+   h. **allowed-tools** — `AskUserQuestion` with `header: "Tools"`, question: "Should the skill have access to all tools, or a restricted subset?". Options:
    - **All tools** — omit the field (default; what most skills want)
    - **Restricted subset** — set `allowed-tools:` explicitly
 
      If the author picks **Restricted subset**, ask one free-text follow-up: "Which tools should it be allowed to use? (space-separated — e.g. `Read Grep Glob Bash`)". Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask). Use the answer verbatim as the value of `allowed-tools:`.
 
-   h. **Parallelism** — `AskUserQuestion` with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?". Options:
+   i. **Parallelism** — `AskUserQuestion` with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?". Options:
    - **No parallelism** — skill runs inline; no sub-agents or teams
    - **Parallel subagents** — skill spawns 2–3 independent subagents (applies to all roles)
    - **TeamCreate** — skill spawns a team (orchestrators / specialists only)
 
      If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up free-text: "Which conditions gate the spawn decision? (reference the rubric in `_shared/composition.md` — e.g., scope class, file count, communication pivot)". Store the answer as a "Spawn justification" block in the skill body.
 
-   i. **Shared protocols** — `AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
+   j. **Shared protocols** — `AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
    - **Handoff artifact** — writes or reads a GitHub issue handoff block → include `handoff-artifact.md`
    - **Interviewing rules** — interviews the user, asks questions, seeks approval → include `interviewing-rules.md`
    - **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
@@ -76,7 +78,7 @@ A brief statement from the author of what the skill should do — or nothing, in
    - **No** — skip `composition.md`
    - **Yes** — include `composition.md`
 
-   j. **Target location** — `AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
+   k. **Target location** — `AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
    - **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
    - **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
    - **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
@@ -91,7 +93,7 @@ A brief statement from the author of what the skill should do — or nothing, in
    Read the selected template — that is the skeleton you will fill in.
 
 4. **Generate the SKILL.md** by filling in the selected template:
-   - Frontmatter: `name`, `description`, `model`; include `effort: high` / `argument-hint: ...` / `allowed-tools: ...` / `user-invocable: false` only when the author opted in; apply the canonical field order from `_templates/AUTHORING.md`
+   - Frontmatter: `name`, `description`, `when_to_use`, `model`; include `effort: high` / `argument-hint: ...` / `allowed-tools: ...` / `user-invocable: false` only when the author opted in; apply the canonical field order from `_templates/AUTHORING.md`
    - Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
    - If the author selected parallelism in step 2h, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
    - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern")
@@ -115,5 +117,6 @@ A single file written to the chosen target location, conforming to the authoring
 - Never write the file without explicit confirmation. "Sounds good" / silence / non-objection is NOT confirmation.
 - The skeleton is intentionally sparse. Do not invent domain content for sections you were not told about — that locks in guesses.
 - If the author skips a question with "skip" or "default", use the documented default (model: sonnet, effort: omit, argument-hint: omit, allowed-tools: omit, user-invocable: omit, target: personal).
+- Only include `when_to_use` when the author identified a mis-routing risk in step b2. Omit it when the author skipped or said "no".
 - If the target directory already contains a `SKILL.md`, stop and ask whether to overwrite or pick a new name.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol.

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -18,13 +18,17 @@ A brief statement from the author of what the skill should do — or nothing, in
 
 2. **Interview the author** — ask ONE question at a time. Do not bundle. See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`.
 
-   Use `AskUserQuestion` for every question with a bounded option set (steps c, d, e, f, g, h). For free-text questions (a, b), use a plain prompt. In each `AskUserQuestion` call, place the recommended option first and append ` (Recommended)` to its label — derive the recommendation from the description collected in step (b).
+   Use `AskUserQuestion` for every question with a bounded option set (steps c–k except free-text follow-ups). For free-text questions (a, b), use a plain prompt. In each `AskUserQuestion` call, place the recommended option first and append ` (Recommended)` to its label — derive the recommendation from the description collected in step (b).
 
    a. **Name** — plain prompt: "What's the skill called?" Must be lowercase kebab-case (e.g. `deploy-to-vercel`). Matches the directory name under `skills/`.
 
    b. **Description** — plain prompt: "In one or two sentences: what does this skill do, and when should it trigger?" Frame as "Does X. Use when Y." This is the primary trigger mechanism — specificity matters more than elegance. If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
 
-   c. **Mis-routing** — plain prompt: "Is mis-routing plausible — could another skill be invoked instead? If yes, describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). If no, type 'skip' — `when_to_use` will be omitted." Only generate `when_to_use` frontmatter when the author identifies an actual disambiguation need; omit otherwise.
+   c. **Mis-routing** — `AskUserQuestion` with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?". Options:
+   - **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
+   - **No / Skip** — omit `when_to_use` frontmatter.
+
+   Only generate `when_to_use` frontmatter when the author answers Yes; omit otherwise.
 
    d. **Role** — `AskUserQuestion` with `header: "Role"`, question: "Which role does this skill fill?". Options (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
    - **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
@@ -88,16 +92,16 @@ A brief statement from the author of what the skill should do — or nothing, in
    - Specialist or Utility → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.specialist.template.md`. For Utility, remove the "Optionally: a seed brief" paragraph from Input — utility skills are user-invocable and don't receive briefs.
    - Primitive → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.primitive.template.md`
 
-   Both orchestrator and specialist templates now include placeholders for parallelism justification (step 2h). Fill these in based on the author's answer.
+   Both orchestrator and specialist templates now include placeholders for parallelism justification (step 2i). Fill these in based on the author's answer.
 
    Read the selected template — that is the skeleton you will fill in.
 
 4. **Generate the SKILL.md** by filling in the selected template:
    - Frontmatter: `name`, `description`, `when_to_use`, `model`; include `effort: high` / `argument-hint: ...` / `allowed-tools: ...` / `user-invocable: false` only when the author opted in; apply the canonical field order from `_templates/AUTHORING.md`
    - Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
-   - If the author selected parallelism in step 2h, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
+   - If the author selected parallelism in step 2i, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
    - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern")
-   - Include `composition.md` reference if the author selected it in step 2i
+   - Include `composition.md` reference if the author selected it in step 2j
 
 5. **Show the draft** to the author in a fenced code block. Ask: "Does this look right? Shall I write it to `<target-path>`? (y/n)". Do not write on silence or "looks good" — require an explicit yes.
 
@@ -117,6 +121,6 @@ A single file written to the chosen target location, conforming to the authoring
 - Never write the file without explicit confirmation. "Sounds good" / silence / non-objection is NOT confirmation.
 - The skeleton is intentionally sparse. Do not invent domain content for sections you were not told about — that locks in guesses.
 - If the author skips a question with "skip" or "default", use the documented default (model: sonnet, effort: omit, argument-hint: omit, allowed-tools: omit, user-invocable: omit, target: personal).
-- Only include `when_to_use` when the author identified a mis-routing risk in step b2. Omit it when the author skipped or said "no".
+- Only include `when_to_use` when the author identified a mis-routing risk in step 2c. Omit it when the author skipped or answered "No / Skip".
 - If the target directory already contains a `SKILL.md`, stop and ask whether to overwrite or pick a new name.
 - See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prune
-description: Audit skill authoring quality and CLAUDE.md rule hygiene.
+description: Audit CLAUDE.md rule hygiene, skill authoring quality, and optionally the Obsidian vault for stale content.
 model: haiku
 effort: low
 allowed-tools: Agent Bash Read
@@ -14,12 +14,22 @@ Audit project rules and docs for staleness and authoring quality.
 3. **Vault**: (Optional) Delegates to `claude-obsidian:wiki-lint`.
 
 ## Process
-**Dispatch**: Before spawning, enumerate files for each lane:
+
+**Lane selection**: Ask the user which lanes to run before doing any work:
+
+`AskUserQuestion` with `header: "Lanes"`, `multiSelect: true`, question: "Which audit lanes should I run?". Pre-select all three. Options:
+- **Rules** — audit `CLAUDE.md` files, imports, and auto-memory for staleness
+- **Authoring** — check `CLAUDE.md` / `AGENTS.md` / `SKILL.md` for structural quality
+- **Vault** — lint the Obsidian wiki for stale/orphaned content (requires claude-obsidian)
+
+**Vault dependency check**: If Vault is selected, check whether the `claude-obsidian` plugin is installed (look for `claude-obsidian:wiki-lint` skill availability). If not installed, note "claude-obsidian not installed, skipping vault lane" and proceed with the remaining selected lanes only.
+
+**Dispatch**: Enumerate files for each selected lane, then spawn one Task sub-agent per selected lane in parallel:
 - **Rules files**: global `~/.claude/CLAUDE.md`, all `@import`ed files, project `CLAUDE.md`, `MEMORY.md` and topic files.
 - **Authoring files**: all `CLAUDE.md`, `AGENTS.md`, `SKILL.md` files under the project root.
 - **Vault files**: none (vault lane uses claude-obsidian tools directly; pass empty list).
 
-Spawn 3 parallel Task sub-agents (one per lane). Each spawn prompt must include: `lane` (rules|authoring|vault), `cwd` (absolute project root path), `files` (pre-enumerated list above), `claude_obsidian_installed` (true/false; vault lane only). Each must start with `cd <cwd> && pwd`.
+Each spawn prompt must include: `lane` (rules|authoring|vault), `cwd` (absolute project root path), `files` (pre-enumerated list above), `claude_obsidian_installed` (true/false; vault lane only). Each must start with `cd <cwd> && pwd`.
 
 ### Rules Lane
 1. **Gather**: Global `CLAUDE.md` → `@imports` → Project `CLAUDE.md` → `MEMORY.md` + topic files.
@@ -35,8 +45,7 @@ Read each file in `files`. Run 5 checks (Cite Augment Code study):
 5. **Decision-Table**: Prose matching "Use X for A, use Y for B" (>= 3 branches) → recommend table conversion.
 
 ### Vault Lane
-- `claude-obsidian:wiki-lint` available → invoke it → flag obsolete concept/entity notes.
-- Otherwise → skip and note installation prompt.
+Invoke `claude-obsidian:wiki-lint` and flag obsolete/orphaned concept and entity notes.
 
 ## Classification & Output
 **Classify Rule items**: `Current` | `Stale` | `Superseded` | `Unclear`.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: prune
-description: Audit CLAUDE.md rules, authoring quality, and optionally the obsidian vault for staleness.
-when_to_use: Use to audit CLAUDE.md rules, skill authoring quality, or the wiki vault for staleness.
+description: Audit skill authoring quality and CLAUDE.md rule hygiene.
 model: haiku
 effort: low
 allowed-tools: Agent Bash Read

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: review
 description: Review implementation against requirements or PR. Posts inline GitHub review comments.
-when_to_use: Use to review a PR or implementation against requirements. Posts inline GitHub review comments.
 argument-hint: "[PR# or URL]"
 model: sonnet
 effort: high
@@ -67,7 +66,7 @@ Lead review phase. Goal: Thoroughly review implementation and produce actionable
 4. **Post**: Atomic REST call via `gh api repos/.../reviews`. `event: "COMMENT"`. Anchor to `headRefOid` (SHA).
 
 ## Rules
-- **Separation**: Never fix issues during review.
+- **Separation**: Never fix issues during review. Report findings in the review output; fixes happen in a subsequent `/build` cycle.
 - **Consensus**: All reviewers must agree before finalizing.
 - **Blocking**: Critical findings block. Deep mode: High-severity blocks for Security/Perf.
 - **Scope**: Flag changes outside issue scope.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: verify
 description: QA verification of implementation against AC. Reports pass/fail per criterion.
-when_to_use: Use to verify implementation against acceptance criteria. Reports pass/fail per criterion.
 argument-hint: "[issue#]"
 model: haiku
 effort: low
@@ -52,7 +51,7 @@ Lead verification phase. Goal: Verify every AC from the issue is met with eviden
 6. **Convergence**: Discuss edge cases → unified QA report.
 
 ## Rules
-- **Separation**: Never fix issues during verification.
+- **Separation**: Never fix issues during verification. Report failures in the verify output; fixes are a `/build` responsibility.
 - **Evidence-Based**: No "it works" — every criterion needs evidence.
 - **Feedback Loop**: Any failure → report goes back to `/build` for fixes.
-- **Isolation**: Never forward build-session history to QA teammates.
+- **Isolation**: Never forward build-session history to QA teammates. Pass only the seed brief and the issue AC to QA agents.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -79,5 +79,5 @@ NOTES.md removed with worktree (was present / was already absent)
 - Refuse outright (no proceed-anyway) when branch is the default branch or worktree path is not in `git worktree list --porcelain`.
 - Use `git branch -D` only when dirty-worktree override was explicitly confirmed by user.
 - Single confirmation covers all removals — do not ask separately for each artifact.
-- Do not write to GitHub issue body. This skill has no handoff artifact.
+- Do not write to GitHub issue body. Use `/compound` to capture learnings into the wiki instead.
 - Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time. NOTES.md removal here is incidental.


### PR DESCRIPTION
## Summary

- **`when_to_use` is now conditional, not required.** Include it only when mis-routing is plausible — explicit exclusions ("Does NOT X — use /Y"), sequence preconditions, or disambiguation from similar skills. Omit when `description` alone is unambiguous. Removes two redundant `when_to_use` fields from `review` and `verify` (verbatim echoes of `description`). Transforms `prune`'s `when_to_use` from an echo into a real exclusion distinguishing it from `/lint`.
- **`scope:` frontmatter field removed.** The proposed field addressed contributor confusion at authoring time, not runtime dispatch. Better `when_to_use` values with explicit exclusions solve the actual problem.
- **Modularity rules added to AUTHORING.md.** ≤150 line skill body cap, `_shared/` promotion rubric (≥3 skills), on-demand loading, `[Ref: name]` shorthand.
- **Writing Style section added.** Formalises Augment Code study findings: numbered workflows (+25% correctness), decision tables (+25% best-practices adherence), code snippets (+20% pattern reuse).
- **`new-skill` interview updated.** Step b2 now asks "Is mis-routing plausible?" instead of "What trigger phrases?", generating `when_to_use` only when the author identifies an actual disambiguation need.
- **Paired Do alternatives added** to orphaned Don'ts in `build`, `review`, `verify`, `wrap-up`.

Closes #89. Supersedes the `scope:` direction from #80.

## Test plan

- [ ] Open a new session, invoke `/new-skill`, and confirm step c (mis-routing) appears before role, and that skipping it produces a SKILL.md without `when_to_use`.
- [ ] Verify `/review` and `/verify` appear in the slash-command menu with only their `description` shown (no `when_to_use` hint).
- [ ] Run `/prune` and confirm it does not offer to lint wiki content (that's `/lint`'s domain).