### PR TITLE
slim: reduce new-skill to 44-line cap, extract Process section

### DIFF
--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -16,7 +16,7 @@ A brief statement from the author of what the skill should do — or nothing, in
 
 1. Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — skill-types table, `_shared/` files decision table, frontmatter guide.
 
-2. **Interview the author** — ask ONE question at a time. [Ref: references/interview-steps.md]
+2. **Interview the author** — ask ONE question at a time. See `references/interview-steps.md` for the question sequence.
 
    Use `AskUserQuestion` for bounded option sets (c–k); plain prompt for free-text (a, b). Place recommended option first with ` (Recommended)` — derive from step (b).
 

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -16,7 +16,7 @@ A brief statement from the author of what the skill should do — or nothing, in
 
 1. Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — skill-types table, `_shared/` files decision table, frontmatter guide.
 
-2. **Interview the author** — ask ONE question at a time. See `references/interview-steps.md` for the question sequence.
+2. **Interview the author** — ask ONE question at a time. See `skills/new-skill/references/interview-steps.md` for the question sequence.
 
    Use `AskUserQuestion` for bounded option sets (c–k); plain prompt for free-text (a, b). Place recommended option first with ` (Recommended)` — derive from step (b).
 

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -10,117 +10,35 @@ Interactive skill scaffolder. Help author create skill conforming to claude-work
 
 ## Input
 
-A brief statement from the author of what the skill should do — or nothing, in which case start with question (a) below.
+A brief statement from the author of what the skill should do — or nothing, in which case start with step (a).
 
 ## Process
 
-1. Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — the skill-types table, decision table for `_shared/` files, and frontmatter guide. You will quote its guidance back to the author when they are unsure.
+1. Read `${CLAUDE_PLUGIN_ROOT}/_templates/AUTHORING.md` — skill-types table, `_shared/` files decision table, frontmatter guide.
 
-2. **Interview the author** — ask ONE question at a time. Do not bundle. See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`.
+2. **Interview the author** — ask ONE question at a time. [Ref: references/interview-steps.md]
 
-   Use `AskUserQuestion` for every question with a bounded option set (steps c–k except free-text follow-ups). For free-text questions (a, b), use a plain prompt. In each `AskUserQuestion` call, place the recommended option first and append ` (Recommended)` to its label — derive the recommendation from the description collected in step (b).
+   Use `AskUserQuestion` for bounded option sets (c–k); plain prompt for free-text (a, b). Place recommended option first with ` (Recommended)` — derive from step (b).
 
-   a. **Name** — plain prompt: "What's the skill called?" Must be lowercase kebab-case (e.g. `deploy-to-vercel`). Matches the directory name under `skills/`.
+3. **Select template** based on role: Orchestrator → `SKILL.orchestrator.template.md`; Specialist/Utility → `SKILL.specialist.template.md`; Primitive → `SKILL.primitive.template.md`.
 
-   b. **Description** — plain prompt: "In one or two sentences: what does this skill do, and when should it trigger?" Frame as "Does X. Use when Y." This is the primary trigger mechanism — specificity matters more than elegance. If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
+4. **Generate SKILL.md** by filling template: Frontmatter (`name`, `description`, `model` plus opt-in fields per author choice); skeleton sections as placeholders; spawn-justification if parallelism selected; `_shared/` reference lines per `_templates/AUTHORING.md`.
 
-   c. **Mis-routing** — `AskUserQuestion` with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?". Options:
-   - **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
-   - **No / Skip** — omit `when_to_use` frontmatter.
+5. **Show draft** in fenced code block. Ask: "Shall I write it to `<target-path>`? (y/n)". Require explicit yes.
 
-   Only generate `when_to_use` frontmatter when the author answers Yes; omit otherwise.
+6. **On yes**: create directory if needed, write file. Report path and advise filling placeholder sections.
 
-   d. **Role** — `AskUserQuestion` with `header: "Role"`, question: "Which role does this skill fill?". Options (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
-   - **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
-   - **Specialist** — executes a bounded task; receives a seed brief from an orchestrator (e.g. `/build`, `/review`, `/architecture`)
-   - **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
-   - **Utility** — user-invocable maintenance/post-work skill; no seed brief, no handoff artifact (e.g. `/compound`, `/prune`, `/resolve-pr-feedback`)
-
-     If the author picks **Orchestrator**, ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?". Options:
-
-   - **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator tier (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
-   - **Coordinator** — sequences sub-skills in a loop; research happens upstream or in the sub-skills (e.g. `/implement`). Defaults model to `sonnet`, no `effort`.
-
-     This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps d/e).
-
-     If the author picks **Specialist** or **Primitive**, ask one follow-up `AskUserQuestion` with `header: "Visibility"`, question: "Should this skill be hidden from the slash-command menu?". Options:
-   - **No (Recommended)** — omit `user-invocable` (skill appears in menu; default)
-   - **Yes** — add `user-invocable: false` (hides from menu; use for orchestrator-internal specialists not meant for direct user invocation)
-
-   e. **Model** — `AskUserQuestion` with `header: "Model"`, question: "Which model fits?". Options:
-   - **sonnet** — standard multi-step workflows, implementation, review
-   - **haiku** — fast lookup, formatting, retrieval, light verification
-   - **opus** — deep research, architecture, high-stakes decisions
-
-   f. **effort** — `AskUserQuestion` with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?". Options:
-   - **Standard** — omit `effort` (default)
-   - **High** — add `effort: high` to frontmatter
-
-   g. **argument-hint** — ask: "Does this skill accept a positional argument from the user? If yes, enter the hint text (e.g. `[issue#]`, `[PR# or URL]`). Type 'no' to skip." Store as `argument-hint` when provided; omit when skipped.
-
-   h. **allowed-tools** — `AskUserQuestion` with `header: "Tools"`, question: "Should the skill have access to all tools, or a restricted subset?". Options:
-   - **All tools** — omit the field (default; what most skills want)
-   - **Restricted subset** — set `allowed-tools:` explicitly
-
-     If the author picks **Restricted subset**, ask one free-text follow-up: "Which tools should it be allowed to use? (space-separated — e.g. `Read Grep Glob Bash`)". Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask). Use the answer verbatim as the value of `allowed-tools:`.
-
-   i. **Parallelism** — `AskUserQuestion` with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?". Options:
-   - **No parallelism** — skill runs inline; no sub-agents or teams
-   - **Parallel subagents** — skill spawns 2–3 independent subagents (applies to all roles)
-   - **TeamCreate** — skill spawns a team (orchestrators / specialists only)
-
-     If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up free-text: "Which conditions gate the spawn decision? (reference the rubric in `_shared/composition.md` — e.g., scope class, file count, communication pivot)". Store the answer as a "Spawn justification" block in the skill body.
-
-   j. **Shared protocols** — `AskUserQuestion` with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?". Walk through the AUTHORING.md decision table. Options (4-option limit):
-   - **Handoff artifact** — writes or reads a GitHub issue handoff block → include `handoff-artifact.md`
-   - **Interviewing rules** — interviews the user, asks questions, seeks approval → include `interviewing-rules.md`
-   - **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
-   - **Compaction protocol** — manages in-phase context (clearing stale results, delegating, `/compact`) → include `compaction-protocol.md`
-
-     Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does this skill author an orchestrator or design a multi-skill workflow?". Options:
-
-   - **No** — skip `composition.md`
-   - **Yes** — include `composition.md`
-
-   k. **Target location** — `AskUserQuestion` with `header: "Target"`, question: "Where should the skill be written?". Options:
-   - **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
-   - **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
-   - **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
-
-3. **Select the template** based on the author's role answer (step 2c):
-   - Orchestrator (either variant) → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.orchestrator.template.md`. For Coordinator, drop the "Dispatch a research team" step from the template body per its header note.
-   - Specialist or Utility → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.specialist.template.md`. For Utility, remove the "Optionally: a seed brief" paragraph from Input — utility skills are user-invocable and don't receive briefs.
-   - Primitive → `${CLAUDE_PLUGIN_ROOT}/_templates/SKILL.primitive.template.md`
-
-   Both orchestrator and specialist templates now include placeholders for parallelism justification (step 2i). Fill these in based on the author's answer.
-
-   Read the selected template — that is the skeleton you will fill in.
-
-4. **Generate the SKILL.md** by filling in the selected template:
-   - Frontmatter: `name`, `description`, `when_to_use`, `model`; include `effort: high` / `argument-hint: ...` / `allowed-tools: ...` / `user-invocable: false` only when the author opted in; apply the canonical field order from `_templates/AUTHORING.md`
-   - Body: keep the skeleton sections (Input / Process / Output / Rules) as placeholders for the author to fill — don't invent domain content
-   - If the author selected parallelism in step 2i, include the spawn-justification text from their answer in the "Spawn justification" block in the skill body (orchestrator or specialist templates both have this now)
-   - Append a reference line at the end of the relevant section for each selected `_shared/` file. Use the full `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` path, matching the pattern in `_templates/AUTHORING.md` (§ "Reference pattern")
-   - Include `composition.md` reference if the author selected it in step 2j
-
-5. **Show the draft** to the author in a fenced code block. Ask: "Does this look right? Shall I write it to `<target-path>`? (y/n)". Do not write on silence or "looks good" — require an explicit yes.
-
-6. **On yes**: create the directory if needed, write the file. Report the absolute path and tell the author:
-   - "Fill in the Input / Process / Output / Rules sections. The skeleton has placeholders."
-   - "Test by invoking `/<name>` in a new session. Claude loads skills at session start."
-
-7. **On no**: ask which question they want to revise, loop back to that step, regenerate.
+7. **On no**: ask which step to revise, loop back, regenerate.
 
 ## Output
 
-A single file written to the chosen target location, conforming to the authoring standard. Empty skeleton sections that the author fills in afterwards — this skill scaffolds the frame, not the domain content.
+A single file at the chosen target location, conforming to the authoring standard. Empty skeleton sections for the author to fill.
 
 ## Rules
 
-- One question at a time. No bundling.
-- Never write the file without explicit confirmation. "Sounds good" / silence / non-objection is NOT confirmation.
-- The skeleton is intentionally sparse. Do not invent domain content for sections you were not told about — that locks in guesses.
-- If the author skips a question with "skip" or "default", use the documented default (model: sonnet, effort: omit, argument-hint: omit, allowed-tools: omit, user-invocable: omit, target: personal).
-- Only include `when_to_use` when the author identified a mis-routing risk in step 2c. Omit it when the author skipped or answered "No / Skip".
-- If the target directory already contains a `SKILL.md`, stop and ask whether to overwrite or pick a new name.
-- See `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md` for the questioning protocol.
+- One question at a time. Require explicit yes before writing.
+- Do not invent domain content — locks in guesses.
+- Defaults (if skipped): model: sonnet; effort, argument-hint, allowed-tools, user-invocable: omit; target: personal.
+- Include `when_to_use` only if author identified mis-routing risk (step c); omit otherwise.
+- If target `SKILL.md` exists, ask whether to overwrite.
+- [Ref: ${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md]

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -19,7 +19,7 @@ This file details the 11-step interview sequence that new-skill conducts with th
 
 ## Step (c): Mis-routing
 
-**`AskUserQuestion`** with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?".
+**`AskUserQuestion`** with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?"
 
 **Options:**
 - **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
@@ -29,7 +29,7 @@ Only generate `when_to_use` frontmatter when the author answers Yes; omit otherw
 
 ## Step (d): Role
 
-**`AskUserQuestion`** with `header: "Role"`, question: "Which role does this skill fill?".
+**`AskUserQuestion`** with `header: "Role"`, question: "Which role does this skill fill?"
 
 **Options** (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
 - **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
@@ -37,7 +37,7 @@ Only generate `when_to_use` frontmatter when the author answers Yes; omit otherw
 - **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
 - **Utility** — user-invocable maintenance/post-work skill; no seed brief, no handoff artifact (e.g. `/compound`, `/prune`, `/resolve-pr-feedback`)
 
-**If Orchestrator:** Ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?".
+**If Orchestrator:** Ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?"
 
 **Options:**
 - **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator tier (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
@@ -45,7 +45,7 @@ Only generate `when_to_use` frontmatter when the author answers Yes; omit otherw
 
 This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps e/f).
 
-**If Specialist or Primitive:** Ask one follow-up `AskUserQuestion` with `header: "Visibility"`, question: "Should this skill be hidden from the slash-command menu?".
+**If Specialist or Primitive:** Ask one follow-up `AskUserQuestion` with `header: "Visibility"`, question: "Should this skill be hidden from the slash-command menu?"
 
 **Options:**
 - **No (Recommended)** — omit `user-invocable` (skill appears in menu; default)
@@ -53,7 +53,7 @@ This answer determines which template to use in step 3 and pre-fills the model/e
 
 ## Step (e): Model
 
-**`AskUserQuestion`** with `header: "Model"`, question: "Which model fits?".
+**`AskUserQuestion`** with `header: "Model"`, question: "Which model fits?"
 
 **Options:**
 - **sonnet** — standard multi-step workflows, implementation, review
@@ -62,7 +62,7 @@ This answer determines which template to use in step 3 and pre-fills the model/e
 
 ## Step (f): Effort
 
-**`AskUserQuestion`** with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?".
+**`AskUserQuestion`** with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?"
 
 **Options:**
 - **Standard** — omit `effort` (default)
@@ -103,7 +103,7 @@ If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up fr
 
 ## Step (j): Shared protocols
 
-**`AskUserQuestion`** with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?".
+**`AskUserQuestion`** with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?"
 
 - Walk through the AUTHORING.md decision table.
 
@@ -113,7 +113,7 @@ If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up fr
 - **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
 - **Compaction protocol** — manages in-phase context (clearing stale results, delegating, `/compact`) → include `compaction-protocol.md`
 
-Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does this skill author an orchestrator or design a multi-skill workflow?".
+Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does this skill author an orchestrator or design a multi-skill workflow?"
 
 **Options:**
 - **No** — skip `composition.md`
@@ -121,7 +121,7 @@ Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does t
 
 ## Step (k): Target location
 
-**`AskUserQuestion`** with `header: "Target"`, question: "Where should the skill be written?".
+**`AskUserQuestion`** with `header: "Target"`, question: "Where should the skill be written?"
 
 **Options:**
 - **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -1,0 +1,129 @@
+# Interview steps for new-skill
+
+This file details the 11-step interview sequence that new-skill conducts with the author, one question at a time.
+
+## Step (a): Name
+
+**Plain prompt**: "What's the skill called?"
+
+- Must be lowercase kebab-case (e.g. `deploy-to-vercel`).
+- Matches the directory name under `skills/`.
+
+## Step (b): Description
+
+**Plain prompt**: "In one or two sentences: what does this skill do, and when should it trigger?"
+
+- Frame as "Does X. Use when Y."
+- This is the primary trigger mechanism — specificity matters more than elegance.
+- If the author's draft is vague, grill for concrete trigger phrases (what would the user type?).
+
+## Step (c): Mis-routing
+
+**`AskUserQuestion`** with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?".
+
+**Options:**
+- **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
+- **No / Skip** — omit `when_to_use` frontmatter.
+
+Only generate `when_to_use` frontmatter when the author answers Yes; omit otherwise.
+
+## Step (d): Role
+
+**`AskUserQuestion`** with `header: "Role"`, question: "Which role does this skill fill?".
+
+**Options** (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
+- **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
+- **Specialist** — executes a bounded task; receives a seed brief from an orchestrator (e.g. `/build`, `/review`, `/architecture`)
+- **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
+- **Utility** — user-invocable maintenance/post-work skill; no seed brief, no handoff artifact (e.g. `/compound`, `/prune`, `/resolve-pr-feedback`)
+
+**If Orchestrator:** Ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?".
+
+**Options:**
+- **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator tier (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
+- **Coordinator** — sequences sub-skills in a loop; research happens upstream or in the sub-skills (e.g. `/implement`). Defaults model to `sonnet`, no `effort`.
+
+This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps e/f).
+
+**If Specialist or Primitive:** Ask one follow-up `AskUserQuestion` with `header: "Visibility"`, question: "Should this skill be hidden from the slash-command menu?".
+
+**Options:**
+- **No (Recommended)** — omit `user-invocable` (skill appears in menu; default)
+- **Yes** — add `user-invocable: false` (hides from menu; use for orchestrator-internal specialists not meant for direct user invocation)
+
+## Step (e): Model
+
+**`AskUserQuestion`** with `header: "Model"`, question: "Which model fits?".
+
+**Options:**
+- **sonnet** — standard multi-step workflows, implementation, review
+- **haiku** — fast lookup, formatting, retrieval, light verification
+- **opus** — deep research, architecture, high-stakes decisions
+
+## Step (f): Effort
+
+**`AskUserQuestion`** with `header: "Effort"`, question: "Does this skill run long-form multi-turn research or decision-making?".
+
+**Options:**
+- **Standard** — omit `effort` (default)
+- **High** — add `effort: high` to frontmatter
+
+## Step (g): Argument hint
+
+**Plain prompt**: "Does this skill accept a positional argument from the user? If yes, enter the hint text (e.g. `[issue#]`, `[PR# or URL]`). Type 'no' to skip."
+
+- Store as `argument-hint` when provided.
+- Omit when skipped.
+
+## Step (h): Allowed tools
+
+**`AskUserQuestion`** with `header: "Tools"`, question: "Should the skill have access to all tools, or a restricted subset?".
+
+**Options:**
+- **All tools** — omit the field (default; what most skills want)
+- **Restricted subset** — set `allowed-tools:` explicitly
+
+If the author picks **Restricted subset**, ask one free-text follow-up: "Which tools should it be allowed to use? (space-separated — e.g. `Read Grep Glob Bash`)".
+
+- Validate that each entry is a real Claude Code tool name (reject unknown names and re-ask).
+- Use the answer verbatim as the value of `allowed-tools:`.
+
+## Step (i): Parallelism
+
+**`AskUserQuestion`** with `header: "Parallelism"`, question: "Does this skill spawn sub-agents or teams? If yes, which primitive?".
+
+**Options:**
+- **No parallelism** — skill runs inline; no sub-agents or teams
+- **Parallel subagents** — skill spawns 2–3 independent subagents (applies to all roles)
+- **TeamCreate** — skill spawns a team (orchestrators / specialists only)
+
+If the author picks **Parallel subagents** or **TeamCreate**, ask a follow-up free-text: "Which conditions gate the spawn decision? (reference the rubric in `_shared/composition.md` — e.g., scope class, file count, communication pivot)".
+
+- Store the answer as a "Spawn justification" block in the skill body.
+
+## Step (j): Shared protocols
+
+**`AskUserQuestion`** with `header: "Protocols"`, `multiSelect: true`, question: "Which shared protocols does this skill need?".
+
+- Walk through the AUTHORING.md decision table.
+
+**Options** (4-option limit):
+- **Handoff artifact** — writes or reads a GitHub issue handoff block → include `handoff-artifact.md`
+- **Interviewing rules** — interviews the user, asks questions, seeks approval → include `interviewing-rules.md`
+- **NOTES.md protocol** — creates or reads `.claude/NOTES.md` → include `notes-md-protocol.md`
+- **Compaction protocol** — manages in-phase context (clearing stale results, delegating, `/compact`) → include `compaction-protocol.md`
+
+Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does this skill author an orchestrator or design a multi-skill workflow?".
+
+**Options:**
+- **No** — skip `composition.md`
+- **Yes** — include `composition.md`
+
+## Step (k): Target location
+
+**`AskUserQuestion`** with `header: "Target"`, question: "Where should the skill be written?".
+
+**Options:**
+- **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
+- **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
+- **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)


### PR DESCRIPTION
Closes #101

Extracts 98-line Process section (interview steps a–k) to references/interview-steps.md. SKILL.md retains role selection, template selection, and output format as a high-level overview within the 44-line cap. All behavioral content preserved in reference file.