### PR TITLE
slim: reduce find-skills skill to 50-line cap

### DIFF
--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -29,6 +29,6 @@ Browse at https://skills.sh/.
 
 ## How to Help Users Find Skills
 
-[Ref: references/search-guide.md]
+Read `references/search-guide.md`.
 
-For search strategy tips, skill categories, and fallback guidance (when no skills are found), [Ref: references/categories.md].
+For search strategy tips, skill categories, and fallback guidance (when no skills are found), see `references/categories.md`.

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -17,15 +17,16 @@ Use this skill when the user:
 - Says "find a skill for X" or "is there a skill for X"
 - Asks "can you do X" where X is a specialized capability
 - Expresses interest in extending agent capabilities or mentions needing help with a specific domain
+- Searches for tools, templates, workflows, or examples to use
 
 ## The Skills CLI
 
 The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Key commands:
 - `npx skills find [query]` — search for skills
 - `npx skills add <package>` — install a skill
-- `npx skills check` / `update` — check/update all skills
+- `npx skills check` / `npx skills update` — check/update all skills
 
-Browse at https://skills.sh/.
+Browse at https://skills.sh/
 
 ## How to Help Users Find Skills
 

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -13,106 +13,22 @@ Discovery sub-agent (haiku) for search + leaderboard fetch (payoff ≥3×; retri
 ## When to Use This Skill
 
 Use this skill when the user:
-
 - Asks "how do I do X" where X might be a common task with an existing skill
 - Says "find a skill for X" or "is there a skill for X"
 - Asks "can you do X" where X is a specialized capability
-- Expresses interest in extending agent capabilities
-- Wants to search for tools, templates, or workflows
-- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+- Expresses interest in extending agent capabilities or mentions needing help with a specific domain
 
-## What is the Skills CLI?
+## The Skills CLI
 
-The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Key commands:
+- `npx skills find [query]` — search for skills
+- `npx skills add <package>` — install a skill
+- `npx skills check` / `update` — check/update all skills
 
-**Key commands:**
-
-- `npx skills find [query]` - Search for skills interactively or by keyword
-- `npx skills add <package>` - Install a skill from GitHub or other sources
-- `npx skills check` - Check for skill updates
-- `npx skills update` - Update all installed skills
-
-**Browse skills at:** https://skills.sh/
+Browse at https://skills.sh/.
 
 ## How to Help Users Find Skills
 
-### Step 1: Understand What They Need
+[Ref: references/search-guide.md]
 
-When a user asks for help with something, identify:
-
-1. The domain (e.g., React, testing, design, deployment)
-2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
-3. Whether this is a common enough task that a skill likely exists
-
-### Step 2: Dispatch a Discovery Sub-agent
-
-Delegate steps 3–4 (leaderboard check + CLI search) to a research sub-agent. Pass: query terms derived from step 1, the user's stated goal. The sub-agent returns a list of candidate skills with one-line summaries, install counts, and source reputations. The main thread handles install confirmation and execution.
-
-Sub-agent spawn prompt must start with:
-```
-cd <cwd> && pwd  # verify CWD — sub-agents do not inherit parent CWD
-```
-
-### Step 3: Check the Leaderboard First (sub-agent)
-
-Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
-
-For example, top skills for web development include:
-- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
-- `anthropics/skills` — Frontend design, document processing (100K+ installs)
-
-### Step 4: Search for Skills (sub-agent)
-
-If the leaderboard doesn't cover the user's need, run the find command:
-
-```bash
-npx skills find [query]
-```
-
-For example:
-
-- User asks "how do I make my React app faster?" → `npx skills find react performance`
-- User asks "can you help me with PR reviews?" → `npx skills find pr review`
-- User asks "I need to create a changelog" → `npx skills find changelog`
-
-### Step 5: Verify Quality Before Recommending (sub-agent)
-
-**Do not recommend a skill based solely on search results.** Always verify:
-
-1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
-2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
-3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
-
-### Step 6: Present Options to the User (main thread)
-
-When the sub-agent returns candidate skills, present them to the user with:
-
-1. The skill name and what it does
-2. The install count and source
-3. The install command they can run
-4. A link to learn more at skills.sh
-
-Example response:
-
-```
-I found a skill that might help! The "react-best-practices" skill provides
-React and Next.js performance optimization guidelines from Vercel Engineering.
-(185K installs)
-
-To install it:
-npx skills add vercel-labs/agent-skills@react-best-practices
-
-Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
-```
-
-### Step 7: Offer to Install (main thread)
-
-If the user wants to proceed, install the skill:
-
-```bash
-npx skills add <owner/repo@skill> -g -y
-```
-
-The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
-
-Read `skills/find-skills/references/categories.md` when you need to help users refine their search strategy or handle cases where no skills are found. It includes common skill categories, search tips, and fallback guidance for users.
+For search strategy tips, skill categories, and fallback guidance (when no skills are found), [Ref: references/categories.md].

--- a/skills/find-skills/references/search-guide.md
+++ b/skills/find-skills/references/search-guide.md
@@ -1,0 +1,80 @@
+# How to Help Users Find Skills
+
+## Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+## Step 2: Dispatch a Discovery Sub-agent
+
+Delegate steps 3–4 (leaderboard check + CLI search) to a research sub-agent. Pass: query terms derived from step 1, the user's stated goal. The sub-agent returns a list of candidate skills with one-line summaries, install counts, and source reputations. The main thread handles install confirmation and execution.
+
+Sub-agent spawn prompt must start with:
+```
+cd <cwd> && pwd  # verify CWD — sub-agents do not inherit parent CWD
+```
+
+## Step 3: Check the Leaderboard First (sub-agent)
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+## Step 4: Search for Skills (sub-agent)
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+## Step 5: Verify Quality Before Recommending (sub-agent)
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+## Step 6: Present Options to the User (main thread)
+
+When the sub-agent returns candidate skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+## Step 7: Offer to Install (main thread)
+
+If the user wants to proceed, install the skill:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.


### PR DESCRIPTION
Closes #102

Extracts inline how-to guide to references/search-guide.md. SKILL.md retains trigger conditions and flow within the 50-line cap.