### PR TITLE
feat: add /ship skill — single-issue end-to-end pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ GitHub Releases (with auto-generated notes and source tarballs) remain the canon
 
 ### Added
 
+- **`/ship` skill** — new single-issue end-to-end pipeline that chains `/define` → `/implement` → `/resolve-pr-feedback` (looped to zero unresolved threads) → `/compound` → `/wrap-up`. State-based resume on re-invocation: each `/ship <N>` call reads current issue/PR state and runs only the next applicable phase. Introduced as a new sibling skill rather than extending `/epic-autopilot` to keep the linear single-issue state machine separate from epic fanout logic. (#92)
+
 - **`agents/` directory** — new top-level directory for reusable agent definitions, mirroring the claude-obsidian pattern. Seeded with `agents/prune-lane.md`: a single-lane audit worker for `/prune` that documents the spawn-prompt contract (CWD verification, pre-enumerated file list, structured report output). (#76)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ GitHub Releases (with auto-generated notes and source tarballs) remain the canon
 
 ### Added
 
-- **`/ship` skill** — new single-issue end-to-end pipeline that chains `/define` → `/implement` → `/resolve-pr-feedback` (looped to zero unresolved threads) → `/compound` → `/wrap-up`. State-based resume on re-invocation: each `/ship <N>` call reads current issue/PR state and runs only the next applicable phase. Introduced as a new sibling skill rather than extending `/epic-autopilot` to keep the linear single-issue state machine separate from epic fanout logic. (#92)
+- **`_shared/orchestrator-rules.md`** — new shared protocol extracting rules common to all pipeline orchestrators: CWD verification, delegation (no reimplemented sub-skill logic), no-autonomous-merge, and seed-brief contract. Replaces duplicated rules in `/issue-autopilot` and `/epic-autopilot`.
+
+- **`/issue-autopilot` skill** — new single-issue end-to-end pipeline that chains `/define` → `/implement` → `/resolve-pr-feedback` (looped to zero unresolved threads) → `/compound` → `/wrap-up`. State-based resume on re-invocation: each `/issue-autopilot <N>` call reads current issue/PR state and runs only the next applicable phase. Introduced as a new sibling skill rather than extending `/epic-autopilot` to keep the linear single-issue state machine separate from epic fanout logic. (#92)
 
 - **`agents/` directory** — new top-level directory for reusable agent definitions, mirroring the claude-obsidian pattern. Seeded with `agents/prune-lane.md`: a single-lane audit worker for `/prune` that documents the spawn-prompt contract (CWD verification, pre-enumerated file list, structured report output). (#76)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ flowchart TB
         subgraph Meta["Other tools"]
             direction LR
             EpicAutopilot["/epic-autopilot — autonomous epic→PR"]
+            Ship["/ship — single-issue end-to-end"]
             NewSkill["/new-skill"]
             FindSkills["/find-skills"]
             Prune["/prune — audit memory"]
@@ -77,7 +78,7 @@ flowchart TB
     class Canvas canvas
     class Discovery,Define,Implement orch
     class D_Describe,D_Specify,D_Scout,Df_Arch,Df_Design,I_Build,I_Review,I_Verify spec
-    class GrillMe,NewSkill,FindSkills,Prune,AuditIssues,WrapUp,Compound,ResolvePR,EpicAutopilot,Save,WikiQuery,WikiLint meta
+    class GrillMe,NewSkill,FindSkills,Prune,AuditIssues,WrapUp,Compound,ResolvePR,EpicAutopilot,Ship,Save,WikiQuery,WikiLint meta
     class Obsidian ext
 ```
 
@@ -124,6 +125,7 @@ Without this flag, `TeamCreate` is unavailable. Skills detect its absence and fa
 |`/audit-issues`|Drift-check open GitHub issues against the current repo state|
 |`/find-skills`|Discover and install skills from the ecosystem|
 |`/resolve-pr-feedback`|Process PR review feedback in bulk|
+|`/ship`|Single-issue end-to-end pipeline: `/define` → `/implement` → `/resolve-pr-feedback` → `/compound` → `/wrap-up`|
 |`/new-skill`|Scaffold a new skill conforming to this authoring standard|
 
 ## Optional: claude-obsidian integration

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ flowchart TB
         subgraph Meta["Other tools"]
             direction LR
             EpicAutopilot["/epic-autopilot — autonomous epic→PR"]
-            Ship["/ship — single-issue end-to-end"]
+            IssueAutopilot["/issue-autopilot — single-issue end-to-end"]
             NewSkill["/new-skill"]
             FindSkills["/find-skills"]
             Prune["/prune — audit memory"]
@@ -78,7 +78,7 @@ flowchart TB
     class Canvas canvas
     class Discovery,Define,Implement orch
     class D_Describe,D_Specify,D_Scout,Df_Arch,Df_Design,I_Build,I_Review,I_Verify spec
-    class GrillMe,NewSkill,FindSkills,Prune,AuditIssues,WrapUp,Compound,ResolvePR,EpicAutopilot,Ship,Save,WikiQuery,WikiLint meta
+    class GrillMe,NewSkill,FindSkills,Prune,AuditIssues,WrapUp,Compound,ResolvePR,EpicAutopilot,IssueAutopilot,Save,WikiQuery,WikiLint meta
     class Obsidian ext
 ```
 
@@ -111,6 +111,7 @@ Without this flag, `TeamCreate` is unavailable. Skills detect its absence and fa
 |`/define`|Plan architecture and design; produces the implementation handoff|
 |`/implement`|Full build→review→verify cycle, ends with a draft PR|
 |`/epic-autopilot`|Autonomous epic→PR pipeline; chains `/discovery → /define → /implement` per sub-issue|
+|`/issue-autopilot`|Single-issue end-to-end pipeline: `/define` → `/implement` → `/resolve-pr-feedback` → `/compound` → `/wrap-up`|
 |`/build`|Code against an issue's acceptance criteria using TDD|
 |`/review`|Review an implementation or external PR; correctness, standards, and conditional specialists|
 |`/verify`|QA verification of every acceptance criterion|
@@ -125,7 +126,6 @@ Without this flag, `TeamCreate` is unavailable. Skills detect its absence and fa
 |`/audit-issues`|Drift-check open GitHub issues against the current repo state|
 |`/find-skills`|Discover and install skills from the ecosystem|
 |`/resolve-pr-feedback`|Process PR review feedback in bulk|
-|`/ship`|Single-issue end-to-end pipeline: `/define` → `/implement` → `/resolve-pr-feedback` → `/compound` → `/wrap-up`|
 |`/new-skill`|Scaffold a new skill conforming to this authoring standard|
 
 ## Optional: claude-obsidian integration
@@ -166,11 +166,12 @@ Shared protocols at `_shared/`:
 
 |File|Purpose|
 |-|-|
+|`compaction-protocol.md`|Context editing → delegation → /compact order|
+|`composition.md`|Multi-skill composition patterns and contracts|
 |`handoff-artifact.md`|Five-field GitHub issue handoff structure|
 |`interviewing-rules.md`|One-question-at-a-time interview protocol|
 |`notes-md-protocol.md`|In-phase NOTES.md memory tier|
-|`compaction-protocol.md`|Context editing → delegation → /compact order|
-|`composition.md`|Multi-skill composition patterns and contracts|
+|`orchestrator-rules.md`|Shared rules for pipeline orchestrators: CWD verification, delegation, no-autonomous-merge, seed-brief contract|
 
 ## Releasing
 

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -34,7 +34,7 @@ Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles.
 ## Location and lifecycle
 
 - **Path:** `<worktree-root>/.claude/NOTES.md`.
-- **Created by `/build`** at phase start, immediately after `git worktree add`, with initial task list from issue.
+- **Created by `/build`** at phase start, immediately after `wt switch --create`, with initial task list from issue.
 - **Updated by `/build`** after each completed task, significant decision, and before `/compact`.
 - **Read on resume by `/build`** — before re-reading the issue.
 - **Harvested by `/implement`** at PR-creation time. `## Decisions made this session` and `## Open questions` flow into PR body's `## Notes` section.

--- a/_shared/orchestrator-rules.md
+++ b/_shared/orchestrator-rules.md
@@ -4,7 +4,7 @@ Rules that apply to all pipeline orchestrators (`/issue-autopilot`, `/epic-autop
 
 ## CWD verification
 
-Run [Ref: repo-preflight] at entry. Echo resolved `owner/repo` before every downstream cross-repo `gh` mutation. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
+Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` at entry. Echo resolved `owner/repo` before every downstream cross-repo `gh` mutation. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
 
 ## Delegation
 
@@ -16,4 +16,4 @@ Merging is always a human action. Exit cleanly at the awaiting-merge stage; neve
 
 ## Seed-brief contract
 
-See [Ref: specialist-mode — Autonomous Implement Invocation].
+See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` § Autonomous Implement Invocation.

--- a/_shared/orchestrator-rules.md
+++ b/_shared/orchestrator-rules.md
@@ -1,0 +1,19 @@
+# Orchestrator Rules — Shared Protocol
+
+Rules that apply to all pipeline orchestrators (`/issue-autopilot`, `/epic-autopilot`).
+
+## CWD verification
+
+Run [Ref: repo-preflight] at entry. Echo resolved `owner/repo` before every downstream cross-repo `gh` mutation. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
+
+## Delegation
+
+Each stage delegates to the designated sub-skill. Do not reimplement logic owned by `/implement`, `/resolve-pr-feedback`, `/compound`, `/wrap-up`, or any other sub-skill.
+
+## No autonomous merge
+
+Merging is always a human action. Exit cleanly at the awaiting-merge stage; never trigger a merge.
+
+## Seed-brief contract
+
+See [Ref: specialist-mode — Autonomous Implement Invocation].

--- a/_shared/specialist-mode.md
+++ b/_shared/specialist-mode.md
@@ -36,6 +36,27 @@ Confirmations verifying *state* are skipped; *discovery/rigor* gates remain.
 |`/design`|design-space research|interactive session|
 |`/implement`|(handled by orchestrator)|exhausted-exit prompt (unless `autonomous: true`)|
 
+## Autonomous Implement Invocation
+
+Canonical seed-brief for orchestrators that spawn `/implement` with `autonomous: true`:
+
+```
+<seed-brief>
+preflight_verified: true
+scope_class: <Lightweight | Standard | Deep>
+repo: <owner/repo>
+branch: <feat/slug>
+active_issue: <issue-number>
+autonomous: true
+payload:
+  type: research
+  prior_art: "<Issue #N ## Implementation plan (architecture and design decisions from /define)>"
+  open_questions: "<unresolved constraints from /define, or empty>"
+</seed-brief>
+```
+
+Override only the fields that differ per invocation; all other fields are required as-is.
+
 ## Orchestrator Duties
 1. Run repo/scope-preflight once at entry.
 2. Pass valid seed-brief (`preflight_verified: true`) to every specialist.

--- a/_shared/worktree-protocol.md
+++ b/_shared/worktree-protocol.md
@@ -1,0 +1,25 @@
+# Worktree Protocol — Shared Reference
+
+Standard commands for creating and managing feature worktrees.
+
+## Create
+
+```bash
+git checkout <base-branch> && git pull
+git worktree add .worktrees/<branch> -b <branch>
+cd .worktrees/<branch>
+git branch --set-upstream-to=origin/<base-branch>
+```
+
+`<base-branch>` is `main` for top-level features, or a parent branch for dependent sub-features.
+
+## Verify
+
+```bash
+git worktree list
+git rev-parse --abbrev-ref HEAD   # must equal <branch>
+```
+
+## Remove
+
+Handled by `/wrap-up`. Do not remove manually unless instructed.

--- a/_shared/worktree-protocol.md
+++ b/_shared/worktree-protocol.md
@@ -1,23 +1,20 @@
 # Worktree Protocol — Shared Reference
 
-Standard commands for creating and managing feature worktrees.
+Standard commands for creating and managing feature worktrees using the `wt` CLI.
 
 ## Create
 
 ```bash
-git checkout <base-branch> && git pull
-git worktree add .worktrees/<branch> -b <branch>
-cd .worktrees/<branch>
-git branch --set-upstream-to=origin/<base-branch>
+wt switch --create <branch>                        # base defaults to main
+wt switch --create <branch> --base <base-branch>   # explicit base
 ```
 
-`<base-branch>` is `main` for top-level features, or a parent branch for dependent sub-features.
+`wt switch --create` creates the branch, creates the worktree, sets the upstream tracking branch, and switches into the worktree.
 
 ## Verify
 
 ```bash
-git worktree list
-git rev-parse --abbrev-ref HEAD   # must equal <branch>
+wt list
 ```
 
 ## Remove

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -59,7 +59,7 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` and run when Trigger cond
 
 1. Read the issue, all comments, and linked sub-issues to understand the full scope.
 
-2. **Create a git worktree** (`git worktree add`). Worktrees keep the main workspace clean and let teammates operate in isolation. Lightweight still uses a worktree.
+2. **Create a git worktree** (`wt switch --create`). Worktrees keep the main workspace clean and let teammates operate in isolation. Lightweight still uses a worktree.
 
    Before creating `./.claude/NOTES.md`, verify `/.claude/NOTES.md` is listed in `.gitignore` at repo root; add if missing. Create `./.claude/NOTES.md` with the initial task list harvested from the issue. This is the living worklog — it survives unexpected session close. See `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`.
 
@@ -97,7 +97,7 @@ A feature branch in a worktree with all acceptance criteria implemented, tests p
 ## Rules
 
 - Use `superpowers:test-driven-development` for the TDD workflow.
-- Use `git worktree add` / `git worktree remove` for worktree management.
+- Use `wt switch --create` / `wt remove` for worktree management.
 - Pick the spawn primitive per the Scope Assessment. Lightweight codes inline.
 - Do not ask the user whether to use teams — pick the scope and go. Pick inline / subagent / team based on the Scope Assessment table above.
 - Do not open a PR — that happens after /implement completes the full cycle.

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -72,7 +72,7 @@ Once every sub-issue has an approved `## Implementation plan`, proceed to **Stag
 
 ```
 git checkout main && git pull
-git checkout -b feat/epic-<N>
+wt switch --create feat/epic-<N>
 git commit --allow-empty -m "chore: open epic #<N>"
 git push -u origin feat/epic-<N>
 ```

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -109,8 +109,8 @@ For each tier in ascending order:
 1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
 2. Dispatch all sub-tasks in current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M:
    - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
-   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See `_shared/worktree-protocol.md`.
-   - Pass seed brief to sub-agent's `/implement` invocation. See `_shared/specialist-mode.md` with overrides:
+   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`.
+   - Pass seed brief to sub-agent's `/implement` invocation. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` with overrides:
      - `scope_class`: `Deep`
      - `branch`: `feat/epic-<N>-sub-<M>`
      - `active_issue`: `<M>`
@@ -196,4 +196,4 @@ A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be 
 - Sub-issue branch and worktree names follow `feat/epic-<N>-sub-<M>` exactly. M is the globally unique GitHub sub-issue number.
 - `autonomous: true` in the seed brief is reserved for sub-task spawns from this skill. Do not pass from other orchestrators.
 - `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
-- **Seed-brief contract**: See [Ref: specialist-mode — Autonomous Implement Invocation].
+- **Seed-brief contract**: See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md#Autonomous Implement Invocation`.

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -109,23 +109,13 @@ For each tier in ascending order:
 1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
 2. Dispatch all sub-tasks in current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M:
    - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
-   - Create worktree and branch: `git worktree add .worktrees/feat/epic-<N>-sub-<M> -b feat/epic-<N>-sub-<M> <base-branch>`, then `git branch --set-upstream-to=origin/<base-branch>`.
-   - Pass seed brief to sub-agent's `/implement` invocation:
-
-```
-<seed-brief>
-preflight_verified: true
-scope_class: Deep
-repo: <owner/repo>
-branch: feat/epic-<N>-sub-<M>
-active_issue: <M>
-autonomous: true
-payload:
-  type: research
-  prior_art: "Sub-issue #<M>'s ## Implementation plan (architecture and design decisions from /define)"
-  open_questions: "<any unresolved constraints surfaced during /define for sub-issue #<M>, or empty>"
-</seed-brief>
-```
+   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See [Ref: worktree-protocol].
+   - Pass seed brief to sub-agent's `/implement` invocation. See [Ref: specialist-mode — Autonomous Implement Invocation] with overrides:
+     - `scope_class`: `Deep`
+     - `branch`: `feat/epic-<N>-sub-<M>`
+     - `active_issue`: `<M>`
+     - `payload.prior_art`: `"Sub-issue #<M>'s ## Implementation plan (architecture and design decisions from /define)"`
+     - `payload.open_questions`: unresolved constraints from /define for sub-issue #M, or empty
 
 PR base is communicated via git upstream, not the brief. `/implement` detects it with `git rev-parse --abbrev-ref --symbolic-full-name @{u}` and passes `--base <detected>` to `gh pr create`.
 
@@ -206,4 +196,4 @@ A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be 
 - Sub-issue branch and worktree names follow `feat/epic-<N>-sub-<M>` exactly. M is the globally unique GitHub sub-issue number.
 - `autonomous: true` in the seed brief is reserved for sub-task spawns from this skill. Do not pass from other orchestrators.
 - `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
-- See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the `autonomous` seed-brief field contract.
+- **Seed-brief contract**: See [Ref: specialist-mode — Autonomous Implement Invocation].

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -191,7 +191,7 @@ A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be 
 
 ## Rules
 
-See [Ref: orchestrator-rules] for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/orchestrator-rules.md` for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
 
 - Require explicit user approval at each gate (Stage 1, Stage 2, each Stage 3 sub-issue). Silence is not approval.
 - The user must not modify the epic issue body or any sub-issue body during Stage 4. Sub-agents read at spawn time.

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -109,8 +109,8 @@ For each tier in ascending order:
 1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
 2. Dispatch all sub-tasks in current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M:
    - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
-   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See [Ref: worktree-protocol].
-   - Pass seed brief to sub-agent's `/implement` invocation. See [Ref: specialist-mode — Autonomous Implement Invocation] with overrides:
+   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See `_shared/worktree-protocol.md`.
+   - Pass seed brief to sub-agent's `/implement` invocation. See `_shared/specialist-mode.md` with overrides:
      - `scope_class`: `Deep`
      - `branch`: `feat/epic-<N>-sub-<M>`
      - `active_issue`: `<M>`

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -191,9 +191,10 @@ A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be 
 
 ## Rules
 
+See [Ref: orchestrator-rules] for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
+
 - Require explicit user approval at each gate (Stage 1, Stage 2, each Stage 3 sub-issue). Silence is not approval.
 - The user must not modify the epic issue body or any sub-issue body during Stage 4. Sub-agents read at spawn time.
 - Sub-issue branch and worktree names follow `feat/epic-<N>-sub-<M>` exactly. M is the globally unique GitHub sub-issue number.
 - `autonomous: true` in the seed brief is reserved for sub-task spawns from this skill. Do not pass from other orchestrators.
 - `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
-- **Seed-brief contract**: See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md#Autonomous Implement Invocation`.

--- a/skills/issue-autopilot/SKILL.md
+++ b/skills/issue-autopilot/SKILL.md
@@ -20,7 +20,7 @@ A single positive integer — the GitHub issue number to ship.
 
 On every invocation:
 
-1. Run [Ref: repo-preflight]. Echo resolved `owner/repo` back to the user. Pause for confirmation.
+1. Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
 2. Detect current state using the commands in **State detection** below.
 3. Consult the **Resume state machine** to determine which stage to enter.
 
@@ -40,11 +40,11 @@ On every invocation:
 
 **Entry condition**: Issue has `## Implementation plan`, branch `feat/issue-<N>` does not exist, no open PR.
 
-1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See [Ref: worktree-protocol].
+1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`.
 
 2. Determine `scope_class` from the plan body (look for size/scope hints; default to `Standard`).
 
-3. Run `/implement <N>` from within the worktree. See [Ref: specialist-mode — Autonomous Implement Invocation] with overrides:
+3. Run `/implement <N>` from within the worktree. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` § Autonomous Implement Invocation with overrides:
    - `scope_class`: determined above
    - `branch`: `feat/issue-<N>`
    - `active_issue`: `<N>`
@@ -134,7 +134,7 @@ gh pr view <PR#> --json reviewThreads \
 
 ## Rules
 
-See [Ref: orchestrator-rules] for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/orchestrator-rules.md` for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
 
 - **Loop-break**: In Stage 3, if the unresolved thread count is non-zero and unchanged after one pass, break immediately with a needs-human summary.
 - **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/issue-autopilot` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.

--- a/skills/issue-autopilot/SKILL.md
+++ b/skills/issue-autopilot/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ship
+name: issue-autopilot
 description: Single-issue equivalent of /epic-autopilot. Chains /define → /implement → /resolve-pr-feedback → /compound → /wrap-up for one issue.
 when_to_use: Use when you have a single GitHub issue and want the full lifecycle automated end-to-end with natural pause points for human review and merge.
 argument-hint: "<issue#>"
@@ -20,7 +20,7 @@ A single positive integer — the GitHub issue number to ship.
 
 On every invocation:
 
-1. Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
+1. Run [Ref: repo-preflight]. Echo resolved `owner/repo` back to the user. Pause for confirmation.
 2. Detect current state using the commands in **State detection** below.
 3. Consult the **Resume state machine** to determine which stage to enter.
 
@@ -32,7 +32,7 @@ On every invocation:
 2. `/define` pauses for its own user-approval gate — do not add a second gate.
 3. After `/define` exits, print:
 
-   > Definition complete. Re-invoke `/ship <N>` to continue to implementation.
+   > Definition complete. Re-invoke `/issue-autopilot <N>` to continue to implementation.
 
 4. **Exit.** User re-invokes after reviewing the plan.
 
@@ -40,11 +40,11 @@ On every invocation:
 
 **Entry condition**: Issue has `## Implementation plan`, branch `feat/issue-<N>` does not exist, no open PR.
 
-1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`.
+1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See [Ref: worktree-protocol].
 
 2. Determine `scope_class` from the plan body (look for size/scope hints; default to `Standard`).
 
-3. Run `/implement <N>` from within the worktree. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md#Autonomous Implement Invocation` with overrides:
+3. Run `/implement <N>` from within the worktree. See [Ref: specialist-mode — Autonomous Implement Invocation] with overrides:
    - `scope_class`: determined above
    - `branch`: `feat/issue-<N>`
    - `active_issue`: `<N>`
@@ -55,7 +55,7 @@ On every invocation:
 
 5. After `/implement` exits, print:
 
-   > Draft PR opened. Invite human review, then re-invoke `/ship <N>`.
+   > Draft PR opened. Invite human review, then re-invoke `/issue-autopilot <N>`.
 
 6. **Exit.**
 
@@ -80,8 +80,8 @@ On every invocation:
    | Result | Action |
    |-|-|
    | Final count == 0 | Proceed immediately to Stage 4 in this invocation |
-   | Final count > 0 and decreased | Print "Partial progress: `<before>` → `<after>` unresolved threads. Re-invoke `/ship <N>` after the next review pass." Exit. |
-   | Final count > 0 and unchanged (or `/resolve-pr-feedback` returned `needs-human` verdicts) | Print needs-human summary listing remaining threads. Exit with: "Needs human review — see threads above. Re-invoke `/ship <N>` after addressing them." |
+   | Final count > 0 and decreased | Print "Partial progress: `<before>` → `<after>` unresolved threads. Re-invoke `/issue-autopilot <N>` after the next review pass." Exit. |
+   | Final count > 0 and unchanged (or `/resolve-pr-feedback` returned `needs-human` verdicts) | Print needs-human summary listing remaining threads. Exit with: "Needs human review — see threads above. Re-invoke `/issue-autopilot <N>` after addressing them." |
 
 ### Stage 4 — Zero unresolved, awaiting merge
 
@@ -90,7 +90,7 @@ On every invocation:
 Print:
 
 > PR #`<PR#>` is clean — zero unresolved review threads.
-> Merge the PR on GitHub, then re-invoke `/ship <N>` to capture learnings and clean up.
+> Merge the PR on GitHub, then re-invoke `/issue-autopilot <N>` to capture learnings and clean up.
 
 **Exit.** Merging is a human action; the skill never triggers a merge.
 
@@ -134,9 +134,7 @@ gh pr view <PR#> --json reviewThreads \
 
 ## Rules
 
-- **CWD verification**: Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` at entry, echo `owner/repo`. Before every downstream cross-repo `gh` mutation, re-echo the resolved repo. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
-- **No duplicated logic**: Each stage delegates to the existing skill. No logic from `/implement`, `/resolve-pr-feedback`, `/compound`, or `/wrap-up` is reimplemented here.
-- **No autonomous merge**: Merging is always a human action; exit cleanly at Stage 4.
+See [Ref: orchestrator-rules] for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
+
 - **Loop-break**: In Stage 3, if the unresolved thread count is non-zero and unchanged after one pass, break immediately with a needs-human summary.
-- **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/ship` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.
-- **Seed-brief contract**: See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md#Autonomous Implement Invocation`.
+- **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/issue-autopilot` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -40,33 +40,16 @@ On every invocation:
 
 **Entry condition**: Issue has `## Implementation plan`, branch `feat/issue-<N>` does not exist, no open PR.
 
-1. Pull latest `main` and create worktree:
-
-   ```bash
-   git checkout main && git pull
-   git worktree add .worktrees/feat/issue-<N> -b feat/issue-<N>
-   cd .worktrees/feat/issue-<N>
-   git branch --set-upstream-to=origin/main
-   ```
+1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See [Ref: worktree-protocol].
 
 2. Determine `scope_class` from the plan body (look for size/scope hints; default to `Standard`).
 
-3. Run `/implement <N>` with seed-brief (from within the worktree):
-
-   ```
-   <seed-brief>
-   preflight_verified: true
-   scope_class: <determined above>
-   repo: <owner/repo>
-   branch: feat/issue-<N>
-   active_issue: <N>
-   autonomous: true
-   payload:
-     type: research
-     prior_art: "Issue #<N> ## Implementation plan (architecture and design decisions from /define)"
-     open_questions: "<Open questions from the plan, or empty>"
-   </seed-brief>
-   ```
+3. Run `/implement <N>` from within the worktree. See [Ref: specialist-mode — Autonomous Implement Invocation] with overrides:
+   - `scope_class`: determined above
+   - `branch`: `feat/issue-<N>`
+   - `active_issue`: `<N>`
+   - `payload.prior_art`: `"Issue #<N> ## Implementation plan (architecture and design decisions from /define)"`
+   - `payload.open_questions`: open questions from the plan, or empty
 
 4. `/implement` runs the full build → review → verify cycle and opens a draft PR (`autonomous: true` suppresses its exit prompt).
 
@@ -156,4 +139,4 @@ gh pr view <PR#> --json reviewThreads \
 - **No autonomous merge**: Merging is always a human action; exit cleanly at Stage 4.
 - **Loop-break**: In Stage 3, if the unresolved thread count is non-zero and unchanged after one pass, break immediately with a needs-human summary.
 - **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/ship` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.
-- **Seed-brief contract**: See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the `autonomous` field and full seed-brief format.
+- **Seed-brief contract**: See [Ref: specialist-mode — Autonomous Implement Invocation].

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -20,7 +20,7 @@ A single positive integer — the GitHub issue number to ship.
 
 On every invocation:
 
-1. Run [Ref: repo-preflight]. Echo resolved `owner/repo` back to the user. Pause for confirmation.
+1. Run `_shared/repo-preflight`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
 2. Detect current state using the commands in **State detection** below.
 3. Consult the **Resume state machine** to determine which stage to enter.
 
@@ -40,11 +40,11 @@ On every invocation:
 
 **Entry condition**: Issue has `## Implementation plan`, branch `feat/issue-<N>` does not exist, no open PR.
 
-1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See [Ref: worktree-protocol].
+1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See `_shared/worktree-protocol.md`.
 
 2. Determine `scope_class` from the plan body (look for size/scope hints; default to `Standard`).
 
-3. Run `/implement <N>` from within the worktree. See [Ref: specialist-mode — Autonomous Implement Invocation] with overrides:
+3. Run `/implement <N>` from within the worktree. See `_shared/specialist-mode.md#Autonomous Implement Invocation` with overrides:
    - `scope_class`: determined above
    - `branch`: `feat/issue-<N>`
    - `active_issue`: `<N>`
@@ -134,9 +134,9 @@ gh pr view <PR#> --json reviewThreads \
 
 ## Rules
 
-- **CWD verification**: Run [Ref: repo-preflight] at entry, echo `owner/repo`. Before every downstream cross-repo `gh` mutation, re-echo the resolved repo. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
+- **CWD verification**: Run `_shared/repo-preflight.md` at entry, echo `owner/repo`. Before every downstream cross-repo `gh` mutation, re-echo the resolved repo. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
 - **No duplicated logic**: Each stage delegates to the existing skill. No logic from `/implement`, `/resolve-pr-feedback`, `/compound`, or `/wrap-up` is reimplemented here.
 - **No autonomous merge**: Merging is always a human action; exit cleanly at Stage 4.
 - **Loop-break**: In Stage 3, if the unresolved thread count is non-zero and unchanged after one pass, break immediately with a needs-human summary.
 - **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/ship` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.
-- **Seed-brief contract**: See [Ref: specialist-mode — Autonomous Implement Invocation].
+- **Seed-brief contract**: See `_shared/specialist-mode.md#Autonomous Implement Invocation`.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -20,7 +20,7 @@ A single positive integer — the GitHub issue number to ship.
 
 On every invocation:
 
-1. Run `_shared/repo-preflight.md`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
+1. Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
 2. Detect current state using the commands in **State detection** below.
 3. Consult the **Resume state machine** to determine which stage to enter.
 
@@ -40,11 +40,11 @@ On every invocation:
 
 **Entry condition**: Issue has `## Implementation plan`, branch `feat/issue-<N>` does not exist, no open PR.
 
-1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See `_shared/worktree-protocol.md`.
+1. Pull latest `main` and create worktree for branch `feat/issue-<N>` on base `main`. See `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`.
 
 2. Determine `scope_class` from the plan body (look for size/scope hints; default to `Standard`).
 
-3. Run `/implement <N>` from within the worktree. See `_shared/specialist-mode.md#Autonomous Implement Invocation` with overrides:
+3. Run `/implement <N>` from within the worktree. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md#Autonomous Implement Invocation` with overrides:
    - `scope_class`: determined above
    - `branch`: `feat/issue-<N>`
    - `active_issue`: `<N>`
@@ -134,9 +134,9 @@ gh pr view <PR#> --json reviewThreads \
 
 ## Rules
 
-- **CWD verification**: Run `_shared/repo-preflight.md` at entry, echo `owner/repo`. Before every downstream cross-repo `gh` mutation, re-echo the resolved repo. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
+- **CWD verification**: Run `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` at entry, echo `owner/repo`. Before every downstream cross-repo `gh` mutation, re-echo the resolved repo. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
 - **No duplicated logic**: Each stage delegates to the existing skill. No logic from `/implement`, `/resolve-pr-feedback`, `/compound`, or `/wrap-up` is reimplemented here.
 - **No autonomous merge**: Merging is always a human action; exit cleanly at Stage 4.
 - **Loop-break**: In Stage 3, if the unresolved thread count is non-zero and unchanged after one pass, break immediately with a needs-human summary.
 - **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/ship` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.
-- **Seed-brief contract**: See `_shared/specialist-mode.md#Autonomous Implement Invocation`.
+- **Seed-brief contract**: See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md#Autonomous Implement Invocation`.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: ship
+description: Single-issue equivalent of /epic-autopilot. Chains /define → /implement → /resolve-pr-feedback → /compound → /wrap-up for one issue.
+when_to_use: Use when you have a single GitHub issue and want the full lifecycle automated end-to-end with natural pause points for human review and merge.
+argument-hint: "<issue#>"
+model: opus
+effort: high
+allowed-tools: Agent Bash Read TaskCreate TaskUpdate
+---
+
+You are orchestrating the single-issue ship pipeline. Your goal: take a GitHub issue number and drive it to a merged PR with clean local state — pausing only where human action is required (review, merge).
+
+## Input
+
+A single positive integer — the GitHub issue number to ship.
+
+## Process
+
+### Stage 0 — Resume detection
+
+On every invocation:
+
+1. Run [Ref: repo-preflight]. Echo resolved `owner/repo` back to the user. Pause for confirmation.
+2. Detect current state using the commands in **State detection** below.
+3. Consult the **Resume state machine** to determine which stage to enter.
+
+### Stage 1 — Define gate
+
+**Entry condition**: Issue lacks `## Implementation plan` in its body.
+
+1. Run `/define <N>` (interactive). `/define` produces architecture and design decisions and writes `## Implementation plan` into the issue body.
+2. `/define` pauses for its own user-approval gate — do not add a second gate.
+3. After `/define` exits, print:
+
+   > Definition complete. Re-invoke `/ship <N>` to continue to implementation.
+
+4. **Exit.** User re-invokes after reviewing the plan.
+
+### Stage 2 — Implement
+
+**Entry condition**: Issue has `## Implementation plan`, branch `feat/issue-<N>` does not exist, no open PR.
+
+1. Pull latest `main` and create worktree:
+
+   ```bash
+   git checkout main && git pull
+   git worktree add .worktrees/feat/issue-<N> -b feat/issue-<N>
+   cd .worktrees/feat/issue-<N>
+   git branch --set-upstream-to=origin/main
+   ```
+
+2. Determine `scope_class` from the plan body (look for size/scope hints; default to `Standard`).
+
+3. Run `/implement <N>` with seed-brief (from within the worktree):
+
+   ```
+   <seed-brief>
+   preflight_verified: true
+   scope_class: <determined above>
+   repo: <owner/repo>
+   branch: feat/issue-<N>
+   active_issue: <N>
+   autonomous: true
+   payload:
+     type: research
+     prior_art: "Issue #<N> ## Implementation plan (architecture and design decisions from /define)"
+     open_questions: "<Open questions from the plan, or empty>"
+   </seed-brief>
+   ```
+
+4. `/implement` runs the full build → review → verify cycle and opens a draft PR (`autonomous: true` suppresses its exit prompt).
+
+5. After `/implement` exits, print:
+
+   > Draft PR opened. Invite human review, then re-invoke `/ship <N>`.
+
+6. **Exit.**
+
+### Stage 3 — Resolve PR feedback loop
+
+**Entry condition**: Branch `feat/issue-<N>` exists, open PR on that branch, PR not merged, unresolved review threads > 0.
+
+1. Record initial unresolved thread count:
+
+   ```bash
+   gh pr view <PR#> --json reviewThreads --jq '[.reviewThreads[] | select(.isResolved == false)] | length'
+   ```
+
+2. Echo resolved repo `owner/repo` before the cross-repo mutation.
+
+3. Run `/resolve-pr-feedback` (no thread URL — processes all unresolved threads on this PR).
+
+4. After `/resolve-pr-feedback` exits, record final unresolved count via the same command.
+
+5. Apply **loop-break heuristic**:
+
+   | Result | Action |
+   |-|-|
+   | Final count == 0 | Proceed immediately to Stage 4 in this invocation |
+   | Final count > 0 and decreased | Print "Partial progress: `<before>` → `<after>` unresolved threads. Re-invoke `/ship <N>` after the next review pass." Exit. |
+   | Final count > 0 and unchanged (or `/resolve-pr-feedback` returned `needs-human` verdicts) | Print needs-human summary listing remaining threads. Exit with: "Needs human review — see threads above. Re-invoke `/ship <N>` after addressing them." |
+
+### Stage 4 — Zero unresolved, awaiting merge
+
+**Entry condition** (reached from Stage 3 or on re-invocation): Branch exists, open PR, PR not merged, zero unresolved review threads.
+
+Print:
+
+> PR #`<PR#>` is clean — zero unresolved review threads.
+> Merge the PR on GitHub, then re-invoke `/ship <N>` to capture learnings and clean up.
+
+**Exit.** Merging is a human action; the skill never triggers a merge.
+
+### Stage 5 — Post-merge
+
+**Entry condition**: PR for `feat/issue-<N>` is merged.
+
+1. Echo resolved repo `owner/repo`.
+2. Run `/compound` — review-time learnings pass (autonomous; pass NOTES.md context if present).
+3. Run `/wrap-up` from the worktree root — preserves its interactive confirms (worktree removal is destructive).
+4. Print:
+
+   > Ship complete: PR merged, learnings filed, worktree cleaned.
+
+**Exit.**
+
+## Resume state machine
+
+| State on entry | Stage |
+|-|-|
+| Issue closed, no open PR | Refuse: print state, exit |
+| Issue lacks `## Implementation plan` | Stage 1 — Define gate |
+| Plan present, branch `feat/issue-<N>` absent, no open PR | Stage 2 — Implement |
+| Branch and open PR exist, PR not merged, unresolved threads > 0 | Stage 3 — Resolve PR feedback loop |
+| Branch and open PR exist, PR not merged, unresolved threads == 0 | Stage 4 — Zero unresolved, awaiting merge |
+| PR merged | Stage 5 — Post-merge |
+
+## State detection
+
+```bash
+# Issue state and body
+gh issue view <N> --json state,body
+
+# Open PR on branch
+gh pr list --head feat/issue-<N> --json number,url,state,reviewThreads
+
+# Unresolved thread count (once PR# is known)
+gh pr view <PR#> --json reviewThreads \
+  --jq '[.reviewThreads[] | select(.isResolved == false)] | length'
+```
+
+## Rules
+
+- **CWD verification**: Run [Ref: repo-preflight] at entry, echo `owner/repo`. Before every downstream cross-repo `gh` mutation, re-echo the resolved repo. Pass `preflight_verified: true` in seed briefs so sub-skills skip redundant preflights.
+- **No duplicated logic**: Each stage delegates to the existing skill. No logic from `/implement`, `/resolve-pr-feedback`, `/compound`, or `/wrap-up` is reimplemented here.
+- **No autonomous merge**: Merging is always a human action; exit cleanly at Stage 4.
+- **Loop-break**: In Stage 3, if the unresolved thread count is non-zero and unchanged after one pass, break immediately with a needs-human summary.
+- **Compound placement**: `/implement` already invokes `/compound` at PR creation (implementation-time pass). `/ship` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, no deduplication needed.
+- **Seed-brief contract**: See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for the `autonomous` field and full seed-brief format.

--- a/skills/ship/SKILL.md
+++ b/skills/ship/SKILL.md
@@ -20,7 +20,7 @@ A single positive integer — the GitHub issue number to ship.
 
 On every invocation:
 
-1. Run `_shared/repo-preflight`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
+1. Run `_shared/repo-preflight.md`. Echo resolved `owner/repo` back to the user. Pause for confirmation.
 2. Detect current state using the commands in **State detection** below.
 3. Consult the **Resume state machine** to determine which stage to enter.
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -22,7 +22,7 @@ Gather:
 1. **Worktree path** — `git rev-parse --show-toplevel` from current directory, or use path user provides.
 2. **Branch name** — `git rev-parse --abbrev-ref HEAD`.
 3. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD --short` (strips `origin/`). Fall back to checking `['main', 'master', 'develop']` only when symbolic-ref lookup fails; log which method was used.
-4. **Worktree membership** — `git worktree list --porcelain`. Confirm worktree path appears in this list.
+4. **Worktree membership** — `wt list`. Confirm worktree path appears in this list.
 5. **Working-tree cleanliness** — `git status --short` and `git log @{u}..HEAD --oneline` (unpushed commits not in PR).
 6. **PR state** — if user provided PR number, run `gh pr view <N> --json state,headRefName` to confirm it is open and points to current branch.
 
@@ -31,7 +31,7 @@ Gather:
 |Condition|Outcome|
 |-|-|
 |Branch matches default branch|**Refuse outright.** No proceed-anyway prompt|
-|Worktree path not in `git worktree list --porcelain`|**Refuse outright.** Out-of-tree paths never managed by `/wrap-up`|
+|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed by `/wrap-up`|
 |Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt** (Step 3)|
 |Worktree clean, feature branch, worktree in-tree|**Single confirmation** (Step 4)|
 
@@ -49,8 +49,7 @@ Wait for explicit confirmation. Do not proceed on silence.
 Show the exact actions that will run:
 
 > I will:
-> - `git worktree remove <path>` (removes the worktree directory and its contents, including `.claude/NOTES.md` if present)
-> - `git branch -d <branch>` (or `-D` if commits would be lost)
+> - `wt remove <branch>` (removes the worktree directory, its contents including `.claude/NOTES.md` if present, and the branch)
 >
 > Proceed?
 
@@ -60,9 +59,8 @@ Wait for explicit confirmation. Do not proceed on silence.
 
 On confirm:
 
-1. `git worktree remove <path>` — removes worktree directory. NOTES.md, if still present inside it, is removed implicitly.
-2. `git branch -d <branch>` (or `git branch -D <branch>` when dirty-worktree path was confirmed and commits would be lost).
-3. Report what was removed: worktree path, branch name, whether NOTES.md was present.
+1. `wt remove <branch>` (or `wt remove --force-delete <branch>` when dirty-worktree override was confirmed and commits would be lost) — removes worktree directory and deletes the branch. NOTES.md, if still present inside it, is removed implicitly.
+2. Report what was removed: worktree path, branch name, whether NOTES.md was present.
 
 ## Output
 
@@ -76,8 +74,8 @@ NOTES.md removed with worktree (was present / was already absent)
 
 ## Rules
 
-- Refuse outright (no proceed-anyway) when branch is the default branch or worktree path is not in `git worktree list --porcelain`.
-- Use `git branch -D` only when dirty-worktree override was explicitly confirmed by user.
+- Refuse outright (no proceed-anyway) when branch is the default branch or worktree path is not in `wt list`.
+- Use `wt remove --force-delete` only when dirty-worktree override was explicitly confirmed by user.
 - Single confirmation covers all removals — do not ask separately for each artifact.
 - Do not write to GitHub issue body. Use `/compound` to capture learnings into the wiki instead.
 - Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time. NOTES.md removal here is incidental.


### PR DESCRIPTION
## Summary

Adds `/ship <issue#>`, a new sibling skill that chains `/define` → `/implement` → `/resolve-pr-feedback` → `/compound` → `/wrap-up` for a single issue. State-based resume: each invocation reads current issue/PR state and runs only the next applicable phase, so natural pause points (human review, merge) require no user orchestration.

## Approach

Introduced as a new sibling skill rather than extending `/epic-autopilot` — `/epic-autopilot` is a fanout orchestrator with tier computation, parallel sub-task dispatch, and epic branch management that would be muddied by a linear single-issue state machine.

## Testing notes

Smoke-test plan (AC6): pick a small open issue in this repo, run `/ship <N>` across the natural pauses (define gate → implement → human review → resolve → merge → wrap-up), and verify: PR merged, worktree removed, branch deleted, `/compound` filed a knowledge note.

Smoke-test to be run after this PR is approved and merged (or against a trivial candidate issue in a follow-up).

## Notes

- `/implement` already invokes `/compound` at PR creation (implementation-time learnings). `/ship` re-invokes `/compound` in Stage 5 after merge to capture review-time learnings — two passes, intentionally distinct.
- Loop-break heuristic in Stage 3: if unresolved thread count is non-zero and unchanged after a `/resolve-pr-feedback` pass, the skill breaks with a needs-human summary rather than looping forever.
- CWD verification: `[Ref: repo-preflight]` runs at entry; resolved `owner/repo` is echoed before every downstream cross-repo `gh` mutation; seed briefs carry `preflight_verified: true`.

Closes #92