### PR TITLE
Redesign /prune: drop Rules+Vault lanes, add Dead-state audit

### DIFF
--- a/agents/prune-lane.md
+++ b/agents/prune-lane.md
@@ -47,7 +47,7 @@ Run **only** the lane specified in `lane`. Do not run the other lane.
    - Lines prefixed `scheduled_task:` are stale schedule entries — the suffix is the missing CWD.
    - All other lines are filesystem paths to dead items.
 2. For each item, gather metadata:
-   - Filesystem paths: `stat` for size and mtime; `head -1` for first H1 / first-line snippet (plans only).
+   - Filesystem paths: `stat` for size and mtime; for plans, grep for the first `# …` heading — if none, use the first non-empty line — as the snippet.
    - `scheduled_task:` entries: report the stale CWD string; no filesystem metadata.
 3. Determine `reason` for each item:
    - Path under `~/.claude/projects/<encoded>/`: `dead project directory` (encoded CWD does not resolve on disk)

--- a/agents/prune-lane.md
+++ b/agents/prune-lane.md
@@ -1,22 +1,21 @@
 ---
 name: prune-lane
-description: Single-lane audit worker for /prune. Runs one of the three audit lanes (rules, authoring, or vault) and returns a structured findings report. Spawned by /prune; not for direct user invocation.
+description: Single-lane audit worker for /prune. Runs one of the two audit lanes (authoring or dead-state) and returns a structured findings report. Spawned by /prune; not for direct user invocation.
 model: haiku
 user-invocable: false
 maxTurns: 15
 tools: Read Bash Skill
 disallowedTools: Write Edit WebFetch WebSearch
 ---
-You are a single-lane audit worker spawned by `/prune`. Your job: run exactly one audit lane and return a structured findings report. The main `/prune` session aggregates reports from all three lane workers.
+You are a single-lane audit worker spawned by `/prune`. Your job: run exactly one audit lane and return a structured findings report. The main `/prune` session aggregates reports from all lane workers.
 
 ## Input
 
 A spawn prompt from `/prune` containing:
 
-- `lane`: one of `rules`, `authoring`, or `vault`
+- `lane`: one of `authoring` or `dead-state`
 - `cwd`: absolute path to the project root
-- `files`: pre-enumerated list of files relevant to this lane
-- `claude_obsidian_installed`: `true` / `false` (vault lane only)
+- `files`: pre-enumerated list of paths from `bin/list-prune-files --<lane>`
 
 ## Pre-flight
 
@@ -28,18 +27,7 @@ Confirm the path matches `cwd` before reading any files. Abort if the `cd` fails
 
 ## Process
 
-Run **only** the lane specified in `lane`. Do not run the other lanes.
-
-### Rules lane
-
-1. Read each file in `files` (CLAUDE.md variants + MEMORY.md).
-2. For each rule/guidance item, assess:
-   - Does the tool/command it references still exist?
-   - Does the pattern still apply?
-   - Has it been superseded?
-   - Is it redundant with built-in behavior?
-3. Classify: `current` / `stale` / `superseded` / `unclear`.
-4. Return classification list as structured output (see Output).
+Run **only** the lane specified in `lane`. Do not run the other lane.
 
 ### Authoring lane
 
@@ -52,36 +40,57 @@ Run **only** the lane specified in `lane`. Do not run the other lanes.
    - **Decision-table candidates** — find prose runs with 3+ "use X for A" branches.
 3. Return per-file findings with file path, line number, issue, and citation.
 
-### Vault lane
+### Dead-state lane
 
-1. If `claude_obsidian_installed` is `false`: return `Vault audit skipped — install claude-obsidian to enable.`
-2. If `true`:
-   - Invoke `claude-obsidian:wiki-lint`. Fold returned findings.
-   - Ask `claude-obsidian:wiki-query` to flag notes whose problem/pattern may no longer apply given recent code changes.
-3. Return the combined vault findings.
+1. For each line in `files`:
+   - Lines prefixed `unflagged:` are regular plans — strip the prefix to get the path.
+   - Lines prefixed `scheduled_task:` are stale schedule entries — the suffix is the missing CWD.
+   - All other lines are filesystem paths to dead items.
+2. For each item, gather metadata:
+   - Filesystem paths: `stat` for size and mtime; `head -1` for first H1 / first-line snippet (plans only).
+   - `scheduled_task:` entries: report the stale CWD string; no filesystem metadata.
+3. Determine `reason` for each item:
+   - Path under `~/.claude/projects/<encoded>/`: `dead project directory` (encoded CWD does not resolve on disk)
+   - `.jsonl` file inside a dead project dir: `transcript in dead project`
+   - Path under `~/.claude/agents/`: `orphan agent — no reference found in SKILL.md, settings, or transcripts`
+   - Path under `~/.claude/plugins/cache/`: `stale plugin cache — not the installed version`
+   - `scheduled_task:` entry: `scheduled task pointing at missing CWD`
+   - Path matching `-agent-[0-9a-f]+\.md$` under `~/.claude/plans/`: `sub-agent spawn artifact`
+   - `unflagged:` path: `regular plan (informational)`
+4. Determine scope for each item:
+   - `current project`: path is under `~/.claude/projects/<encoded-cwd>/` where `<encoded-cwd>` = `cwd | tr '/' '-'`
+   - `other projects`: everything else
+5. Set `suggested-action`:
+   - `archive` for all flagged items
+   - `keep` for `unflagged:` regular plans
 
 ## Output
 
 A structured findings report:
 
 ```
-lane: <rules|authoring|vault>
+lane: <authoring|dead-state>
 files_read: <N>
 findings:
-  - file: <path>
+  - file: <path or scheduled_task:<cwd>>
     line: <N or null>
-    classification: <current|stale|superseded|unclear>  # rules lane only
+    scope: <current project|other projects>  # dead-state lane only
     check: <check name>  # authoring lane only
     issue: <description>
     citation: <source>  # authoring lane only
+    reason: <why flagged>  # dead-state lane only
+    snippet: <first H1 or first line>  # dead-state lane, plans only
+    size: <human-readable>  # dead-state lane only
+    mtime: <ISO date>  # dead-state lane only
+    suggested-action: <archive|keep>  # dead-state lane only
     recommendation: <what to do>
 ```
 
-Emit **only** findings — omit items that are `current` / pass all checks. Keep the report under 2,000 tokens so the main thread can aggregate all three without context pressure.
+Emit **only** findings — omit items that pass all checks. Keep the report under 2,000 tokens so the main thread can aggregate all lanes without context pressure.
 
 ## Rules
 
 - Read **only** the files in `files`. Do not enumerate additional files.
 - Do not write to any file — findings are reported to the main thread for approval.
-- Do not run checks from other lanes.
-- If a file is unreadable, emit a finding with `issue: "unreadable"` and `classification: unclear`.
+- Do not run checks from the other lane.
+- If a file is unreadable, emit a finding with `issue: "unreadable"`.

--- a/bin/list-prune-files
+++ b/bin/list-prune-files
@@ -1,44 +1,27 @@
 #!/usr/bin/env bash
 # Enumerate files for /prune audit lanes.
-# Run from the project root. Outputs one path per line, sorted, deduplicated.
-# Usage: list-prune-files [--rules] [--authoring] [--vault]
-# Defaults to all lanes when no flags are given.
+# Usage: list-prune-files [--authoring] [--dead-state]
+# Defaults to --authoring and --dead-state when no flags are given.
 set -euo pipefail
 
-run_rules=false
+CLAUDE_DIR="${HOME}/.claude"
 run_authoring=false
-run_vault=false
+run_dead_state=false
 
 if [[ $# -eq 0 ]]; then
-  run_rules=true
   run_authoring=true
-  run_vault=true
+  run_dead_state=true
 fi
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --rules)     run_rules=true ;;
-    --authoring) run_authoring=true ;;
-    --vault)     run_vault=true ;;
-    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+    --authoring)     run_authoring=true ;;
+    --dead-state)    run_dead_state=true ;;
+    --rules|--vault) echo "Unknown flag: $1" >&2; exit 1 ;;
+    *)               echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
   shift
 done
-
-emit_rules() {
-  [[ -f "${HOME}/.claude/CLAUDE.md" ]] && echo "${HOME}/.claude/CLAUDE.md"
-  [[ -f "./CLAUDE.md" ]] && echo "./CLAUDE.md"
-
-  # @import-referenced files from both CLAUDE.md files
-  grep -h '^@' "${HOME}/.claude/CLAUDE.md" "./CLAUDE.md" 2>/dev/null \
-    | sed 's/^@//' || true
-
-  # project-scoped auto-memory files
-  local memory_dir="${HOME}/.claude/projects/$(pwd | tr '/' '-')/memory"
-  if [[ -d "$memory_dir" ]]; then
-    find "$memory_dir" -name "*.md"
-  fi
-}
 
 emit_authoring() {
   find . \( -name "CLAUDE.md" -o -name "AGENTS.md" -o -name "SKILL.md" \) \
@@ -50,8 +33,115 @@ emit_authoring() {
     ! -name "CLAUDE.md" ! -name "AGENTS.md" ! -name "SKILL.md" 2>/dev/null || true
 }
 
+_emit_dead_projects() {
+  local projects_dir="${CLAUDE_DIR}/projects"
+  [[ -d "$projects_dir" ]] || return 0
+  for proj_dir in "${projects_dir}"/*/; do
+    [[ -d "$proj_dir" ]] || continue
+    local encoded
+    encoded=$(basename "$proj_dir")
+    local decoded
+    decoded=$(printf '%s' "$encoded" | tr '-' '/')
+    if [[ ! -d "$decoded" ]]; then
+      echo "$proj_dir"
+      find "$proj_dir" -name "*.jsonl" 2>/dev/null || true
+    fi
+  done
+}
+
+_emit_orphan_agents() {
+  local agents_dir="${CLAUDE_DIR}/agents"
+  [[ -d "$agents_dir" ]] || return 0
+  for agent_file in "${agents_dir}"/*.md; do
+    [[ -f "$agent_file" ]] || continue
+    local stem found
+    stem=$(basename "$agent_file" .md)
+    found=0
+
+    # Check installed SKILL.md files in plugin cache
+    if [[ -d "${CLAUDE_DIR}/plugins/cache" ]]; then
+      if grep -qr -- "$stem" "${CLAUDE_DIR}/plugins/cache/" \
+          --include="SKILL.md" 2>/dev/null; then
+        found=1
+      fi
+    fi
+
+    # Check settings*.json under ~/.claude/ (maxdepth 3, exclude archive/)
+    if [[ $found -eq 0 ]]; then
+      while IFS= read -r -d $'\0' f; do
+        if grep -q -- "$stem" "$f" 2>/dev/null; then
+          found=1; break
+        fi
+      done < <(find "${CLAUDE_DIR}" -maxdepth 3 -name "settings*.json" \
+          ! -path "${CLAUDE_DIR}/archive/*" -print0 2>/dev/null)
+    fi
+
+    # Check .jsonl transcripts
+    if [[ $found -eq 0 ]] && [[ -d "${CLAUDE_DIR}/projects" ]]; then
+      if grep -qr -- "$stem" "${CLAUDE_DIR}/projects/" \
+          --include="*.jsonl" 2>/dev/null; then
+        found=1
+      fi
+    fi
+
+    if [[ $found -eq 0 ]]; then echo "$agent_file"; fi
+  done
+}
+
+_emit_stale_plugin_caches() {
+  local cache_dir="${CLAUDE_DIR}/plugins/cache"
+  local installed_json="${CLAUDE_DIR}/plugins/installed_plugins.json"
+  [[ -d "$cache_dir" && -f "$installed_json" ]] || return 0
+  command -v jq &>/dev/null || return 0
+
+  local installed_paths
+  installed_paths=$(jq -r '.plugins | to_entries[] | .value[] | .installPath // empty' \
+    "$installed_json" 2>/dev/null | sed "s|^~/|${HOME}/|" | sed 's|/*$||' | sort -u) || true
+  [[ -n "$installed_paths" ]] || return 0
+
+  while IFS= read -r vdir; do
+    local norm="${vdir%/}"
+    if ! grep -qxF "$norm" <<< "$installed_paths"; then
+      echo "$norm"
+    fi
+  done < <(find "$cache_dir" -mindepth 3 -maxdepth 3 -type d \
+      ! -path "${CLAUDE_DIR}/archive/*" 2>/dev/null)
+}
+
+_emit_stale_schedules() {
+  local scheduled_json="${CLAUDE_DIR}/scheduled_tasks.json"
+  [[ -f "$scheduled_json" ]] || return 0
+  command -v jq &>/dev/null || return 0
+  jq -r '.[] | select(.cwd != null) | .cwd' "$scheduled_json" 2>/dev/null \
+    | while IFS= read -r cwd; do
+        [[ -d "$cwd" ]] || echo "scheduled_task:${cwd}"
+      done
+}
+
+_emit_plan_artifacts() {
+  local plans_dir="${CLAUDE_DIR}/plans"
+  [[ -d "$plans_dir" ]] || return 0
+  for plan_file in "${plans_dir}"/*.md; do
+    [[ -f "$plan_file" ]] || continue
+    local bname
+    bname=$(basename "$plan_file")
+    if [[ "$bname" =~ -agent-[0-9a-f]+\.md$ ]]; then
+      echo "$plan_file"
+    else
+      echo "unflagged:${plan_file}"
+    fi
+  done
+}
+
+emit_dead_state() {
+  _emit_dead_projects
+  _emit_orphan_agents
+  _emit_stale_plugin_caches
+  _emit_stale_schedules
+  _emit_plan_artifacts
+}
+
 {
-  if $run_rules;     then emit_rules; fi
-  if $run_authoring; then emit_authoring; fi
-  # --vault: no files (vault lane uses claude-obsidian tools directly)
+  if $run_authoring;  then emit_authoring;  fi
+  if $run_dead_state; then emit_dead_state; fi
 } | sort -u

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -60,17 +60,22 @@ Regular plans appear in the table with `suggested-action: keep` and a snippet.
 **Approval gate**: Single `AskUserQuestion` over the full dead-state candidate table. Question: "Which items should be archived?". `multiSelect: true`. Pre-select all `suggested-action: archive` items. If the user excludes any, drop those paths before proceeding.
 
 **Archive step** (for approved items only):
-```bash
-archive_root="${HOME}/.claude/archive/$(date -I)"
-# for each approved path <src>:
-rel="${src#${HOME}/.claude/}"
-dst="${archive_root}/${rel}"
-mkdir -p "$(dirname "$dst")"
-mv "$src" "$dst"
-echo "${src} → ${dst}"
-```
 
-Never use `rm`. Print a manifest of moved paths (`src → dst` per line).
+Two item types need different treatment:
+
+- **Filesystem paths** (project dirs, agents, plugin caches, plan files): move with `mv`.
+  ```bash
+  archive_root="${HOME}/.claude/archive/$(date -I)"
+  rel="${src#${HOME}/.claude/}"
+  dst="${archive_root}/${rel}"
+  mkdir -p "$(dirname "$dst")"
+  mv "$src" "$dst"
+  echo "${src} → ${dst}"
+  ```
+
+- **`scheduled_task:<cwd>` entries**: not filesystem paths — edit `scheduled_tasks.json` in place, removing the entry whose `cwd` matches `<cwd>`. Report as `removed from scheduled_tasks.json: <cwd>`.
+
+Never use `rm`. Print a manifest (`src → dst` or `removed from ...: <cwd>` per item).
 
 ## Classification & Output
 **Classify Authoring items**: `Current` | `Stale` | `Superseded` | `Unclear`.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -37,7 +37,7 @@ Always audits global `~/.claude/` regardless of CWD. Flags the following classes
 - `~/.claude/projects/<encoded>/` dirs whose encoded CWD does not resolve to any directory on disk.
 - `.jsonl` transcripts inside those flagged directories.
 - `~/.claude/agents/*.md` files not referenced by any installed skill, `settings*.json`, or recent transcript.
-- `~/.claude/plugins/cache/<plugin>/<version>/` dirs whose version is not the currently installed one.
+- `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` dirs whose version is not the currently installed one.
 - `~/.claude/scheduled_tasks.json` entries pointing at a CWD that no longer exists.
 - `~/.claude/plans/*-agent-<hex>.md` files (sub-agent spawn artifacts). Always candidates.
 
@@ -73,12 +73,11 @@ Two item types need different treatment:
   echo "${src} → ${dst}"
   ```
 
-- **`scheduled_task:<cwd>` entries**: not filesystem paths — edit `scheduled_tasks.json` in place, removing the entry whose `cwd` matches `<cwd>`. Report as `removed from scheduled_tasks.json: <cwd>`.
+- **`scheduled_task:<cwd>` entries**: not filesystem paths — first copy `~/.claude/scheduled_tasks.json` to `${archive_root}/scheduled_tasks.json` (preserves the original state), then edit the original in place to remove every approved entry. Report as `archived scheduled_tasks.json → ${archive_root}/scheduled_tasks.json; removed entries: <cwd1>, <cwd2>, …`.
 
 Never use `rm`. Print a manifest (`src → dst` or `removed from ...: <cwd>` per item).
 
 ## Classification & Output
-**Classify Authoring items**: `Current` | `Stale` | `Superseded` | `Unclear`.
 
 **Final Report**:
 - Authoring findings (grouped by file, cite source, specific issue).
@@ -87,7 +86,6 @@ Never use `rm`. Print a manifest (`src → dst` or `removed from ...: <cwd>` per
 
 ## Rules
 - **No Delete**: Archive only — never `rm` any file.
-- **Conservative**: "Unclear" >= "Stale".
 - **Aggregate Only**: Main thread synthesizes sub-agent output; no re-reading files.
 - **Surgical**: Only list authoring findings; do not rewrite files.
 - **Vault**: Vault health is out of scope. Direct users to run `/lint` separately.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,37 +1,28 @@
 ---
 name: prune
-description: Audit CLAUDE.md rule hygiene, skill authoring quality, and optionally the Obsidian vault for stale content.
+description: Audit skill authoring quality and prune dead state from ~/.claude/. Vault health is delegated to /lint.
 model: haiku
 effort: low
-allowed-tools: Agent Bash Read
+allowed-tools: Agent AskUserQuestion Bash Read
 ---
 ## Role & Constraints
-Audit project rules and docs for staleness and authoring quality.
+Audit skill authoring quality and dead state in `~/.claude/`. Archive approved candidates — never delete.
 
 ## Lanes
-1. **Rules**: Audits `CLAUDE.md` (global/project), imports, and auto-memory.
-2. **Authoring**: Checks `CLAUDE.md` / `AGENTS.md` / `SKILL.md` for structural quality based on Augment Code study.
-3. **Vault**: (Optional) Delegates to `claude-obsidian:wiki-lint`.
+1. **Authoring**: Checks `CLAUDE.md` / `AGENTS.md` / `SKILL.md` for structural quality.
+2. **Dead-state**: Audits global `~/.claude/` for dead project dirs, orphan agents, stale plugin caches, stale scheduled tasks, and sub-agent plan artifacts.
 
 ## Process
 
 **Lane selection**: Ask the user which lanes to run before doing any work:
 
-`AskUserQuestion` with `header: "Lanes"`, `multiSelect: true`, question: "Which audit lanes should I run?". Pre-select all three. Options:
-- **Rules** — audit `CLAUDE.md` files, imports, and auto-memory for staleness
+`AskUserQuestion` with `header: "Lanes"`, `multiSelect: true`, question: "Which audit lanes should I run?". Pre-select both. Options:
 - **Authoring** — check `CLAUDE.md` / `AGENTS.md` / `SKILL.md` for structural quality
-- **Vault** — lint the Obsidian wiki for stale/orphaned content (requires claude-obsidian)
-
-**Vault dependency check**: If Vault is selected, check whether the `claude-obsidian` plugin is installed (look for `claude-obsidian:wiki-lint` skill availability). If not installed, note "claude-obsidian not installed, skipping vault lane" and proceed with the remaining selected lanes only.
+- **Dead-state** — flag dead project dirs, orphan agents, stale plugin caches, stale schedules, and sub-agent artifacts in `~/.claude/`
 
 **Dispatch**: Run `bin/list-prune-files --<lane>` from the project root for each selected lane to get a concrete file list, then spawn one Task sub-agent per selected lane in parallel.
 
-Each spawn prompt must include: `lane` (rules|authoring|vault), `cwd` (absolute project root path), `files` (pre-enumerated list above), `claude_obsidian_installed` (true/false; vault lane only). Each must start with `cd <cwd> && pwd`.
-
-### Rules Lane
-1. **Gather**: Global `CLAUDE.md` → `@imports` → Project `CLAUDE.md` → `MEMORY.md` + topic files.
-2. **Assess**: Does tool/command exist? Does pattern apply? Superseded? Redundant with built-in behavior?
-3. **Auto-Memory**: Is info accurate? Redundant with `CLAUDE.md`?
+Each spawn prompt must include: `lane` (authoring|dead-state), `cwd` (absolute project root path), `files` (pre-enumerated list above). Each must start with `cd <cwd> && pwd`.
 
 ### Authoring Lane
 Read each file in `files`. Run 5 checks (Cite Augment Code study):
@@ -41,21 +32,57 @@ Read each file in `files`. Run 5 checks (Cite Augment Code study):
 4. **Architecture Smell**: Headings like `Architecture`/`Overview` exceeding 30 lines → recommend relocation to reference file.
 5. **Decision-Table**: Prose matching "Use X for A, use Y for B" (>= 3 branches) → recommend table conversion.
 
-### Vault Lane
-Invoke `claude-obsidian:wiki-lint` and flag obsolete/orphaned concept and entity notes.
+### Dead-state Lane
+Always audits global `~/.claude/` regardless of CWD. Flags the following classes:
+- `~/.claude/projects/<encoded>/` dirs whose encoded CWD does not resolve to any directory on disk.
+- `.jsonl` transcripts inside those flagged directories.
+- `~/.claude/agents/*.md` files not referenced by any installed skill, `settings*.json`, or recent transcript.
+- `~/.claude/plugins/cache/<plugin>/<version>/` dirs whose version is not the currently installed one.
+- `~/.claude/scheduled_tasks.json` entries pointing at a CWD that no longer exists.
+- `~/.claude/plans/*-agent-<hex>.md` files (sub-agent spawn artifacts). Always candidates.
+
+Regular plans (`~/.claude/plans/*.md` without `-agent-` suffix) are listed informational-only with `mtime`, size, and first H1/first-line snippet. `suggested-action: keep`.
+
+## Aggregation & Archive
+
+After both sub-agents return:
+
+**Authoring output**: Report findings grouped by file (path, line, issue, recommendation).
+
+**Dead-state output**: Print full candidate table grouped by scope (`current project` / `other projects`):
+
+```
+path | size | mtime | reason | suggested-action
+```
+
+Regular plans appear in the table with `suggested-action: keep` and a snippet.
+
+**Approval gate**: Single `AskUserQuestion` over the full dead-state candidate table. Question: "Which items should be archived?". `multiSelect: true`. Pre-select all `suggested-action: archive` items. If the user excludes any, drop those paths before proceeding.
+
+**Archive step** (for approved items only):
+```bash
+archive_root="${HOME}/.claude/archive/$(date -I)"
+# for each approved path <src>:
+rel="${src#${HOME}/.claude/}"
+dst="${archive_root}/${rel}"
+mkdir -p "$(dirname "$dst")"
+mv "$src" "$dst"
+echo "${src} → ${dst}"
+```
+
+Never use `rm`. Print a manifest of moved paths (`src → dst` per line).
 
 ## Classification & Output
-**Classify Rule items**: `Current` | `Stale` | `Superseded` | `Unclear`.
+**Classify Authoring items**: `Current` | `Stale` | `Superseded` | `Unclear`.
 
 **Final Report**:
-- Total audited items.
-- Items by classification.
 - Authoring findings (grouped by file, cite source, specific issue).
-- Vault results.
+- Dead-state archive manifest (or "No items archived.").
 - Specific recommendations + suggested edits.
 
 ## Rules
-- **No Auto-Delete**: Present recommendations → wait for approval.
+- **No Delete**: Archive only — never `rm` any file.
 - **Conservative**: "Unclear" >= "Stale".
 - **Aggregate Only**: Main thread synthesizes sub-agent output; no re-reading files.
 - **Surgical**: Only list authoring findings; do not rewrite files.
+- **Vault**: Vault health is out of scope. Direct users to run `/lint` separately.


### PR DESCRIPTION
## Summary

Fixes issue #93. Removes Rules and Vault lanes (which produced false positives or duplicated other tools) and adds a new Dead-state lane that audits global `~/.claude/` for dead project directories, orphan agents, stale plugin caches, stale scheduled tasks, and sub-agent plan artifacts. Approved items are archived (moved to `~/.claude/archive/`) rather than deleted.

## Changes

- **`bin/list-prune-files`**: Remove Rules lane, remove Vault flag, add Dead-state enumeration with 6 target classes
- **`agents/prune-lane.md`**: Remove Rules and Vault lane docs, add Dead-state lane with metadata gathering and scope grouping
- **`skills/prune/SKILL.md`**: Drop Rules/Vault lanes, add Dead-state lane docs, add approval gate and archive step

## Verification

✓ All 10 acceptance criteria pass

## Testing notes

- Smoke-tested `--rules`, `--vault` (exit 1), `--dead-state` (enumerates, exit 0)
- Verified `~/.claude/archive/` exclusion for idempotency
- Verified jq filter for installed_plugins.json structure

Closes #93