### PR TITLE
slim: reduce epic-autopilot skill to 50-line cap

### DIFF
--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -7,194 +7,39 @@ model: opus
 effort: high
 allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ---
-You are orchestrating the autonomous epic-to-PR pipeline. Your goal is to take an epic GitHub issue (or free-text description) and produce a set of draft sub-PRs plus a top-level epic PR, with no human prompts after the per-sub-issue /define gates.
+Orchestrate the autonomous epic-to-PR pipeline. Take an epic GitHub issue (or free-text description) and produce draft sub-PRs plus a top-level epic PR, with explicit user approval at gates.
 
 ## Input
 
-A single argument — either:
+- **Positive integer** → existing GitHub epic issue number.
+- **Any other string** → free-text description; `/discovery` will create the epic issue.
 
-- **Positive integer** → treated as existing GitHub epic issue number. Parse: `int(arg) > 0`.
-- **Any other string** → treated as free-text description; `/discovery` will create the epic issue.
+## Scope & Spawn
 
-## Scope Assessment
+**Always Deep** — fanout orchestrator spawning sub-agents throughout.
 
-Always **Deep** — this is a fanout orchestrator. No inline path exists; the skill always spawns sub-agents.
+- Per-sub-issue /define gate: sequential single-subagent per sub-issue (model: sonnet).
+- Autonomous phase: parallel Task sub-agents per tier (model: opus per sub-agent).
 
-### Spawn justification
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for spawn rubric.
 
-Rubric: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
+## Process [Ref: references/stages.md]
 
-- **Per-sub-issue /define gate**: sequential single-subagent per sub-issue. Model: sonnet. Fallback: n/a.
-- **Autonomous phase — parallel Task sub-agents per tier**: one Task sub-agent per sub-issue within a tier, dispatched in a single message. Disjoint (each works on separate branch), parallel (tier-independent), payoff ≥3×. Model: opus per sub-agent. Fallback: sequential.
+- **Stage 0**: Resume detection — read epic and sub-issue bodies; consult Resume logic table.
+- **Stage 1**: Discovery gate — run /discovery if no Requirements section; wait for approval.
+- **Stage 2**: Epic-level /define gate — run /define; wait for approval; check sub-issue count.
+- **Stage 3**: Per-sub-issue /define gate — sequential /define per sub-issue; pause for approval after each.
+- **Stage 4**: Autonomous phase — branch creation, dependency tiers (Kahn's sort with cycle-break), parallel dispatch per tier, settle sub-tasks, open epic PR.
+- **Stage 5**: Exit — print summary.
 
-## Process
-
-### Stage 0 — Resume detection
-
-On every invocation, read the epic issue body and any sub-issue bodies first; consult the **Resume logic** table at the bottom to decide which stage to enter.
-
-### Stage 1 — Discovery gate
-
-If input is a positive integer and the epic issue has a well-formed `## Requirements` section (≥3 acceptance criteria), skip /discovery and go to Stage 2.
-
-Otherwise:
-1. Run `/discovery` on the epic (or free-text description). This is interactive.
-2. **Pause for explicit user approval.** Present: "Discovery complete. Review the issue body above. Approve to continue to /define, or provide feedback."
-3. Wait for explicit approval before proceeding.
-
-### Stage 2 — Epic-level /define gate
-
-1. Run `/define` on the epic issue. This is interactive — /define will produce architecture decisions, create sub-issues with linked-issue relationships, and update the issue body.
-2. **Pause for explicit user approval.** Present: "Epic /define complete. Review the sub-issues and implementation plan above. Approve to continue to per-sub-issue /define, or provide feedback."
-3. Wait for explicit approval.
-
-After approval, read the epic issue body and extract the list of sub-issues. If `/define` produced **≤1 sub-issue**:
-- Print: `Decomposition produced ≤1 sub-issue — running /implement directly on #<N>`
-- Invoke `/implement` on the epic in the lead session (interactive, no `autonomous: true`).
-- Exit.
-
-### Stage 3 — Per-sub-issue /define gate
-
-For each sub-issue in order (ascending issue number):
-
-1. Check if this sub-issue already has `## Implementation plan` in its body. If yes, skip (already defined in prior run).
-2. Spawn a fresh subagent to run `/define` on this sub-issue. Must finish before the next sub-issue's gate — these are sequential.
-3. After the subagent returns, **pause for explicit user approval.** Present: "Sub-issue #<M> /define complete. Review the implementation plan above. Approve to continue to the next sub-issue, or provide feedback."
-4. Wait for explicit approval before moving to next sub-issue.
-
-Once every sub-issue has an approved `## Implementation plan`, proceed to **Stage 4 — Autonomous phase**. No further human prompts until exit.
-
-### Stage 4 — Autonomous phase
-
-**No human prompts from this point forward until exit.**
-
-#### 4a. Epic branch creation
-
-```
-git checkout main && git pull
-wt switch --create feat/epic-<N>
-git commit --allow-empty -m "chore: open epic #<N>"
-git push -u origin feat/epic-<N>
-```
-
-The epic branch must exist and be pushed before any sub-task spawns.
-
-#### 4b. Dependency-tier computation
-
-Read each sub-issue body's `## Implementation plan` to extract the dependency graph. Build tiers using **Kahn's topological sort**:
-
-1. Build adjacency: for each sub-issue M, parse its /define output for "depends on #<X>" references.
-2. Compute in-degree for each node.
-3. Tier 1 = nodes with in-degree 0. Assign to tier 1.
-4. Remove tier-1 nodes; recompute in-degree. Tier 2 = new zero-in-degree nodes. Repeat until empty.
-5. Ties within a tier: break by ascending sub-issue number.
-
-**Cycle handling**: When Kahn's algorithm detects a cycle (zero-in-degree nodes exhaust while nodes remain with non-zero in-degree):
-
-1. Among remaining nodes, pick the **highest-numbered** sub-issue `H`.
-2. Among `H`'s declared dependencies, pick the **lowest-numbered** dependency `L`.
-3. Drop `H`'s `depends on #L` declaration (decrement `H`'s in-degree).
-4. Log to stdout: `Cycle broken: removed dep #<H> → #<L>`.
-5. Resume Kahn's on modified graph.
-
-**Branch base per sub-issue**:
-- Tier-1 → base is `feat/epic-<N>`.
-- Single-parent → base is that parent's branch.
-- Multi-parent → base is the parent with lowest tier number; if multiple parents share lowest tier, choose **lowest-numbered** sub-issue among them. Document remaining parents in the sub-PR `## Notes` as manual merge steps.
-
-#### 4c. Parallel Task dispatch — per tier
-
-For each tier in ascending order:
-
-1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
-2. Dispatch all sub-tasks in current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M:
-   - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
-   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`.
-   - Pass seed brief to sub-agent's `/implement` invocation. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` with overrides:
-     - `scope_class`: `Deep`
-     - `branch`: `feat/epic-<N>-sub-<M>`
-     - `active_issue`: `<M>`
-     - `payload.prior_art`: `"Sub-issue #<M>'s ## Implementation plan (architecture and design decisions from /define)"`
-     - `payload.open_questions`: unresolved constraints from /define for sub-issue #M, or empty
-
-PR base is communicated via git upstream, not the brief. `/implement` detects it with `git rev-parse --abbrev-ref --symbolic-full-name @{u}` and passes `--base <detected>` to `gh pr create`.
-
-3. Wait for all sub-agents in tier to settle before dispatching next tier.
-
-#### 4d. Sub-task settlement and failure handling
-
-Each sub-agent runs `/implement` end-to-end and attempts to open a draft PR. The `autonomous: true` flag suppresses `/implement`'s exhausted-exit prompt, so a draft PR (even exhausted-accepted) settles successfully.
-
-After each sub-task settles, emit one status line:
-- Clean exit: `[sub-issue #<M>] PR opened: <url> (cycles:<N>)`
-- Exhausted-accepted: `[sub-issue #<M>] PR opened: <url> (cycles:3 [exhausted-accepted])`
-- FAILED: `[sub-issue #<M>] FAILED — second retry exhausted`
-
-If a sub-agent **aborts**, retry exactly once with same seed brief (emit `[sub-issue #<M>] RETRYING (attempt 2/2)`); if retry also aborts, mark FAILED and continue siblings.
-
-#### 4e. Epic PR creation
-
-After every sub-task across all tiers has settled (PR open or FAILED):
-
-1. Push `feat/epic-<N>` to remote (empty commit pushed in 4a; push is no-op if already up-to-date).
-2. Open a draft epic PR:
-
-```
-gh pr create --draft \
-  --base main \
-  --head feat/epic-<N> \
-  --title "feat: epic #<N> — <epic title>" \
-  --body "$(cat <<'EOF'
-## Summary
-<1–3 sentences: what the epic delivers, which sub-issues are included>
-
-## Sub-issues and sub-PRs
-
-| Sub-issue | PR | Status |
-|-----------|-----|--------|
-| #<M> <title> | <PR url or FAILED> | <clean / exhausted-accepted / FAILED> |
-...
-
-## Merge order
-
-Merge sub-PRs before the epic PR, in tier order. **GitHub does not auto-update child PR bases after a parent squash/rebase merge** — after each parent PR merges, update dependent branches manually.
-
-## Follow-ups
-<any FAILED sub-tasks, outstanding findings, or deferred work>
-
-Closes #<N>
-EOF
-)"
-```
-
-3. Print epic PR URL and full sub-issue/sub-PR summary table to stdout.
-
-### Stage 5 — Exit
-
-Print exit summary to stdout and exit. The run is complete when all sub-PRs have been opened and the epic PR is open. Merging is left to humans.
-
-## Resume logic
-
-On re-invocation with the same epic issue number, epic-autopilot detects prior state and skips completed phases:
-
-|State detected|Action|
-|-|-|
-|No `## Requirements` in epic body|Re-run from Stage 1|
-|`## Requirements` but no `## Implementation plan`|Re-run from Stage 2|
-|`## Implementation plan` present|Skip Stages 1–2; check sub-issues|
-|Sub-issue has `## Implementation plan`|Skip per-sub-issue /define for that sub-issue|
-|Sub-issue has open PR on its branch|Sub-task settled; skip|
-|Sub-issue has branch but no PR|Re-run `/implement` in existing worktree|
-|Sub-issue has neither branch nor PR|Fresh sub-task spawn|
-
-A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be re-attempted on every resume. To skip it permanently, delete the branch and mark the sub-issue with a `skip` label before re-invoking.
+Full stage details, decision trees, tier computation, and failure handling: [Ref: references/stages.md]
 
 ## Rules
 
-See `${CLAUDE_PLUGIN_ROOT}/_shared/orchestrator-rules.md` for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
+See `${CLAUDE_PLUGIN_ROOT}/_shared/orchestrator-rules.md` for CWD, delegation, no-autonomous-merge, seed-brief contract.
 
-- Require explicit user approval at each gate (Stage 1, Stage 2, each Stage 3 sub-issue). Silence is not approval.
-- The user must not modify the epic issue body or any sub-issue body during Stage 4. Sub-agents read at spawn time.
-- Sub-issue branch and worktree names follow `feat/epic-<N>-sub-<M>` exactly. M is the globally unique GitHub sub-issue number.
-- `autonomous: true` in the seed brief is reserved for sub-task spawns from this skill. Do not pass from other orchestrators.
-- `/compound` and `/wrap-up` are not run by epic-autopilot — they remain user-invoked utilities.
+- Require explicit user approval at each gate. Silence is not approval.
+- User must not modify epic or sub-issue bodies during Stage 4. Sub-agents read at spawn time.
+- Sub-issue branch/worktree: `feat/epic-<N>-sub-<M>` (M is globally unique GitHub number).
+- `autonomous: true` reserved for sub-task spawns. Do not pass from other orchestrators.
+- `/compound` and `/wrap-up` remain user-invoked utilities.

--- a/skills/epic-autopilot/references/stages.md
+++ b/skills/epic-autopilot/references/stages.md
@@ -1,0 +1,161 @@
+# Epic-autopilot Stages
+
+## Stage 0 — Resume detection
+
+On every invocation, read the epic issue body and any sub-issue bodies first; consult the **Resume logic** table at the bottom to decide which stage to enter.
+
+## Stage 1 — Discovery gate
+
+If input is a positive integer and the epic issue has a well-formed `## Requirements` section (≥3 acceptance criteria), skip /discovery and go to Stage 2.
+
+Otherwise:
+1. Run `/discovery` on the epic (or free-text description). This is interactive.
+2. **Pause for explicit user approval.** Present: "Discovery complete. Review the issue body above. Approve to continue to /define, or provide feedback."
+3. Wait for explicit approval before proceeding.
+
+## Stage 2 — Epic-level /define gate
+
+1. Run `/define` on the epic issue. This is interactive — /define will produce architecture decisions, create sub-issues with linked-issue relationships, and update the issue body.
+2. **Pause for explicit user approval.** Present: "Epic /define complete. Review the sub-issues and implementation plan above. Approve to continue to per-sub-issue /define, or provide feedback."
+3. Wait for explicit approval.
+
+After approval, read the epic issue body and extract the list of sub-issues. If `/define` produced **≤1 sub-issue**:
+- Print: `Decomposition produced ≤1 sub-issue — running /implement directly on #<N>`
+- Invoke `/implement` on the epic in the lead session (interactive, no `autonomous: true`).
+- Exit.
+
+## Stage 3 — Per-sub-issue /define gate
+
+For each sub-issue in order (ascending issue number):
+
+1. Check if this sub-issue already has `## Implementation plan` in its body. If yes, skip (already defined in prior run).
+2. Spawn a fresh subagent to run `/define` on this sub-issue. Must finish before the next sub-issue's gate — these are sequential.
+3. After the subagent returns, **pause for explicit user approval.** Present: "Sub-issue #<M> /define complete. Review the implementation plan above. Approve to continue to the next sub-issue, or provide feedback."
+4. Wait for explicit approval before moving to next sub-issue.
+
+Once every sub-issue has an approved `## Implementation plan`, proceed to **Stage 4 — Autonomous phase**. No further human prompts until exit.
+
+## Stage 4 — Autonomous phase
+
+**No human prompts from this point forward until exit.**
+
+### 4a. Epic branch creation
+
+```
+git checkout main && git pull
+wt switch --create feat/epic-<N>
+git commit --allow-empty -m "chore: open epic #<N>"
+git push -u origin feat/epic-<N>
+```
+
+The epic branch must exist and be pushed before any sub-task spawns.
+
+### 4b. Dependency-tier computation
+
+Read each sub-issue body's `## Implementation plan` to extract the dependency graph. Build tiers using **Kahn's topological sort**:
+
+1. Build adjacency: for each sub-issue M, parse its /define output for "depends on #<X>" references.
+2. Compute in-degree for each node.
+3. Tier 1 = nodes with in-degree 0. Assign to tier 1.
+4. Remove tier-1 nodes; recompute in-degree. Tier 2 = new zero-in-degree nodes. Repeat until empty.
+5. Ties within a tier: break by ascending sub-issue number.
+
+**Cycle handling**: When Kahn's algorithm detects a cycle (zero-in-degree nodes exhaust while nodes remain with non-zero in-degree):
+
+1. Among remaining nodes, pick the **highest-numbered** sub-issue `H`.
+2. Among `H`'s declared dependencies, pick the **lowest-numbered** dependency `L`.
+3. Drop `H`'s `depends on #L` declaration (decrement `H`'s in-degree).
+4. Log to stdout: `Cycle broken: removed dep #<H> → #<L>`.
+5. Resume Kahn's on modified graph.
+
+**Branch base per sub-issue**:
+- Tier-1 → base is `feat/epic-<N>`.
+- Single-parent → base is that parent's branch.
+- Multi-parent → base is the parent with lowest tier number; if multiple parents share lowest tier, choose **lowest-numbered** sub-issue among them. Document remaining parents in the sub-PR `## Notes` as manual merge steps.
+
+### 4c. Parallel Task dispatch — per tier
+
+For each tier in ascending order:
+
+1. **Before dispatching tier T**, verify every tier-T−1 sub-task has settled (PR open or FAILED). Tier 1 has no prerequisite.
+2. Dispatch all sub-tasks in current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M:
+   - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
+   - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. See `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`.
+   - Pass seed brief to sub-agent's `/implement` invocation. See `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` with overrides:
+     - `scope_class`: `Deep`
+     - `branch`: `feat/epic-<N>-sub-<M>`
+     - `active_issue`: `<M>`
+     - `payload.prior_art`: `"Sub-issue #<M>'s ## Implementation plan (architecture and design decisions from /define)"`
+     - `payload.open_questions`: unresolved constraints from /define for sub-issue #M, or empty
+
+PR base is communicated via git upstream, not the brief. `/implement` detects it with `git rev-parse --abbrev-ref --symbolic-full-name @{u}` and passes `--base <detected>` to `gh pr create`.
+
+3. Wait for all sub-agents in tier to settle before dispatching next tier.
+
+### 4d. Sub-task settlement and failure handling
+
+Each sub-agent runs `/implement` end-to-end and attempts to open a draft PR. The `autonomous: true` flag suppresses `/implement`'s exhausted-exit prompt, so a draft PR (even exhausted-accepted) settles successfully.
+
+After each sub-task settles, emit one status line:
+- Clean exit: `[sub-issue #<M>] PR opened: <url> (cycles:<N>)`
+- Exhausted-accepted: `[sub-issue #<M>] PR opened: <url> (cycles:3 [exhausted-accepted])`
+- FAILED: `[sub-issue #<M>] FAILED — second retry exhausted`
+
+If a sub-agent **aborts**, retry exactly once with same seed brief (emit `[sub-issue #<M>] RETRYING (attempt 2/2)`); if retry also aborts, mark FAILED and continue siblings.
+
+### 4e. Epic PR creation
+
+After every sub-task across all tiers has settled (PR open or FAILED):
+
+1. Push `feat/epic-<N>` to remote (empty commit pushed in 4a; push is no-op if already up-to-date).
+2. Open a draft epic PR:
+
+```
+gh pr create --draft \
+  --base main \
+  --head feat/epic-<N> \
+  --title "feat: epic #<N> — <epic title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<1–3 sentences: what the epic delivers, which sub-issues are included>
+
+## Sub-issues and sub-PRs
+
+| Sub-issue | PR | Status |
+|-----------|-----|--------|
+| #<M> <title> | <PR url or FAILED> | <clean / exhausted-accepted / FAILED> |
+...
+
+## Merge order
+
+Merge sub-PRs before the epic PR, in tier order. **GitHub does not auto-update child PR bases after a parent squash/rebase merge** — after each parent PR merges, update dependent branches manually.
+
+## Follow-ups
+<any FAILED sub-tasks, outstanding findings, or deferred work>
+
+Closes #<N>
+EOF
+)"
+```
+
+3. Print epic PR URL and full sub-issue/sub-PR summary table to stdout.
+
+## Stage 5 — Exit
+
+Print exit summary to stdout and exit. The run is complete when all sub-PRs have been opened and the epic PR is open. Merging is left to humans.
+
+## Resume logic
+
+On re-invocation with the same epic issue number, epic-autopilot detects prior state and skips completed phases:
+
+|State detected|Action|
+|-|-|
+|No `## Requirements` in epic body|Re-run from Stage 1|
+|`## Requirements` but no `## Implementation plan`|Re-run from Stage 2|
+|`## Implementation plan` present|Skip Stages 1–2; check sub-issues|
+|Sub-issue has `## Implementation plan`|Skip per-sub-issue /define for that sub-issue|
+|Sub-issue has open PR on its branch|Sub-task settled; skip|
+|Sub-issue has branch but no PR|Re-run `/implement` in existing worktree|
+|Sub-issue has neither branch nor PR|Fresh sub-task spawn|
+
+A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be re-attempted on every resume. To skip it permanently, delete the branch and mark the sub-issue with a `skip` label before re-invoking.

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -10,117 +10,24 @@ Interactive skill scaffolder. Help author create skill conforming to claude-work
 
 ## Input
 
-A brief statement from the author of what the skill should do — or nothing, in which case start with question (a) below.
+A brief statement from the author of what the skill should do, or nothing to start with question (a).
 
 ## Process
 
-1. Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — the skill-types table, decision table for `_shared/` files, and frontmatter guide. You will quote its guidance back to the author when they are unsure.
+Three phases: (1) Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` (skill types, `_shared/` decision table, frontmatter guide); (2) Interview author with 11 questions (name, description, mis-routing, role, model, effort, argument, tools, parallelism, protocols, target) — see [Ref: references/interview-steps.md]; (3) Generate SKILL.md from template, show draft, write on explicit yes.
 
-2. **Interview the author** — ask ONE question at a time. Do not bundle. See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`.
-
-   Use `AskUserQuestion` for every question with a bounded option set (steps c–k except free-text follow-ups). For free-text questions (a, b), use a plain prompt. In each `AskUserQuestion` call, place the recommended option first and append ` (Recommended)` to its label — derive the recommendation from the description collected in step (b).
-
-   a. **Name** — plain prompt: "What's the skill called?" Must be lowercase kebab-case (e.g. `deploy-to-vercel`). Matches the directory name under `skills/`.
-
-   b. **Description** — plain prompt: "In one or two sentences: what does this skill do, and when should it trigger?" Frame as "Does X. Use when Y." This is the primary trigger mechanism — specificity matters more than elegance. If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
-
-   c. **Mis-routing** — `AskUserQuestion` with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?". Options:
-   - **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
-   - **No / Skip** — omit `when_to_use` frontmatter.
-
-   Only generate `when_to_use` frontmatter when the author answers Yes; omit otherwise.
-
-   d. **Role** — `AskUserQuestion` with `header: "Role"`, question: "Which role does this skill fill?". Options (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
-   - **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
-   - **Specialist** — executes a bounded task; receives a seed brief from an orchestrator (e.g. `/build`, `/review`, `/architecture`)
-   - **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
-   - **Utility** — user-invocable maintenance/post-work skill; no seed brief, no handoff artifact (e.g. `/compound`, `/prune`, `/resolve-pr-feedback`)
-
-     If the author picks **Orchestrator**, ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?". Options:
-
-   - **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator tier (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
-   - **Coordinator** — sequences sub-skills in a loop; research happens upstream or in the sub-skills (e.g. `/implement`). Defaults model to `sonnet`, no `effort`.
-
-     This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps d/e).
-
-     If the author picks **Specialist** or **Primitive**, ask one follow-up `AskUserQuestion` with `header: "Visibility"`, question: "Should this skill be hidden from the slash-command menu?". Options:
-   - **No (Recommended)** — omit `user-invocable` (skill appears in menu; default)
-   - **Yes** — add `user-invocable: false` (hides from menu; use for orchestrator-internal specialists not meant for direct user invocation)
-
-   e. **Model** — `AskUserQuestion` with `header: "Model"`, question: "Which model fits?". Options:
-   - **sonnet** — standard multi-step workflows, implementation, review
-   - **haiku** — fast lookup, formatting, retrieval, light verification
-   - **opus** — deep research, architecture, high-stakes decisions
-
-   f. **effort** — `AskUserQuestion` with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?". Options:
-   - **Standard** — omit `effort` (default)
-   - **High** — add `effort: high` to frontmatter
-
-   g. **argument-hint** — ask: "Does this skill accept a positional argument from the user? If yes, enter the hint text (e.g. `[issue#]`, `[PR# or URL]`). Type 'no' to skip." Store as `argument-hint` when provided; omit when skipped.
-
-   h. **allowed-tools** — `AskUserQuestion` with `header: "Tools"`, question: "Should the skill have access to all tools, or a restricted subset?". Options:
-   - **All tools** — omit the field (default; what most skills want)
-   - **Restricted subset** — set `allowed-tools:` explicitly
-
-     If the author picks **Restricted subset**, ask one free-text follow-up: "Which tools should it be allowed to use? (space-separated — e.g. `Read Grep Glob Bash`)". Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask). Use the answer verbatim as the value of `allowed-tools:`.
-
-   i. **Parallelism** — `AskUserQuestion` with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?". Options:
-   - **No parallelism** — skill runs inline; no sub-agents or teams
-   - **Parallel subagents** — skill spawns 2–3 independent subagents (applies to all roles)
-   - **TeamCreate** — skill spawns a team (orchestrators / specialists only)
-
-     If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up free-text: "Which conditions gate the spawn decision? (reference the rubric in `_shared/composition.md` — e.g., scope class, file count, communication pivot)". Store the answer as a "Spawn justification" block in the skill body.
-
-   j. **Shared protocols** — `AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
-   - **Handoff artifact** — writes or reads a GitHub issue handoff block → include `handoff-artifact.md`
-   - **Interviewing rules** — interviews the user, asks questions, seeks approval → include `interviewing-rules.md`
-   - **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
-   - **Compaction protocol** — manages in-phase context (clearing stale results, delegating, `/compact`) → include `compaction-protocol.md`
-
-     Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does this skill author an orchestrator or design a multi-skill workflow?". Options:
-
-   - **No** — skip `composition.md`
-   - **Yes** — include `composition.md`
-
-   k. **Target location** — `AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
-   - **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
-   - **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
-   - **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
-
-3. **Select the template** based on the author's role answer (step 2c):
-   - Orchestrator (either variant) → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.orchestrator.template.md`. For Coordinator, drop the "Dispatch a research team" step from the template body per its header note.
-   - Specialist or Utility → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.specialist.template.md`. For Utility, remove the "Optionally: a seed brief" paragraph from Input — utility skills are user-invocable and don't receive briefs.
-   - Primitive → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.primitive.template.md`
-
-   Both orchestrator and specialist templates now include placeholders for parallelism justification (step 2i). Fill these in based on the author's answer.
-
-   Read the selected template — that is the skeleton you will fill in.
-
-4. **Generate the SKILL.md** by filling in the selected template:
-   - Frontmatter: `name`, `description`, `when_to_use`, `model`; include `effort: high` / `argument-hint: ...` / `allowed-tools: ...` / `user-invocable: false` only when the author opted in; apply the canonical field order from `_templates/AUTHORING.md`
-   - Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
-   - If the author selected parallelism in step 2i, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
-   - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern")
-   - Include `composition.md` reference if the author selected it in step 2j
-
-5. **Show the draft** to the author in a fenced code block. Ask: "Does this look right? Shall I write it to `<target-path>`? (y/n)". Do not write on silence or "looks good" — require an explicit yes.
-
-6. **On yes**: create the directory if needed, write the file. Report the absolute path and tell the author:
-   - "Fill in the Input / Process / Output / Rules sections. The skeleton has placeholders."
-   - "Test by invoking `/<name>` in a new session. Claude loads skills at session start."
-
-7. **On no**: ask which question they want to revise, loop back to that step, regenerate.
+[Ref: references/interview-steps.md]
+[Ref: ${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md]
 
 ## Output
 
-A single file written to the chosen target location, conforming to the authoring standard. Empty skeleton sections that the author fills in afterwards — this skill scaffolds the frame, not the domain content.
+File at target location, conforming to authoring standard. Empty skeleton for author to fill in.
 
 ## Rules
 
-- One question at a time. No bundling.
-- Never write the file without explicit confirmation. "Sounds good" / silence / non-objection is NOT confirmation.
-- The skeleton is intentionally sparse. Do not invent domain content for sections you were not told about — that locks in guesses.
-- If the author skips a question with "skip" or "default", use the documented default (model: sonnet, effort: omit, argument-hint: omit, allowed-tools: omit, user-invocable: omit, target: personal).
-- Only include `when_to_use` when the author identified a mis-routing risk in step 2c. Omit it when the author skipped or answered "No / Skip".
-- If the target directory already contains a `SKILL.md`, stop and ask whether to overwrite or pick a new name.
-- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol.
+- One question at a time; no bundling.
+- Explicit "yes" required before writing.
+- Skeleton is sparse — no invented domain content.
+- Defaults if author skips: model: sonnet, all optional fields omitted, target: personal.
+- Include `when_to_use` only if mis-routing risk identified (step c).
+- If target has `SKILL.md`, ask to overwrite or pick new name.

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -1,0 +1,134 @@
+# Interview steps
+
+Detailed guidance for scaffolding a new skill. This file contains the extended interview process, template selection, and confirmation steps.
+
+## Step 1: Read templates and shared protocols
+
+Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — the skill-types table, decision table for `_shared/` files, and frontmatter guide. You will quote its guidance back to the author when they are unsure.
+
+## Step 2: Interview the author
+
+Ask ONE question at a time. Do not bundle. See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`.
+
+Use `AskUserQuestion` for every question with a bounded option set (steps c–k except free-text follow-ups). For free-text questions (a, b), use a plain prompt. In each `AskUserQuestion` call, place the recommended option first and append ` (Recommended)` to its label — derive the recommendation from the description collected in step (b).
+
+### a. Name
+
+Plain prompt: "What's the skill called?" Must be lowercase kebab-case (e.g. `deploy-to-vercel`). Matches the directory name under `skills/`.
+
+### b. Description
+
+Plain prompt: "In one or two sentences: what does this skill do, and when should it trigger?" Frame as "Does X. Use when Y." This is the primary trigger mechanism — specificity matters more than elegance. If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
+
+### c. Mis-routing
+
+`AskUserQuestion` with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?". Options:
+- **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
+- **No / Skip** — omit `when_to_use` frontmatter.
+
+Only generate `when_to_use` frontmatter when the author answers Yes; omit otherwise.
+
+### d. Role
+
+`AskUserQuestion` with `header: "Role"`, question: "Which role does this skill fill?". Options (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
+- **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
+- **Specialist** — executes a bounded task; receives a seed brief from an orchestrator (e.g. `/build`, `/review`, `/architecture`)
+- **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
+- **Utility** — user-invocable maintenance/post-work skill; no seed brief, no handoff artifact (e.g. `/compound`, `/prune`, `/resolve-pr-feedback`)
+
+If the author picks **Orchestrator**, ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?". Options:
+- **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator tier (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
+- **Coordinator** — sequences sub-skills in a loop; research happens upstream or in the sub-skills (e.g. `/implement`). Defaults model to `sonnet`, no `effort`.
+
+This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps d/e).
+
+If the author picks **Specialist** or **Primitive**, ask one follow-up `AskUserQuestion` with `header: "Visibility"`, question: "Should this skill be hidden from the slash-command menu?". Options:
+- **No (Recommended)** — omit `user-invocable` (skill appears in menu; default)
+- **Yes** — add `user-invocable: false` (hides from menu; use for orchestrator-internal specialists not meant for direct user invocation)
+
+### e. Model
+
+`AskUserQuestion` with `header: "Model"`, question: "Which model fits?". Options:
+- **sonnet** — standard multi-step workflows, implementation, review
+- **haiku** — fast lookup, formatting, retrieval, light verification
+- **opus** — deep research, architecture, high-stakes decisions
+
+### f. Effort
+
+`AskUserQuestion` with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?". Options:
+- **Standard** — omit `effort` (default)
+- **High** — add `effort: high` to frontmatter
+
+### g. Argument hint
+
+Ask: "Does this skill accept a positional argument from the user? If yes, enter the hint text (e.g. `[issue#]`, `[PR# or URL]`). Type 'no' to skip." Store as `argument-hint` when provided; omit when skipped.
+
+### h. Allowed tools
+
+`AskUserQuestion` with `header: "Tools"`, question: "Should the skill have access to all tools, or a restricted subset?". Options:
+- **All tools** — omit the field (default; what most skills want)
+- **Restricted subset** — set `allowed-tools:` explicitly
+
+If the author picks **Restricted subset**, ask one free-text follow-up: "Which tools should it be allowed to use? (space-separated — e.g. `Read Grep Glob Bash`)". Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask). Use the answer verbatim as the value of `allowed-tools:`.
+
+### i. Parallelism
+
+`AskUserQuestion` with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?". Options:
+- **No parallelism** — skill runs inline; no sub-agents or teams
+- **Parallel subagents** — skill spawns 2–3 independent subagents (applies to all roles)
+- **TeamCreate** — skill spawns a team (orchestrators / specialists only)
+
+If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up free-text: "Which conditions gate the spawn decision? (reference the rubric in `_shared/composition.md` — e.g., scope class, file count, communication pivot)". Store the answer as a "Spawn justification" block in the skill body.
+
+### j. Shared protocols
+
+`AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
+- **Handoff artifact** — writes or reads a GitHub issue handoff block → include `handoff-artifact.md`
+- **Interviewing rules** — interviews the user, asks questions, seeks approval → include `interviewing-rules.md`
+- **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
+- **Compaction protocol** — manages in-phase context (clearing stale results, delegating, `/compact`) → include `compaction-protocol.md`
+
+Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does this skill author an orchestrator or design a multi-skill workflow?". Options:
+- **No** — skip `composition.md`
+- **Yes** — include `composition.md`
+
+### k. Target location
+
+`AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
+- **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
+- **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
+- **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
+
+## Step 3: Select the template
+
+Based on the author's role answer (step 2d):
+- Orchestrator (either variant) → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.orchestrator.template.md`. For Coordinator, drop the "Dispatch a research team" step from the template body per its header note.
+- Specialist or Utility → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.specialist.template.md`. For Utility, remove the "Optionally: a seed brief" paragraph from Input — utility skills are user-invocable and don't receive briefs.
+- Primitive → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.primitive.template.md`
+
+Both orchestrator and specialist templates now include placeholders for parallelism justification (step 2i). Fill these in based on the author's answer.
+
+Read the selected template — that is the skeleton you will fill in.
+
+## Step 4: Generate the SKILL.md
+
+Fill in the selected template:
+- Frontmatter: `name`, `description`, `when_to_use`, `model`; include `effort: high` / `argument-hint: ...` / `allowed-tools: ...` / `user-invocable: false` only when the author opted in; apply the canonical field order from `_templates/AUTHORING.md`
+- Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
+- If the author selected parallelism in step 2i, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
+- Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern")
+- Include `composition.md` reference if the author selected it in step 2j
+
+## Step 5: Show draft and confirm
+
+Show the draft to the author in a fenced code block. Ask: "Does this look right? Shall I write it to `<target-path>`? (y/n)". Do not write on silence or "looks good" — require an explicit yes.
+
+## Step 6: Write and report
+
+On yes: create the directory if needed, write the file. Report the absolute path and tell the author:
+- "Fill in the Input / Process / Output / Rules sections. The skeleton has placeholders."
+- "Test by invoking `/<name>` in a new session. Claude loads skills at session start."
+
+## Step 7: Revise and loop
+
+On no: ask which question they want to revise, loop back to that step, regenerate.


### PR DESCRIPTION
Closes #99

Extracts per-stage decision trees to references/stages.md. SKILL.md now serves as an orchestration overview within the 50-line cap.