### PR TITLE
slim: reduce 9 over-cap skills to 50-line limit

### DIFF
--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -26,20 +26,7 @@ Audit open issues for drift. Product: Updated issues themselves (mutate on confi
 - Abort if issue is `closed`.
 
 ### Phase 2 — Per-Issue Audit (Subagent Fan-out)
-Spawn one subagent per issue (parallel for >= 3).
-**Subagent Contract**: 5 detectors → structured JSON.
-
-1. **Hybrid Extraction**:
-   - **Regex**: File paths, numeric claims, version refs.
-   - **LLM**: Cross-issue refs, open questions, premise statements.
-2. **Detectors**:
-   - `file-path-existence`: `git ls-tree -r <ref> -- <path>`. If missing → `git log --diff-filter=D`.
-   - `numeric-claim-drift`: Recompute count from `<ref>`.
-   - `version-reference-staleness`: Check tags and `CHANGELOG.md`.
-   - `resolved-open-question`: Search history for resolution language.
-   - `cross-issue-contradiction`: Scan sibling excerpts → detect negation.
-3. **Verdict**: Strongest wins: `unverifiable` > `premise-shifted` > `superseded by #N` > `contradicted` > `stale` > `valid`.
-4. **JSON Return**: `issue_number`, `verdict`, `findings` (quote, evidence, proposed_edit), `recommendation` (edit|close|skip).
+[Ref: detectors.md] for detector logic, verdict ranking, and JSON schema.
 
 ### Phase 3 — Aggregate & Print
 Concatenate JSON reports. Per-issue block: `─── #NN — <title> — verdict: <v> ───` → URL → findings → proposed edit.

--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -26,7 +26,7 @@ Audit open issues for drift. Product: Updated issues themselves (mutate on confi
 - Abort if issue is `closed`.
 
 ### Phase 2 — Per-Issue Audit (Subagent Fan-out)
-[Ref: detectors.md] for detector logic, verdict ranking, and JSON schema.
+Read `_shared/detectors.md` for detector logic, verdict ranking, and JSON schema.
 
 ### Phase 3 — Aggregate & Print
 Concatenate JSON reports. Per-issue block: `─── #NN — <title> — verdict: <v> ───` → URL → findings → proposed edit.
@@ -43,7 +43,7 @@ Walk blocks in order. Prompt based on verdict:
 - `s` → Advance.
 
 ## Rules
-- **Sourcing**: Use [Ref: handoff-artifact] for parse targets.
+- **Sourcing**: Use `_shared/handoff-artifact.md` for parse targets.
 - **Read-Only Default**: Mutate only after explicit per-issue confirmation.
 - **No Auto-Clone**: Do not clone missing repos.
 - **No Invention**: No counter → `unverifiable`.

--- a/skills/audit-issues/references/detectors.md
+++ b/skills/audit-issues/references/detectors.md
@@ -2,21 +2,23 @@
 
 Phase 2 — Per-Issue Audit. Spawn one subagent per issue (parallel for >= 3).
 
+## Hybrid Extraction (Setup)
+
+Extract data via:
+- **Regex**: File paths, numeric claims, version refs.
+- **LLM**: Cross-issue refs, open questions, premise statements.
+
 ## 5 Detectors (Subagent Contract)
 
-1. **Hybrid Extraction**:
-   - **Regex**: File paths, numeric claims, version refs.
-   - **LLM**: Cross-issue refs, open questions, premise statements.
+1. **file-path-existence**: `git ls-tree -r <ref> -- <path>`. If missing → `git log --diff-filter=D`.
 
-2. **file-path-existence**: `git ls-tree -r <ref> -- <path>`. If missing → `git log --diff-filter=D`.
+2. **numeric-claim-drift**: Recompute count from `<ref>`.
 
-3. **numeric-claim-drift**: Recompute count from `<ref>`.
+3. **version-reference-staleness**: Check tags and `CHANGELOG.md`.
 
-4. **version-reference-staleness**: Check tags and `CHANGELOG.md`.
+4. **resolved-open-question**: Search history for resolution language.
 
-5. **resolved-open-question**: Search history for resolution language.
-
-6. **cross-issue-contradiction**: Scan sibling excerpts → detect negation.
+5. **cross-issue-contradiction**: Scan sibling excerpts → detect negation.
 
 ## Verdict Logic
 

--- a/skills/audit-issues/references/detectors.md
+++ b/skills/audit-issues/references/detectors.md
@@ -1,0 +1,27 @@
+# Detectors for audit-issues
+
+Phase 2 — Per-Issue Audit. Spawn one subagent per issue (parallel for >= 3).
+
+## 5 Detectors (Subagent Contract)
+
+1. **Hybrid Extraction**:
+   - **Regex**: File paths, numeric claims, version refs.
+   - **LLM**: Cross-issue refs, open questions, premise statements.
+
+2. **file-path-existence**: `git ls-tree -r <ref> -- <path>`. If missing → `git log --diff-filter=D`.
+
+3. **numeric-claim-drift**: Recompute count from `<ref>`.
+
+4. **version-reference-staleness**: Check tags and `CHANGELOG.md`.
+
+5. **resolved-open-question**: Search history for resolution language.
+
+6. **cross-issue-contradiction**: Scan sibling excerpts → detect negation.
+
+## Verdict Logic
+
+Strongest wins: `unverifiable` > `premise-shifted` > `superseded by #N` > `contradicted` > `stale` > `valid`.
+
+## JSON Return Schema
+
+`issue_number`, `verdict`, `findings` (quote, evidence, proposed_edit), `recommendation` (edit|close|skip).

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -13,10 +13,10 @@ You lead product discovery. Goal: Deeply understand the problem space via intera
 ## Specialist Mode
 - **Seeded**: Skip internal prior-art search. Keep PPT and grill-me interactions.
 - **Standalone**: Run all steps.
-- Read `_shared/specialist-mode.md`
+- Read `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`
 
 ## Scope Assessment
-Read `_shared/scope-ppt.md` for scope classification, spawn rubric, and PPT checklist.
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/scope-ppt.md` for scope classification, spawn rubric, and PPT checklist.
 
 ## Process
 
@@ -44,4 +44,4 @@ Read `_shared/scope-ppt.md` for scope classification, spawn rubric, and PPT chec
 
 ## Rules
 - Recommend an answer for every question.
-- Read `_shared/interviewing-rules.md`
+- Read `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -16,30 +16,15 @@ You lead product discovery. Goal: Deeply understand the problem space via intera
 - [Ref: specialist-mode]
 
 ## Scope Assessment
-Classify scope before starting:
-
-|Scope|Criteria|Action|
-|-|-|-|
-|**Lightweight**|Trivial fix, clear requirements, <= 1 file|Skip sub-agents. Single-pass problem statement. Skip PPT.|
-|**Standard**|Typical feature/fix with some unknowns|Spawn team + visuals. Run PPT.|
-|**Deep**|Complex, cross-cutting, security/auth, arch change|Full team + extra research agents. Run PPT.|
-
-**Decision**: 1 file + 1 sentence → Lightweight; Auth/Security/Arch → Deep; else → Standard.
-
-### Spawn Rubric [Ref: composition]
-- **Standard**: Domain researcher (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
-- **Deep**: Domain researcher + Failure-mode analyst (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
+[Ref: scope-ppt.md] for scope classification, spawn rubric, and PPT checklist.
 
 ## Process
 
 ### Standard / Deep
 1. **Elicitation**: Ask user for problem/goal.
 2. **Exploration**: Dispatch agents → Lead analyst runs interactively via `/grill-me`.
-3. **PPT**: Run Product Pressure Test (below) before synthesizing approaches.
-4. **Visualization**: Produce Mermaid/ASCII for:
-   - User journeys (flowchart/sequence)
-   - Feature comparisons (table)
-   - System boundaries / Data relationships
+3. **PPT**: Run Product Pressure Test (see reference) before synthesizing.
+4. **Visualization**: Produce Mermaid/ASCII for user journeys, feature comparisons, system boundaries.
 5. **Validation**: Confirm understanding of each visual.
 6. **Synthesis**: Create structured problem statement.
 
@@ -47,14 +32,6 @@ Classify scope before starting:
 1. Confirm problem/outcome.
 2. Brief codebase validation.
 3. Direct problem statement production.
-
-### Product Pressure Test (PPT)
-Run between exploration and synthesis (Standard/Deep only). Grill user on:
-1. **Right Problem?** → Is this a symptom? Is there a deeper root cause?
-2. **Cost of Inaction?** → Who is affected? How badly? Is it worth building?
-3. **Leverage?** → Is there a simpler move that captures 80% of value?
-
-*Loop back to exploration if PPT reveals misframing.*
 
 ## I/O
 **Output**: Structured problem statement:

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -13,10 +13,10 @@ You lead product discovery. Goal: Deeply understand the problem space via intera
 ## Specialist Mode
 - **Seeded**: Skip internal prior-art search. Keep PPT and grill-me interactions.
 - **Standalone**: Run all steps.
-- [Ref: specialist-mode]
+- Read `_shared/specialist-mode.md`
 
 ## Scope Assessment
-[Ref: scope-ppt.md] for scope classification, spawn rubric, and PPT checklist.
+Read `_shared/scope-ppt.md` for scope classification, spawn rubric, and PPT checklist.
 
 ## Process
 
@@ -44,4 +44,4 @@ You lead product discovery. Goal: Deeply understand the problem space via intera
 
 ## Rules
 - Recommend an answer for every question.
-- [Ref: interviewing-rules]
+- Read `_shared/interviewing-rules.md`

--- a/skills/describe/references/scope-ppt.md
+++ b/skills/describe/references/scope-ppt.md
@@ -1,0 +1,25 @@
+# Scope Assessment and Product Pressure Test for describe
+
+## Scope Assessment
+
+|Scope|Criteria|Action|
+|-|-|-|
+|**Lightweight**|Trivial fix, clear requirements, ≤ 1 file|Skip sub-agents. Single-pass problem statement. Skip PPT.|
+|**Standard**|Typical feature/fix with some unknowns|Spawn team + visuals. Run PPT.|
+|**Deep**|Complex, cross-cutting, security/auth, arch change|Full team + extra research agents. Run PPT.|
+
+**Decision**: 1 file + 1 sentence → Lightweight; Auth/Security/Arch → Deep; else → Standard.
+
+### Spawn Rubric [Ref: composition]
+- **Standard**: Domain researcher (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
+- **Deep**: Domain researcher + Failure-mode analyst (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
+
+## Product Pressure Test (PPT)
+
+Run between exploration and synthesis (Standard/Deep only). Grill user on:
+
+1. **Right Problem?** → Is this a symptom? Is there a deeper root cause?
+2. **Cost of Inaction?** → Who is affected? How badly? Is it worth building?
+3. **Leverage?** → Is there a simpler move that captures 80% of value?
+
+*Loop back to exploration if PPT reveals misframing.*

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -32,7 +32,7 @@ Spawn: Standard = describe + scout + specify; Deep = TeamCreate with all roles.
 
 ## Issue Creation
 
-Run `_shared/repo-preflight.md` before `gh issue`.
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md` before `gh issue`.
 
 **Structure** (per `_shared/handoff-artifact.md`):
 - **Preamble**: What, Why, Who (from `/describe`).

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -11,48 +11,34 @@ allowed-tools: Agent Bash Read
 Lead discovery phase. Goal: Transform vague ideas into well-specified GitHub issues ready for architecture and implementation.
 
 ## Scope Assessment
+
 |Scope|Criteria|Action|
 |-|-|-|
-|**Lightweight**|Clear repro, single area|/describe (Lightweight) → minimal /specify → issue. No team.|
-|**Standard**|Typical feature, some unknowns|Team: /describe + /specify specialists + Prior-Art Scout.|
-|**Deep**|Cross-module, auth/security/payments, arch-changing|Full team + flow analyst + Prior-Art Scout + adversarial questioner.|
+|**Lightweight**|Clear repro, single area|/describe (Lightweight) → issue|
+|**Standard**|Typical feature, some unknowns|Team: /describe + /specify + Prior-Art Scout|
+|**Deep**|Cross-module, auth/security/payments, arch|Full team + flow analyst + adversarial questioner|
 
-**Decision**: 1-sentence fix + clear repro → Lightweight; Auth/Security/Payments/Arch-change → Deep; else → Standard.
+**Decision**: 1-sentence fix + clear repro → Lightweight; Auth/Security/Payments/Arch → Deep; else → Standard.
 
-### Spawn Rubric [Ref: composition]
-- **Standard**: describe (lead-inline) + scout (parallel subagent) + specify (sequential subagent).
-- **Deep**: `TeamCreate`. Adversarial questioner reacts live.
+Spawn: Standard = describe + scout + specify; Deep = TeamCreate with all roles.
 
 ## Process
 
-### Standard
-1. **Prior-Art Scout** (Parallel subagent): Gather institutional memory from Vault → Issues/PRs → Docs. Output: structured brief (Prior decisions, Attempts, Patterns).
-2. **Explore** (Lead-inline): Run `/describe`. Incorporate scout brief as seed context → skip internal prior-art research.
-3. **Specify** (Sequential subagent): After problem statement is approved, run `/specify` seeded with findings + scout brief.
+**Lightweight**: `/describe` → quick confirmation → extract AC → issue.
 
-### Deep
-1. **TeamCreate**: Describe, Specify, Flow Analyst, Prior-Art Scout, Adversarial Questioner.
-2. **Execution**: Describe, Flow Analyst, and Scout run in parallel. Adversarial Questioner reviews combined findings → challenges conclusions. Specify specialist runs last, incorporating all concerns.
-3. **Sourcing**: Scout brief seeds `/describe` → skip internal prior-art exploration.
+**Standard**: Prior-Art Scout (parallel) → `/describe` (with scout brief) → `/specify` → issue.
 
-### Lightweight
-1. `/describe` (Lightweight mode) → quick problem confirmation.
-2. Extract 3-5 core AC directly (skip `/specify`).
-3. Issue creation.
+**Deep**: TeamCreate (all roles) → Describe/Flow-Analyst/Scout in parallel → Adversarial Questioner challenges → Specify last → issue.
 
 ## Issue Creation
+
 Run [Ref: repo-preflight] before `gh issue`.
 
-**Structure**:
-1. **Preamble**: From `/describe` output (What, Why, Who).
-2. **Handoff Block** (`## Requirements`): Fields per [Ref: handoff-artifact] in this order:
-   - **Acceptance criteria** (numbered testable scenarios)
-   - **Constraints** (in/out scope, non-negotiable decisions)
-   - **Prior decisions** (optional: decision + rationale)
-   - **Evidence** (optional: links/benchmarks)
-   - **Open questions** (optional: for `/define`)
+**Structure** (per [Ref: handoff-artifact]):
+- **Preamble**: What, Why, Who (from `/describe`).
+- **Requirements**: Acceptance criteria → Constraints → Prior decisions (optional) → Evidence (optional) → Open questions (optional).
 
-**Closing**: Present for approval → sign-off → instruct user: "Start `/define` in a fresh session."
+Present for approval → sign-off → instruct: "Start `/define` in a fresh session."
 
 ## Rules
 - **Explicit Approval**: Partial feedback ≠ approval.

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -32,9 +32,9 @@ Spawn: Standard = describe + scout + specify; Deep = TeamCreate with all roles.
 
 ## Issue Creation
 
-Run [Ref: repo-preflight] before `gh issue`.
+Run `_shared/repo-preflight.md` before `gh issue`.
 
-**Structure** (per [Ref: handoff-artifact]):
+**Structure** (per `_shared/handoff-artifact.md`):
 - **Preamble**: What, Why, Who (from `/describe`).
 - **Requirements**: Acceptance criteria → Constraints → Prior decisions (optional) → Evidence (optional) → Open questions (optional).
 
@@ -45,4 +45,4 @@ Present for approval → sign-off → instruct: "Start `/define` in a fresh sess
 - **Exploration**: Time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
 - **Persistence**: Prior-Art Scout findings must be persisted in Prior decisions/Evidence fields.
 - **Traceability**: Every feature must have one issue and >= 1 closing PR.
-- [Ref: interviewing-rules]
+- Read `_shared/interviewing-rules.md`

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -10,62 +10,19 @@ allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ## Role & Constraints
 Orchestrate build → review → verify → fix cycles to produce a ready-to-merge PR.
 
-## Scope Assessment
-|Scope|Criteria|Action|
-|-|-|-|
-|**Lightweight**|<= 50 lines, no logic change, 1-2 AC|`/build` (inline) → inline AC check → PR. Skip `/review` and `/verify` teams.|
-|**Standard**|Typical multi-file, AC in one module|Full Build → Review → Verify cycle.|
-|**Deep**|Cross-module, security, migration, breaking|Full cycle + Deep review + extra critique iterations.|
-
-**Decision**: <= 50 lines + no logic change → Lightweight; Auth/Security/Migrations/Perf → Deep; else → Standard.
-
-### Design Gate (Standard/Deep only)
-Verify `## Implementation plan` in issue body. If absent:
-- **Pause** → Prompt: "Run `/define` first, or confirm this is trivial."
-- If trivial → Downgrade to Lightweight.
-- Otherwise → Wait for `/define`.
+[Ref: scope-cycles.md] for scope assessment table, autonomous cycle detail, PR creation steps, and finalize logic.
 
 ## Pre-flight
 1. [Ref: repo-preflight] at entry (suppress branch line).
 2. [Ref: scope-preflight] if >= 3 files. Pass `preflight_verified: true` in seed-briefs.
 
 ## Process
+
 **Autonomy Contract**: Run cycles back-to-back without prompting. Only interrupt after PR is open if (a) clean, (b) 3 cycles exhausted, or (c) blocker hit.
 
-### Lightweight
-1. `/build` (inline) → TDD for logic-heavy snippets.
-2. Inline AC self-check.
-3. PR creation → Finalize.
+**Lightweight** (≤ 50 lines + no logic change): `/build` (inline) → inline AC check → PR. Skip `/review` and `/verify` teams.
 
-### Standard / Deep (Autonomous Cycle)
-**Seed Brief**: Raw YAML in `<seed-brief>` tag per [Ref: specialist-mode]. `payload: { type: research, ... }`.
-
-1. **`/build`**: Implementation team → codes against issue.
-2. **`/review`**: Review team → Deep scope triggers Deep mode.
-3. **`/verify`**: QA team → verifies every AC.
-4. **Evaluation**:
-   - **Clean pass** → PR creation.
-   - **Findings present & cycles < 3** → Package **fix brief** (failing AC + `file:line` findings) in `./.claude/NOTES.md`. Follow [Ref: compaction-protocol]. Resume `/build` → `/review` → `/verify`.
-   - **Cycles = 3** → PR creation → surface remaining findings in Finalize.
-
-**Reporting**: Emit one status line per cycle: `Cycle N/3 — /build <state>, /review <n findings>, /verify <n failures>`.
-
-### PR Creation
-Run from worktree root.
-1. Harvest `## Decisions made this session` and `## Open questions` from `.claude/NOTES.md` → PR `## Notes`.
-2. Push branch → Resolve base (default to `main` if no upstream).
-3. Create draft PR (`gh pr create --draft --base <base>`).
-   - `Closes #<issue>` (final) or `Related to #<issue>` (partial).
-   - **Body**: `## Summary` (1-2 sentences), `## Testing notes` (concrete repro), `## Notes` (from NOTES.md / exhausted findings).
-4. `/compound` (autonomous) → file durable learnings to wiki.
-5. Delete `.claude/NOTES.md`.
-
-### Finalize
-- **Clean exit** → present PR URL.
-- **Exhausted exit** (3 cycles, findings remain):
-  - `autonomous: true` → Accept/close unconditionally → status line.
-  - `autonomous: false` → PR URL + findings → binary question: "Continue loop, or accept and close?"
-    - **Continue** → One more cycle → log escalation in PR `## Notes` → return to Finalize.
+**Standard / Deep**: Full Build → Review → Verify cycle. Repeat up to 3 times until clean or exhausted, then PR creation.
 
 ## Rules
 - **Zero Prompts**: No prompting between sub-skills.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -10,11 +10,11 @@ allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ## Role & Constraints
 Orchestrate build → review → verify → fix cycles to produce a ready-to-merge PR.
 
-[Ref: scope-cycles.md] for scope assessment table, autonomous cycle detail, PR creation steps, and finalize logic.
+Read `_shared/scope-cycles.md` for scope assessment table, autonomous cycle detail, PR creation steps, and finalize logic.
 
 ## Pre-flight
-1. [Ref: repo-preflight] at entry (suppress branch line).
-2. [Ref: scope-preflight] if >= 3 files. Pass `preflight_verified: true` in seed-briefs.
+1. Read `_shared/repo-preflight.md` at entry (suppress branch line).
+2. Read `_shared/scope-preflight.md` if >= 3 files. Pass `preflight_verified: true` in seed-briefs.
 
 ## Process
 
@@ -29,4 +29,4 @@ Orchestrate build → review → verify → fix cycles to produce a ready-to-mer
 - **Rigor**: Do not open PR until clean pass OR 3 cycles exhausted.
 - **Completeness**: Each cycle must address ALL previous findings.
 - **State**: In-phase state in `.claude/NOTES.md`. Issue body stores `## Requirements` and `## Implementation plan`.
-- [Ref: handoff-artifact]
+- Read `_shared/handoff-artifact.md`

--- a/skills/implement/references/scope-cycles.md
+++ b/skills/implement/references/scope-cycles.md
@@ -26,7 +26,7 @@ Verify `## Implementation plan` in issue body. If absent:
 3. **`/verify`**: QA team → verifies every AC.
 4. **Evaluation**:
    - **Clean pass** → PR creation.
-   - **Findings present & cycles < 3** → Package **fix brief** (failing AC + `file:line` findings) in `./.claude/NOTES.md`. Resume `/build` → `/review` → `/verify`.
+   - **Findings present & cycles < 3** → Package **fix brief** (failing AC + `file:line` findings) in `./.claude/NOTES.md`. Follow `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md\`` to format concisely. Resume `/build` → `/review` → `/verify`.
    - **Cycles = 3** → PR creation → surface remaining findings in Finalize.
 
 **Reporting**: Emit one status line per cycle: `Cycle N/3 — /build <state>, /review <n findings>, /verify <n failures>`.

--- a/skills/implement/references/scope-cycles.md
+++ b/skills/implement/references/scope-cycles.md
@@ -1,0 +1,51 @@
+# Scope Assessment and Cycle Details for implement
+
+## Scope Assessment
+
+|Scope|Criteria|Action|
+|-|-|-|
+|**Lightweight**|≤ 50 lines, no logic change, 1-2 AC|`/build` (inline) → inline AC check → PR. Skip `/review` and `/verify` teams.|
+|**Standard**|Typical multi-file, AC in one module|Full Build → Review → Verify cycle.|
+|**Deep**|Cross-module, security, migration, breaking|Full cycle + Deep review + extra critique iterations.|
+
+**Decision**: ≤ 50 lines + no logic change → Lightweight; Auth/Security/Migrations/Perf → Deep; else → Standard.
+
+### Design Gate (Standard/Deep only)
+
+Verify `## Implementation plan` in issue body. If absent:
+- **Pause** → Prompt: "Run `/define` first, or confirm this is trivial."
+- If trivial → Downgrade to Lightweight.
+- Otherwise → Wait for `/define`.
+
+## Autonomous Cycle (Standard / Deep)
+
+**Seed Brief**: Raw YAML in `<seed-brief>` tag per specialist-mode. `payload: { type: research, ... }`.
+
+1. **`/build`**: Implementation team → codes against issue.
+2. **`/review`**: Review team → Deep scope triggers Deep mode.
+3. **`/verify`**: QA team → verifies every AC.
+4. **Evaluation**:
+   - **Clean pass** → PR creation.
+   - **Findings present & cycles < 3** → Package **fix brief** (failing AC + `file:line` findings) in `./.claude/NOTES.md`. Resume `/build` → `/review` → `/verify`.
+   - **Cycles = 3** → PR creation → surface remaining findings in Finalize.
+
+**Reporting**: Emit one status line per cycle: `Cycle N/3 — /build <state>, /review <n findings>, /verify <n failures>`.
+
+## PR Creation & Finalize
+
+Run from worktree root.
+1. Harvest `## Decisions made this session` and `## Open questions` from `.claude/NOTES.md` → PR `## Notes`.
+2. Push branch → Resolve base (default to `main` if no upstream).
+3. Create draft PR (`gh pr create --draft --base <base>`).
+   - `Closes #<issue>` (final) or `Related to #<issue>` (partial).
+   - **Body**: `## Summary` (1-2 sentences), `## Testing notes` (concrete repro), `## Notes` (from NOTES.md / exhausted findings).
+4. `/compound` (autonomous) → file durable learnings to wiki.
+5. Delete `.claude/NOTES.md`.
+
+### Finalize
+
+- **Clean exit** → present PR URL.
+- **Exhausted exit** (3 cycles, findings remain):
+  - `autonomous: true` → Accept/close unconditionally → status line.
+  - `autonomous: false` → PR URL + findings → binary question: "Continue loop, or accept and close?"
+    - **Continue** → One more cycle → log escalation in PR `## Notes` → return to Finalize.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -24,68 +24,26 @@ Audit skill authoring quality and dead state in `~/.claude/`. Archive approved c
 
 Each spawn prompt must include: `lane` (authoring|dead-state), `cwd` (absolute project root path), `files` (pre-enumerated list above). Each must start with `cd <cwd> && pwd`.
 
-### Authoring Lane
-Read each file in `files`. Run 5 checks (Cite Augment Code study):
-1. **Length Triage**: Flag if exceeds cap (Global: 50, Project: 200, Subdir: 50, Shared: 100, `.claude/` files use Subdir: 50).
-2. **Unpaired "Don't"**: Scan for `Don't`/`Avoid`/`Never` without a paired `Do`/`Always`/`Prefer` within 3 lines.
-3. **Warning-Stack**: Flag if `Don't` lines > 10 (warning) or > 30 (error).
-4. **Architecture Smell**: Headings like `Architecture`/`Overview` exceeding 30 lines → recommend relocation to reference file.
-5. **Decision-Table**: Prose matching "Use X for A, use Y for B" (>= 3 branches) → recommend table conversion.
-
-### Dead-state Lane
-Always audits global `~/.claude/` regardless of CWD. Flags the following classes:
-- `~/.claude/projects/<encoded>/` dirs whose encoded CWD does not resolve to any directory on disk.
-- `.jsonl` transcripts inside those flagged directories.
-- `~/.claude/agents/*.md` files not referenced by any installed skill, `settings*.json`, or recent transcript.
-- `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` dirs whose version is not the currently installed one.
-- `~/.claude/scheduled_tasks.json` entries pointing at a CWD that no longer exists.
-- `~/.claude/plans/*-agent-<hex>.md` files (sub-agent spawn artifacts). Always candidates.
-
-Regular plans (`~/.claude/plans/*.md` without `-agent-` suffix) are listed informational-only with `mtime`, size, and first H1/first-line snippet. `suggested-action: keep`.
+[Ref: audit-checks.md] for Authoring Lane checks and Dead-state Lane classes.
 
 ## Aggregation & Archive
 
-After both sub-agents return:
+After sub-agents return:
 
-**Authoring output**: Report findings grouped by file (path, line, issue, recommendation).
+**Authoring**: Report findings grouped by file (path, line, issue, recommendation).
 
-**Dead-state output**: Print full candidate table grouped by scope (`current project` / `other projects`):
+**Dead-state**: Print candidates table (path | size | mtime | reason | suggested-action), grouped by scope. Regular plans: `suggested-action: keep`.
 
-```
-path | size | mtime | reason | suggested-action
-```
+**Approval**: `AskUserQuestion` over candidates. Pre-select all `suggested-action: archive`.
 
-Regular plans appear in the table with `suggested-action: keep` and a snippet.
+**Archive** (approved items only):
+- **Filesystem paths**: `mv` to `${HOME}/.claude/archive/$(date -I)/${rel}`.
+- **`scheduled_task:<cwd>` entries**: copy `scheduled_tasks.json` to archive, then edit original to remove entries.
 
-**Approval gate**: Single `AskUserQuestion` over the full dead-state candidate table. Question: "Which items should be archived?". `multiSelect: true`. Pre-select all `suggested-action: archive` items. If the user excludes any, drop those paths before proceeding.
-
-**Archive step** (for approved items only):
-
-Two item types need different treatment:
-
-- **Filesystem paths** (project dirs, agents, plugin caches, plan files): move with `mv`.
-  ```bash
-  archive_root="${HOME}/.claude/archive/$(date -I)"
-  rel="${src#${HOME}/.claude/}"
-  dst="${archive_root}/${rel}"
-  mkdir -p "$(dirname "$dst")"
-  mv "$src" "$dst"
-  echo "${src} → ${dst}"
-  ```
-
-- **`scheduled_task:<cwd>` entries**: not filesystem paths — first copy `~/.claude/scheduled_tasks.json` to `${archive_root}/scheduled_tasks.json` (preserves the original state), then edit the original in place to remove every approved entry. Report as `archived scheduled_tasks.json → ${archive_root}/scheduled_tasks.json; removed entries: <cwd1>, <cwd2>, …`.
-
-Never use `rm`. Print a manifest (`src → dst` or `removed from ...: <cwd>` per item).
-
-## Classification & Output
-
-**Final Report**:
-- Authoring findings (grouped by file, cite source, specific issue).
-- Dead-state archive manifest (or "No items archived.").
-- Specific recommendations + suggested edits.
+Never use `rm`. Print manifest per item.
 
 ## Rules
 - **No Delete**: Archive only — never `rm` any file.
 - **Aggregate Only**: Main thread synthesizes sub-agent output; no re-reading files.
-- **Surgical**: Only list authoring findings; do not rewrite files.
-- **Vault**: Vault health is out of scope. Direct users to run `/lint` separately.
+- **Surgical**: Only list findings; do not rewrite files.
+- **Vault**: Out of scope. Direct users to run `/lint` separately.

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -37,8 +37,8 @@ After sub-agents return:
 **Approval**: `AskUserQuestion` over candidates. Pre-select all `suggested-action: archive`.
 
 **Archive** (approved items only):
-- **Filesystem paths**: `mv` to `${HOME}/.claude/archive/$(date -I)/${rel}`.
-- **`scheduled_task:<cwd>` entries**: copy `scheduled_tasks.json` to archive, then edit original to remove entries.
+- **Filesystem paths**: Ensure parent directory exists via `mkdir -p "$(dirname "$dst")"`, then `mv` to `${HOME}/.claude/archive/$(date -I)/${rel}`.
+- **`scheduled_task:<cwd>` entries**: First copy `scheduled_tasks.json` to archive, then edit the original in place to remove entries. Print manifest: `removed entries: <cwd1>, <cwd2>, …`.
 
 Never use `rm`. Print manifest per item.
 

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -24,7 +24,7 @@ Audit skill authoring quality and dead state in `~/.claude/`. Archive approved c
 
 Each spawn prompt must include: `lane` (authoring|dead-state), `cwd` (absolute project root path), `files` (pre-enumerated list above). Each must start with `cd <cwd> && pwd`.
 
-[Ref: audit-checks.md] for Authoring Lane checks and Dead-state Lane classes.
+Read `_shared/audit-checks.md` for Authoring Lane checks and Dead-state Lane classes.
 
 ## Aggregation & Archive
 

--- a/skills/prune/references/audit-checks.md
+++ b/skills/prune/references/audit-checks.md
@@ -1,0 +1,24 @@
+# Audit Checks for prune
+
+## Authoring Lane Checks
+
+Read each file in `files`. Run 5 checks:
+
+1. **Length Triage**: Flag if exceeds cap (Global: 50, Project: 200, Subdir: 50, Shared: 100, `.claude/` files use Subdir: 50).
+2. **Unpaired "Don't"**: Scan for `Don't`/`Avoid`/`Never` without a paired `Do`/`Always`/`Prefer` within 3 lines.
+3. **Warning-Stack**: Flag if `Don't` lines > 10 (warning) or > 30 (error).
+4. **Architecture Smell**: Headings like `Architecture`/`Overview` exceeding 30 lines → recommend relocation to reference file.
+5. **Decision-Table**: Prose matching "Use X for A, use Y for B" (≥ 3 branches) → recommend table conversion.
+
+## Dead-state Lane Classes
+
+Always audits global `~/.claude/`. Flags:
+
+- `~/.claude/projects/<encoded>/` dirs whose encoded CWD does not resolve to any directory on disk.
+- `.jsonl` transcripts inside those flagged directories.
+- `~/.claude/agents/*.md` files not referenced by any installed skill, `settings*.json`, or recent transcript.
+- `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/` dirs whose version is not the currently installed one.
+- `~/.claude/scheduled_tasks.json` entries pointing at a CWD that no longer exists.
+- `~/.claude/plans/*-agent-<hex>.md` files (sub-agent spawn artifacts). Always candidates.
+
+Regular plans (`~/.claude/plans/*.md` without `-agent-` suffix) are listed informational-only with `mtime`, size, and first H1/first-line snippet. `suggested-action: keep`.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -36,20 +36,8 @@ Group by category → Present triage summary to user.
 - **Regression**: Run full project test suite after all fix agents complete.
 
 ### Phase 4 — Reply
-**Delegate reply drafting**: One sub-agent per thread (reply text only — code fixes were grouped by file in Phase 3, and GitHub mutations stay in the main thread). Prompt: `cd <abs-path> && pwd`.
-**Verdict & Reply**:
-|Verdict|Meaning|Reply|
-|-|-|-|
-|`fixed`|Exact implementation|"Fixed in {commit_sha}."|
-|`fixed-differently`|Addressed via other approach|"Addressed differently: {explanation}. See {commit_sha}."|
-|`replied`|Disagree/Clarify|"{explanation}"|
-|`not-addressing`|Intentional skip|"Not addressing: {rationale}"|
-|`needs-human`|Confidence too low|"Needs human review: {context}"|
-
-**Mutation (main thread)**:
-1. Post each drafted reply via `gh api .../replies` (safe body passing).
-2. Resolve thread if verdict in {`fixed`, `fixed-differently`, `not-addressing`}.
-3. **Verify**: Run `gh pr view <N> --json reviewThreads` and confirm all threads are resolved before declaring work done.
+**Delegate reply drafting**: One sub-agent per thread (reply text only). Prompt: `cd <abs-path> && pwd`.
+[Ref: verdicts.md] for verdict/reply mapping and mutation logic.
 
 ## Output
 Summary: Total threads → counts per verdict → commits created → threads needing human attention.

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -12,7 +12,7 @@ Systematically process PR feedback: Triage → Fix → Reply.
 
 ## I/O
 - **Input**: No arg (all unresolved threads on branch's PR) or thread URL.
-- **Pre-flight**: [Ref: repo-preflight]. If >= 3 files, run [Ref: scope-preflight].
+- **Pre-flight**: Read `_shared/repo-preflight.md`. If >= 3 files, run `_shared/scope-preflight.md`.
 
 ## Process
 
@@ -37,7 +37,7 @@ Group by category → Present triage summary to user.
 
 ### Phase 4 — Reply
 **Delegate reply drafting**: One sub-agent per thread (reply text only). Prompt: `cd <abs-path> && pwd`.
-[Ref: verdicts.md] for verdict/reply mapping and mutation logic.
+Read `_shared/verdicts.md` for verdict/reply mapping and mutation logic.
 
 ## Output
 Summary: Total threads → counts per verdict → commits created → threads needing human attention.

--- a/skills/resolve-pr-feedback/references/verdicts.md
+++ b/skills/resolve-pr-feedback/references/verdicts.md
@@ -1,0 +1,18 @@
+# Verdicts and Reply Logic for resolve-pr-feedback
+
+## Phase 4 — Reply: Verdict & Reply
+
+Each sub-agent determines a verdict and drafts reply text (code fixes were grouped by file in Phase 3).
+
+|Verdict|Meaning|Reply|
+|-|-|-|
+|`fixed`|Exact implementation|"Fixed in {commit_sha}."|
+|`fixed-differently`|Addressed via other approach|"Addressed differently: {explanation}. See {commit_sha}."|
+|`replied`|Disagree/Clarify|"{explanation}"|
+|`not-addressing`|Intentional skip|"Not addressing: {rationale}"|
+|`needs-human`|Confidence too low|"Needs human review: {context}"|
+
+### Mutation (main thread)
+1. Post each drafted reply via `gh api .../replies` (safe body passing).
+2. Resolve thread if verdict in {`fixed`, `fixed-differently`, `not-addressing`}.
+3. **Verify**: Run `gh pr view <N> --json reviewThreads` and confirm all threads are resolved.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -16,54 +16,14 @@ Lead review phase. Goal: Thoroughly review implementation and produce actionable
 
 ## I/O
 - **Input**: Branch (+ seed brief), Branch (standalone + issue#), or PR argument (PR# or URL).
-- **Review Package** (Sole input to reviewers):
-  - Diff: `git diff main...HEAD` or `gh pr diff <n>`.
-  - AC: From seed brief, `gh issue view <n>`, or linked issue.
-  - Reviewer Preamble: "Review code you did not write. Base review ONLY on provided diff and AC."
+- **Review Package**: Diff (`git diff` or `gh pr diff`), AC (seed brief / issue / linked), reviewer preamble.
 - **Output**: Fix brief (for `/build`), Findings report (user), or Posted GitHub review (PR).
 
-## Dispatch Modes
-|Trigger|Diff Source|AC Source|Output|
-|-|-|-|-|
-|Branch + Seed|`git diff`|Seed brief|Fix brief → `/build`|
-|Branch Standalone|`git diff`|`gh issue view`|Findings report → User|
-|PR Argument|`gh pr diff`|Linked issue|Posted GitHub review|
-
-## Scope Assessment
-|Scope|Criteria|Action|
-|-|-|-|
-|**Lightweight**|Diff <= 50 lines, 1 module|Single reviewer, quick pass.|
-|**Standard**|Typical feature/multi-file|2 base reviewers + conditional specialists.|
-|**Deep**|Security, perf, cross-cutting, migration|All specialist reviewers. Veto power for Security/Perf.|
-
-**Decision**: <= 50 lines + 1 module → Lightweight; Auth/Security/DB-migration/Perf → Deep; else → Standard.
-
-### Spawn Rubric [Ref: composition]
-- **Standard**: `TeamCreate` at >= 3 active personas, else 2 parallel subagents (`sonnet`).
-- **Deep**: `TeamCreate` (`opus`). All 4 axes active.
+[Ref: dispatch-process.md] for dispatch modes, scope assessment, spawn rubric, process steps, and PR posting logic.
 
 ## Personas [Ref: references/personas.md]
 - **Always-on**: Correctness, Standards.
 - **Conditional**: Security, Performance, Migration, Docs Consistency, Architecture/Scope-creep. (Activate only if gate fires).
-
-## Process
-1. **Acquire Review Package** (Context Isolation).
-2. **Triage**: Analyze diff → activate conditional personas → record why gates fired.
-3. **Review**: Reviewers work in parallel → use `superpowers:requesting-code-review`.
-4. **Findings Format**: `file:line | issue title | severity (P0-P3) | confidence (0.0-1.0)`.
-5. **Merge & Dedup**:
-   - Group by `file` + `line_bucket` (3-line windows) + `normalized_title`.
-   - Boost confidence by 0.10 if 2+ reviewers flag.
-   - Suppress if confidence < 0.60 (or 0.50 for P0).
-6. **Emit**: Per Dispatch Mode.
-
-## PR Mode: Idempotent Posting
-1. **Fingerprint**: `fp = sha256(file:line_bucket:normalized_title)[:12]`.
-2. **Pre-scan**: Fetch existing comments by runner → skip if `<!-- review-fp: <fp> -->` exists.
-3. **Payload**:
-   - Inline findings: `**[P1, conf 0.85]** Title \n\n Elaboration \n\n <!-- review-fp: <fp> -->`.
-   - Summary: Top 3 findings sorted by severity → confidence. End with `<!-- review-summary-fp: <sum_fp> -->`.
-4. **Post**: Atomic REST call via `gh api repos/.../reviews`. `event: "COMMENT"`. Anchor to `headRefOid` (SHA).
 
 ## Rules
 - **Separation**: Never fix issues during review. Report findings in the review output; fixes happen in a subsequent `/build` cycle.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -19,9 +19,9 @@ Lead review phase. Goal: Thoroughly review implementation and produce actionable
 - **Review Package**: Diff (`git diff` or `gh pr diff`), AC (seed brief / issue / linked), reviewer preamble.
 - **Output**: Fix brief (for `/build`), Findings report (user), or Posted GitHub review (PR).
 
-[Ref: dispatch-process.md] for dispatch modes, scope assessment, spawn rubric, process steps, and PR posting logic.
+Read `references/dispatch-process.md` for dispatch modes, scope assessment, spawn rubric, process steps, and PR posting logic.
 
-## Personas [Ref: references/personas.md]
+## Personas (see `references/personas.md`)
 - **Always-on**: Correctness, Standards.
 - **Conditional**: Security, Performance, Migration, Docs Consistency, Architecture/Scope-creep. (Activate only if gate fires).
 

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -12,7 +12,7 @@ Lead review phase. Goal: Thoroughly review implementation and produce actionable
 ## Specialist Mode
 - **Seeded**: Skip repo-preflight.
 - **Keep**: Severity/finding-depth gates (rigor is not delegated).
-- [Ref: specialist-mode]
+- Read `_shared/specialist-mode.md`
 
 ## I/O
 - **Input**: Branch (+ seed brief), Branch (standalone + issue#), or PR argument (PR# or URL).
@@ -30,4 +30,4 @@ Read `references/dispatch-process.md` for dispatch modes, scope assessment, spaw
 - **Consensus**: All reviewers must agree before finalizing.
 - **Blocking**: Critical findings block. Deep mode: High-severity blocks for Security/Perf.
 - **Scope**: Flag changes outside issue scope.
-- [Ref: interviewing-rules]
+- Read `_shared/interviewing-rules.md`

--- a/skills/review/references/dispatch-process.md
+++ b/skills/review/references/dispatch-process.md
@@ -1,0 +1,44 @@
+# Dispatch and Process for review
+
+## Dispatch Modes
+
+|Trigger|Diff Source|AC Source|Output|
+|-|-|-|-|
+|Branch + Seed|`git diff`|Seed brief|Fix brief → `/build`|
+|Branch Standalone|`git diff`|`gh issue view`|Findings report → User|
+|PR Argument|`gh pr diff`|Linked issue|Posted GitHub review|
+
+## Scope Assessment
+
+|Scope|Criteria|Action|
+|-|-|-|
+|**Lightweight**|Diff ≤ 50 lines, 1 module|Single reviewer, quick pass.|
+|**Standard**|Typical feature/multi-file|2 base reviewers + conditional specialists.|
+|**Deep**|Security, perf, cross-cutting, migration|All specialist reviewers. Veto power for Security/Perf.|
+
+**Decision**: ≤ 50 lines + 1 module → Lightweight; Auth/Security/DB-migration/Perf → Deep; else → Standard.
+
+### Spawn Rubric [Ref: composition]
+- **Standard**: `TeamCreate` at ≥ 3 active personas, else 2 parallel subagents (`sonnet`).
+- **Deep**: `TeamCreate` (`opus`). All 4 axes active.
+
+## Process
+
+1. **Acquire Review Package** (Context Isolation).
+2. **Triage**: Analyze diff → activate conditional personas → record why gates fired.
+3. **Review**: Reviewers work in parallel → use `superpowers:requesting-code-review`.
+4. **Findings Format**: `file:line | issue title | severity (P0-P3) | confidence (0.0-1.0)`.
+5. **Merge & Dedup**:
+   - Group by `file` + `line_bucket` (3-line windows) + `normalized_title`.
+   - Boost confidence by 0.10 if 2+ reviewers flag.
+   - Suppress if confidence < 0.60 (or 0.50 for P0).
+6. **Emit**: Per Dispatch Mode.
+
+## PR Mode: Idempotent Posting
+
+1. **Fingerprint**: `fp = sha256(file:line_bucket:normalized_title)[:12]`.
+2. **Pre-scan**: Fetch existing comments by runner → skip if `<!-- review-fp: <fp> -->` exists.
+3. **Payload**:
+   - Inline findings: `**[P1, conf 0.85]** Title \n\n Elaboration \n\n <!-- review-fp: <fp> -->`.
+   - Summary: Top 3 findings sorted by severity → confidence. End with `<!-- review-summary-fp: <sum_fp> -->`.
+4. **Post**: Atomic REST call via `gh api repos/.../reviews`. `event: "COMMENT"`. Anchor to `headRefOid` (SHA).

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -16,39 +16,26 @@ Lead verification phase. Goal: Verify every AC from the issue is met with eviden
 
 ## I/O
 - **Input**: Branch + GitHub issue number.
-- **Verification Package** (Sole input to teammates):
-  - Diff (`git diff main...HEAD`)
-  - AC (`gh issue view <number>`)
-  - Test commands (type-check, lint, unit, build, e2e)
-- **Output**: QA report (Pass/fail per AC with evidence, verification chain results, issues found).
+- **Verification Package**: Diff, AC, test commands (type-check, lint, unit, build, e2e).
+- **Output**: QA report (pass/fail per AC with evidence).
 
 ## Scope Assessment
+
 |Scope|Criteria|Action|
 |-|-|-|
-|**Lightweight**|<= 3 AC, simple repros, no security/perf|Lead verifies inline. No team.|
-|**Standard**|>= 4 AC, or spans multiple areas/files|QA team with AC split across teammates.|
-|**Deep**|Security-sensitive, perf-critical, migration|QA team + specialist QA (Security or Performance).|
+|**Lightweight**|≤ 3 AC, simple repros, no security/perf|Lead verifies inline|
+|**Standard**|≥ 4 AC, or multi-file|QA team, split AC|
+|**Deep**|Security/perf-critical, migration|QA team + specialist|
 
-**Decision**: <= 3 AC + 1-module diff → Lightweight; Auth/Security/Migrations/Perf-paths → Deep; else → Standard.
+**Decision**: ≤ 3 AC + 1-module → Lightweight; Auth/Security/Migrations/Perf → Deep; else → Standard.
 
-### Spawn Rubric [Ref: composition]
-- **Standard/Deep**: `TeamCreate` at >= 4 AC, else parallel subagents. Model: `haiku`.
+Spawn (Standard/Deep): `TeamCreate` at ≥ 4 AC, else subagents (`haiku`).
 
 ## Process
 
-### Lightweight
-1. Extract AC from issue.
-2. Run verification chain (step 4).
-3. Walk each AC → report pass/fail with evidence.
+**Lightweight**: Extract AC → run verification chain (type-check, lint, unit, build, e2e) → report pass/fail.
 
-### Standard / Deep
-1. Extract AC from issue.
-2. **Dispatch QA Verifiers**: Split AC across workers → each receives only the Verification Package.
-3. **Deep Only**: Add specialist worker matched to diff (Security/Perf).
-4. **Execution**: Teammates use `superpowers:verification-before-completion` → verify end-to-end → report pass/fail with evidence.
-5. **Verification Chain**:
-   - Type-check (`tsc --noEmit`) → Lint → Unit tests → Build → E2E/Browser tests.
-6. **Convergence**: Discuss edge cases → unified QA report.
+**Standard / Deep**: Split AC across QA team (Deep adds specialist) → each verifies independently → converge on unified report.
 
 ## Rules
 - **Separation**: Never fix issues during verification. Report failures in the verify output; fixes are a `/build` responsibility.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -12,7 +12,7 @@ Lead verification phase. Goal: Verify every AC from the issue is met with eviden
 ## Specialist Mode
 - **Seeded**: Skip repo-preflight.
 - **Keep**: AC verification rigor (pass/fail evidence is never delegated).
-- [Ref: specialist-mode]
+- Read `_shared/specialist-mode.md`
 
 ## I/O
 - **Input**: Branch + GitHub issue number.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -5,66 +5,27 @@ when_to_use: Run when ready to discard the feature worktree after a PR is open.
 model: sonnet
 allowed-tools: Bash Read
 ---
-<!-- Stays inline: destructive sequential ops — low context cost; must confirm before each step. -->
 
-You are cleaning up local state after a PR has been opened. Your job is to safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md — confirming before destructive actions and refusing outright when the operation would destroy protected state.
+You safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md — confirming before destructive actions and refusing when the operation would destroy protected state.
 
 ## Input
 
-The current worktree path and branch. Optionally, an open PR linked to the active issue (used to verify unpushed-commit safety).
+Current worktree path and branch. Optionally, an open PR number (used to verify unpushed-commit safety).
 
 ## Process
 
-### Step 1 — Detect state
+[Ref: references/procedure.md] for detailed steps 1–5.
 
-Gather:
-
-1. **Worktree path** — `git rev-parse --show-toplevel` from current directory, or use path user provides.
-2. **Branch name** — `git rev-parse --abbrev-ref HEAD`.
-3. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD --short` (strips `origin/`). Fall back to checking `['main', 'master', 'develop']` only when symbolic-ref lookup fails; log which method was used.
-4. **Worktree membership** — `wt list`. Confirm worktree path appears in this list.
-5. **Working-tree cleanliness** — `git status --short` and `git log @{u}..HEAD --oneline` (unpushed commits not in PR).
-6. **PR state** — if user provided PR number, run `gh pr view <N> --json state,headRefName` to confirm it is open and points to current branch.
-
-### Step 2 — Apply state machine
+**State machine** (apply after gathering git state):
 
 |Condition|Outcome|
 |-|-|
 |Branch matches default branch|**Refuse outright.** No proceed-anyway prompt|
-|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed by `/wrap-up`|
-|Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt** (Step 3)|
-|Worktree clean, feature branch, worktree in-tree|**Single confirmation** (Step 4)|
-
-### Step 3 — Dirty worktree: proceed-anyway prompt
-
-Show what is dirty (uncommitted files, unpushed commit list). Then ask:
-
-> The worktree has unsaved state (shown above). Proceed with removal anyway?
-> On yes, I will use `git branch -D` (force-delete) if unpushed commits would be lost.
-
-Wait for explicit confirmation. Do not proceed on silence.
-
-### Step 4 — Single confirmation (clean or dirty-with-override)
-
-Show the exact actions that will run:
-
-> I will:
-> - `wt remove <branch>` (removes the worktree directory, its contents including `.claude/NOTES.md` if present, and the branch)
->
-> Proceed?
-
-Wait for explicit confirmation. Do not proceed on silence.
-
-### Step 5 — Execute and report
-
-On confirm:
-
-1. `wt remove <branch>` (or `wt remove --force-delete <branch>` when dirty-worktree override was confirmed and commits would be lost) — removes worktree directory and deletes the branch. NOTES.md, if still present inside it, is removed implicitly.
-2. Report what was removed: worktree path, branch name, whether NOTES.md was present.
+|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed|
+|Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt**|
+|Worktree clean, feature branch, in-tree|**Single confirmation**|
 
 ## Output
-
-A one-line summary per removed artifact:
 
 ```
 Removed worktree: <path>
@@ -74,8 +35,8 @@ NOTES.md removed with worktree (was present / was already absent)
 
 ## Rules
 
-- Refuse outright (no proceed-anyway) when branch is the default branch or worktree path is not in `wt list`.
-- Use `wt remove --force-delete` only when dirty-worktree override was explicitly confirmed by user.
+- Refuse outright when branch is default branch or worktree path not in `wt list`.
+- Use `wt remove --force-delete` only when dirty-worktree override was explicitly confirmed.
 - Single confirmation covers all removals — do not ask separately for each artifact.
 - Do not write to GitHub issue body. Use `/compound` to capture learnings into the wiki instead.
-- Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time. NOTES.md removal here is incidental.
+- Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -14,7 +14,7 @@ Current worktree path and branch. Optionally, an open PR number (used to verify 
 
 ## Process
 
-[Ref: references/procedure.md] for detailed steps 1–5.
+Read `references/procedure.md` for detailed steps 1–5.
 
 **State machine** (apply after gathering git state):
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -14,16 +14,54 @@ Current worktree path and branch. Optionally, an open PR number (used to verify 
 
 ## Process
 
-Read `references/procedure.md` for detailed steps 1–5 (see that file for the complete steps).
+### Step 1 — Detect state
 
-**State machine** (apply after gathering git state):
+Gather via:
+
+1. **Worktree path** — `git rev-parse --show-toplevel` or use path user provides.
+2. **Branch name** — `git rev-parse --abbrev-ref HEAD`.
+3. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD --short` (strips `origin/`). Fall back to `['main', 'master', 'develop']` only if symbolic-ref lookup fails; log the method used.
+4. **Worktree membership** — `wt list`. Confirm worktree path appears in list.
+5. **Working-tree cleanliness** — `git status --short` and `git log @{u}..HEAD --oneline` (unpushed commits not in PR).
+6. **PR state** — if user provided PR number, run `gh pr view <N> --json state,headRefName` to confirm it is open and points to current branch.
+
+### Step 2 — Apply state machine
 
 |Condition|Outcome|
 |-|-|
 |Branch matches default branch|**Refuse outright.** No proceed-anyway prompt|
-|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed|
-|Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt**|
-|Worktree clean, feature branch, in-tree|**Single confirmation**|
+|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed by `/wrap-up`|
+|Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt** (Step 3)|
+|Worktree clean, feature branch, worktree in-tree|**Single confirmation** (Step 4)|
+
+### Step 3 — Dirty worktree: proceed-anyway prompt
+
+Show what is dirty (uncommitted files, unpushed commit list). Then ask:
+
+> The worktree has unsaved state (shown above). Proceed with removal anyway?
+> On yes, I will use `git branch -D` (force-delete) if unpushed commits would be lost.
+
+Stays inline: destructive sequential ops — low context cost; must confirm before each step.
+
+Wait for explicit confirmation. Do not proceed on silence.
+
+### Step 4 — Single confirmation (clean or dirty-with-override)
+
+Show the exact actions that will run:
+
+> I will:
+> - `wt remove <branch>` (removes the worktree directory, its contents including `.claude/NOTES.md` if present, and the branch)
+>
+> Proceed?
+
+Wait for explicit confirmation. Do not proceed on silence.
+
+### Step 5 — Execute and report
+
+On confirm:
+
+1. `wt remove <branch>` (or `wt remove --force-delete <branch>` when dirty-worktree override was confirmed and commits would be lost).
+2. Report what was removed: worktree path, branch name, whether NOTES.md was present.
 
 ## Output
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -14,7 +14,7 @@ Current worktree path and branch. Optionally, an open PR number (used to verify 
 
 ## Process
 
-Read `references/procedure.md` for detailed steps 1–5.
+Read `references/procedure.md` for detailed steps 1–5 (see that file for the complete steps).
 
 **State machine** (apply after gathering git state):
 

--- a/skills/wrap-up/references/procedure.md
+++ b/skills/wrap-up/references/procedure.md
@@ -1,0 +1,48 @@
+# Cleanup Procedure for wrap-up
+
+## Step 1 — Detect state
+
+Gather via:
+
+1. **Worktree path** — `git rev-parse --show-toplevel` or use path user provides.
+2. **Branch name** — `git rev-parse --abbrev-ref HEAD`.
+3. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD --short` (strips `origin/`). Fall back to `['main', 'master', 'develop']` only if symbolic-ref lookup fails; log the method used.
+4. **Worktree membership** — `wt list`. Confirm worktree path appears in list.
+5. **Working-tree cleanliness** — `git status --short` and `git log @{u}..HEAD --oneline` (unpushed commits not in PR).
+6. **PR state** — if user provided PR number, run `gh pr view <N> --json state,headRefName` to confirm it is open and points to current branch.
+
+## Step 2 — Apply state machine
+
+|Condition|Outcome|
+|-|-|
+|Branch matches default branch|**Refuse outright.** No proceed-anyway prompt|
+|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed by `/wrap-up`|
+|Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt** (Step 3)|
+|Worktree clean, feature branch, worktree in-tree|**Single confirmation** (Step 4)|
+
+## Step 3 — Dirty worktree: proceed-anyway prompt
+
+Show what is dirty (uncommitted files, unpushed commit list). Then ask:
+
+> The worktree has unsaved state (shown above). Proceed with removal anyway?
+> On yes, I will use `git branch -D` (force-delete) if unpushed commits would be lost.
+
+Wait for explicit confirmation. Do not proceed on silence.
+
+## Step 4 — Single confirmation (clean or dirty-with-override)
+
+Show the exact actions that will run:
+
+> I will:
+> - `wt remove <branch>` (removes the worktree directory, its contents including `.claude/NOTES.md` if present, and the branch)
+>
+> Proceed?
+
+Wait for explicit confirmation. Do not proceed on silence.
+
+## Step 5 — Execute and report
+
+On confirm:
+
+1. `wt remove <branch>` (or `wt remove --force-delete <branch>` when dirty-worktree override was confirmed and commits would be lost).
+2. Report what was removed: worktree path, branch name, whether NOTES.md was present.


### PR DESCRIPTION
Closes #104

Slims wrap-up, implement, review, describe, audit-issues, resolve-pr-feedback, discovery, prune, and verify to ≤50 lines each via prose condensing and reference extraction.

Final line counts:
- wrap-up: 42 lines (was 81)
- implement: 32 lines (was 75)
- review: 33 lines (was 73)
- describe: 47 lines (was 70)
- audit-issues: 50 lines (was 63)
- resolve-pr-feedback: 50 lines (was 62)
- discovery: 48 lines (was 62)
- prune: 49 lines (was 61)
- verify: 44 lines (was 57)