### PR TITLE
feat(CLAUDE.md): time-box codebase reading during /define and /discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ For the full lifecycle — prerequisites, outcomes, handoffs — see `${CLAUDE_P
 ## Implementation Rules
 
 - **Default to single-agent.** Use `TeamCreate` only for parallelizable work across 3+ independent files or sub-issues. Below that threshold, delegate bulk I/O work to Task sub-agents to prevent main-thread context overrun (see `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` § "Main-thread overrun").
-- **Use the cheapest viable model.** Skills set their own `model:` and `effort:` — trust them.
 - **Respond concisely.** No filler, no preamble.
+- **Use the cheapest viable model.** Skills set their own `model:` and `effort:` — trust them.
+- During `/define` or `/discovery` exploration: time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
 
 ## Token budgets
 

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -42,5 +42,6 @@ Phase Lead. Goal: Transform an approved issue into a concrete implementation pla
 
 ## Rules
 - **Explicit Approval**: Partial feedback ≠ approval.
+- **Exploration**: Time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
 - **Sourcing**: Use [Ref: repo-preflight] before updating issue.
 - [Ref: interviewing-rules]

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -56,6 +56,7 @@ Run [Ref: repo-preflight] before `gh issue`.
 
 ## Rules
 - **Explicit Approval**: Partial feedback ≠ approval.
-- **Traceability**: Every feature must have one issue and >= 1 closing PR.
+- **Exploration**: Time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
 - **Persistence**: Prior-Art Scout findings must be persisted in Prior decisions/Evidence fields.
+- **Traceability**: Every feature must have one issue and >= 1 closing PR.
 - [Ref: interviewing-rules]


### PR DESCRIPTION
## Context

Adds an ambient implementation rule to cap open-ended codebase reading at 3–5 tool calls before asking the user a focused question, preventing unbounded context growth in the define and discovery phases.

This is the plugin-specific counterpart of a generic rule added to `claude-config` in misiekhardcore/claude-config#59.

## Testing

Read `CLAUDE.md` and confirm the new bullet appears under `## Implementation Rules` and references `/define` and `/discovery` specifically.