### PR TITLE
Add verification step to resolve-pr-feedback

### DIFF
--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -49,6 +49,7 @@ Group by category → Present triage summary to user.
 **Mutation (main thread)**:
 1. Post each drafted reply via `gh api .../replies` (safe body passing).
 2. Resolve thread if verdict in {`fixed`, `fixed-differently`, `not-addressing`}.
+3. **Verify**: Run `gh pr view <N> --json reviewThreads` and confirm all threads are resolved before declaring work done.
 
 ## Output
 Summary: Total threads → counts per verdict → commits created → threads needing human attention.


### PR DESCRIPTION
## Summary

- Adds an explicit final check to Phase 4 of the `resolve-pr-feedback` skill: after resolving threads via the GitHub API, run `gh pr view <N> --json reviewThreads` and confirm all threads are resolved before declaring work done.

Moved from [misiekhardcore/claude-config#60](https://github.com/misiekhardcore/claude-config/pull/60) — the rule belongs in the skill, not in the global `CLAUDE.md`.

## Test plan

- [ ] Run `/resolve-pr-feedback` on a PR with feedback and confirm the verification step is executed at the end of Phase 4.