### PR TITLE
fix: replace [Ref:] shorthand with explicit read instructions across skills

### DIFF
--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -3,7 +3,7 @@
 Directives for creating/editing skills. Ensures consistency, token efficiency, and predictability.
 
 ## Skill Roles
-All skills map to one of these five roles (extending the [Ref: composition] model). Use the corresponding template.
+All skills map to one of these five roles (extending the team-composition model; read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`). Use the corresponding template.
 
 |Role|Definition|Example|Model|Template|
 |-|-|-|-|-|
@@ -19,8 +19,7 @@ All skills map to one of these five roles (extending the [Ref: composition] mode
 ### Modularity
 - **Entry-point cap**: Keep skill bodies ≤150 lines. Push stable reference material (schemas, syntax tables, field lists) into `skills/<name>/references/<file>.md`.
 - **`_shared/` promotion**: Promote a doc to `_shared/` when ≥3 skills reference it. Otherwise keep under `skills/<name>/references/`.
-- **On-demand loading**: Never preload `_shared/` files at skill start. Reference via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md` only where needed in the Process steps.
-- **`[Ref: name]` shorthand**: In space-constrained bodies use `[Ref: name]` as shorthand for `${CLAUDE_PLUGIN_ROOT}/_shared/name.md`.
+- **On-demand loading**: Never preload `_shared/` files at skill start. Reference via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` only where needed in the Process steps. Use inline read instructions: `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/composition.md\`` not `[Ref: composition]`.
 
 ### Frontmatter
 Order: `name` → `description` → `when_to_use` → `argument-hint` → `model` → `effort` → `allowed-tools` → `user-invocable` → `disable-model-invocation`.
@@ -58,15 +57,15 @@ Agents dispatched inside a plugin context run with constrained tool access by de
 
 ### Body Layout
 1. **Role & Constraints**: Imperative directives. No "You are a...".
-2. **Specialist Mode**: [Ref: specialist-mode] seed-brief skip-list.
+2. **Specialist Mode**: Read `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md` for seed-brief skip-list.
 3. **I/O**: Input → Output. No paragraphs.
 4. **Scope Assessment**: Table based on complexity → Action.
-5. **Spawn Justification**: [Ref: composition] rubric (Pivot, Disjoint, Parallel, Payoff).
+5. **Spawn Justification**: Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for team-composition rubric (Pivot, Disjoint, Parallel, Payoff).
 6. **Process**: Step-by-step imperative flow.
-7. **Rules**: Hard constraints + [Ref: interviewing-rules].
+7. **Rules**: Hard constraints plus interaction rules (read `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`).
 
 ## `_shared/` Integration
-Do not preload. Reference on-demand via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md`.
+Do not preload. Reference on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` within skill bodies:
 - `handoff-artifact.md`: Issue body state.
 - `interviewing-rules.md`: User interaction.
 - `notes-md-protocol.md`: `.claude/NOTES.md` state.
@@ -74,13 +73,13 @@ Do not preload. Reference on-demand via `${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md
 - `compaction-protocol.md`: In-phase context management.
 - `composition.md`: Team/sub-agent cost and shape.
 
-`[Ref: name]` is shorthand for `${CLAUDE_PLUGIN_ROOT}/_shared/name.md`. Skills use it for compact inline references in space-constrained skill bodies.
+Use explicit read instructions inline: `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/composition.md\`` instead of shorthand `[Ref: composition]`.
 
 ## Compaction Checklist
 Before declaring any compaction (density pass, context-hygiene trim) complete:
 - All gates and numeric thresholds preserved verbatim (no approximation).
 - All spawn rubrics, dispatch contracts, and payload specs intact.
-- All `[Ref:]` cross-references present — none silently removed.
+- All cross-references to `_shared/` files present with explicit `Read` instructions — none silently removed.
 - All verdict/mutation/resolution steps accounted for.
 - Output format spec and section headings unchanged.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,7 +12,7 @@ Lifecycle walkthrough from discovery to closure.
 **State Management**:
 - **Inter-phase**: GitHub issue body (5-field structure in `_shared/handoff-artifact.md`).
 - **Intra-phase**: `./.claude/NOTES.md` (`_shared/notes-md-protocol.md`).
-- **Context Pressure**: [Ref: compaction-protocol] (Edit → Delegate → Compact).
+- **Context Pressure**: See compaction-protocol (read `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md`) for Edit → Delegate → Compact strategy.
 
 ## Phase Details
 

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -12,7 +12,7 @@ Lead architecture team. Goal: Converge on a technical approach via research, ite
 ## Specialist Mode
 - **Seeded**: Skip codebase and patterns research subagent dispatches.
 - **Keep**: Full architecture session (grill-me + devil's advocate).
-- [Ref: specialist-mode]
+- Read `_shared/specialist-mode.md`
 
 ## I/O
 - **Input**: GitHub issue with problem statement and AC (from /discovery).
@@ -43,4 +43,4 @@ Lead architecture team. Goal: Converge on a technical approach via research, ite
 - **Code-First**: Never propose architecture without reading existing code.
 - **Pattern Adherence**: Respect existing patterns unless justifying deviation.
 - **Concrete Only**: No vague placeholders; every section must be decisive.
-- [Ref: interviewing-rules]
+- Read `_shared/interviewing-rules.md`

--- a/skills/build/references/steps.md
+++ b/skills/build/references/steps.md
@@ -1,0 +1,113 @@
+# Build Skill — Scope Assessment & Process Details
+
+## Scope Assessment
+
+Classify the build per criteria below:
+
+|Scope|Criteria|Team|
+|-|-|-|
+|Lightweight|Single-file or tightly scoped; AC fits one module; no sub-issues|Code inline, no team|
+|Standard|2–3 natural work splits (sub-issues or distinct file groups)|Implementation team, one teammate per split|
+|Deep|Many sub-issues, cross-module work, or architecture-changing scope|Larger implementation team; peer coordination|
+
+### Decision Tree
+
+1. Zero sub-issues and diff in one module? → Lightweight
+2. 4+ sub-issues or touches 3+ independent modules? → Deep
+3. Otherwise → Standard
+
+### Spawn Justification
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
+
+- **Standard**: TeamCreate at ≥3 splits, else parallel subagents.
+- **Deep**: TeamCreate.
+
+## Specialist Mode
+
+When invoked by `/implement` with a `<seed-brief>` block, skip:
+- repo-preflight (already run; `preflight_verified: true` in brief)
+- scope-preflight (scope class in brief as `scope_class`)
+- scope-class confirmation
+
+Always keep: the design gate — architecture decisions must be verified cross-phase even when seeded.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/_shared/specialist-mode.md`.
+
+## Process Steps
+
+### Step 0 — Pre-flight
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/_shared/repo-preflight.md`.
+Confirmation prompt: "Does this match the repo and branch you intend to work on?"
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/_shared/scope-preflight.md` — run when Trigger conditions apply.
+
+### Step 1 — Issue Review
+
+Read the issue, all comments, and linked sub-issues to understand the full scope.
+
+### Step 2 — Git Worktree & Task List
+
+Create a git worktree (`wt switch --create`). Worktrees keep the main workspace clean and let teammates operate in isolation. Lightweight still uses a worktree.
+
+Before creating `./.claude/NOTES.md`, verify `/.claude/NOTES.md` is listed in `.gitignore` at repo root; add if missing. Create `./.claude/NOTES.md` with the initial task list harvested from the issue. This is the living worklog — it survives unexpected session close.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md`.
+
+**On resume in an existing worktree**, read `./.claude/NOTES.md` _before_ re-reading the issue. Resume from its **Next action on resume** field.
+
+### Step 3 — Spawn Workers
+
+Spawn workers per the Scope Assessment:
+- **Lightweight**: Code inline, no team.
+- **Standard**: Implementation team or parallel subagents (one per sub-issue or file group).
+- **Deep**: TeamCreate for larger teams.
+
+With TeamCreate, teammates communicate peer-to-peer; with subagents, the lead merges results. Coordinate via the shared task list.
+
+### Step 4 — Test-Driven Development
+
+Each teammate follows **test-driven development (TDD)** for logic-heavy code:
+- Write failing test first — derive from acceptance criteria.
+- Implement until test passes — minimal code.
+- Refactor — clean up while tests stay green.
+- Skip TDD for pure boilerplate/wiring.
+
+### Step 5 — Verify Before Marking Done
+
+Run `superpowers:verification-before-completion` after each task. Mandatory; fix any gaps before committing.
+
+### Step 6 — Simplify as You Go
+
+After every 2-3 task completions, scan for obvious duplication, dead code, or consolidation opportunities in touched files. Not a full refactor — just fast low-hanging fruit. If found, create a micro-task to consolidate before proceeding.
+
+### Step 7 — Context Hygiene
+
+Keep context focused. Trigger on **concept shifts**, not percentages:
+- Stale tool results after work has moved on → clear with context editing.
+- About to read a large file or grep wide → delegate to sub-agent that returns focused report.
+- About to start a new sub-issue or just spawned a sub-agent → natural reset.
+- If `/compact` is unavoidable: flush working set into `./.claude/NOTES.md`, emit `Keep: / Drop:` note, run `/compact`, diff post-compaction summary against Keep list in `./.claude/NOTES.md` before next tool call.
+
+Reference: `${CLAUDE_PLUGIN_ROOT}/_shared/compaction-protocol.md`. Context editing first, sub-agents second, `/compact` last.
+
+### Step 8 — Incremental Commits & Notes
+
+Commit changes incrementally using semantic messages (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`). Update `./.claude/NOTES.md` after each completed task — resume point if session dies.
+
+## Output
+
+A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for /review.
+
+## Rules
+
+- Use `superpowers:test-driven-development` for the TDD workflow.
+- Use `wt switch --create` / `wt remove` for worktree management.
+- Pick the spawn primitive per the Scope Assessment. Lightweight codes inline.
+- Do not ask the user whether to use teams — pick the scope and go. Pick inline / subagent / team based on the Scope Assessment table above.
+- Do not open a PR — that happens after /implement completes the full cycle.
+- Always run the 5-question verification check before marking a task done.
+- Consolidation scans are lightweight — spend seconds, not minutes.
+- Context hygiene is a build-time responsibility — trigger on concept shifts, not percentages. Trigger `/compact` automatically at concept shifts; delegate bulk I/O to sub-agents before context overruns.
+- `./.claude/NOTES.md` is authoritative for in-flight state; if your recall disagrees, trust the file.

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -19,7 +19,7 @@ Phase Lead. Goal: Transform an approved issue into a concrete implementation pla
 
 **Decision**: 1 module + pattern match → Lightweight; Security/Payments/Arch-change → Deep; else → Standard.
 
-### Spawn Rubric [Ref: composition]
+### Spawn Rubric (see `_shared/composition.md`)
 - **Research Team**: 2 parallel `sonnet` agents (Codebase + Patterns).
 - **Standard Team**: Sequential specialists (Architecture → Design).
 - **Deep Team**: Standard + `TeamCreate` critique team (only for high-risk plans).
@@ -32,7 +32,7 @@ Phase Lead. Goal: Transform an approved issue into a concrete implementation pla
    - **Standard**: Architecture → Design (if visual).
    - **Deep**: Architecture → Design → Critique Team.
 4. **Sourcing**: Respect sequence: Architecture decisions first → Design works within those constraints.
-5. **Handoff**: Update GitHub issue body (single source of truth) per [Ref: handoff-artifact].
+5. **Handoff**: Update GitHub issue body (single source of truth) per `_shared/handoff-artifact.md`.
    - Edit/Append `## Implementation plan` section.
    - Record decisions, visuals, and sub-issues with relationships.
    - Define dependency graph for parallelization.
@@ -43,5 +43,5 @@ Phase Lead. Goal: Transform an approved issue into a concrete implementation pla
 ## Rules
 - **Explicit Approval**: Partial feedback ≠ approval.
 - **Exploration**: Time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
-- **Sourcing**: Use [Ref: repo-preflight] before updating issue.
-- [Ref: interviewing-rules]
+- **Sourcing**: Use `_shared/repo-preflight.md` before updating issue.
+- Read `_shared/interviewing-rules.md`

--- a/skills/describe/references/scope-ppt.md
+++ b/skills/describe/references/scope-ppt.md
@@ -10,7 +10,9 @@
 
 **Decision**: 1 file + 1 sentence → Lightweight; Auth/Security/Arch → Deep; else → Standard.
 
-### Spawn Rubric [Ref: composition]
+### Spawn Rubric
+
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 - **Standard**: Domain researcher (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
 - **Deep**: Domain researcher + Failure-mode analyst (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -11,7 +11,7 @@ Lead design team. Goal: Converge on visual and interaction design that fits exis
 ## Specialist Mode
 - **Seeded**: Skip design-space research subagent.
 - **Keep**: Interactive session (grill-me + a11y review).
-- [Ref: specialist-mode]
+- Read `_shared/specialist-mode.md`
 
 ## I/O
 - **Input**: GitHub issue with architecture decisions (from /define).
@@ -41,4 +41,4 @@ Lead design team. Goal: Converge on visual and interaction design that fits exis
 
 ## Rules
 - **Consistency**: Follow existing design system/component patterns unless diverging.
-- [Ref: interviewing-rules]
+- Read `_shared/interviewing-rules.md`

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -41,4 +41,4 @@ A single file at the chosen target location, conforming to the authoring standar
 - Defaults (if skipped): model: sonnet; effort, argument-hint, allowed-tools, user-invocable: omit; target: personal.
 - Include `when_to_use` only if author identified mis-routing risk (step c); omit otherwise.
 - If target `SKILL.md` exists, ask whether to overwrite.
-- [Ref: ${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md]
+- Read `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`

--- a/skills/review/references/dispatch-process.md
+++ b/skills/review/references/dispatch-process.md
@@ -18,7 +18,9 @@
 
 **Decision**: ≤ 50 lines + 1 module → Lightweight; Auth/Security/DB-migration/Perf → Deep; else → Standard.
 
-### Spawn Rubric [Ref: composition]
+### Spawn Rubric
+
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 - **Standard**: `TeamCreate` at ≥ 3 active personas, else 2 parallel subagents (`sonnet`).
 - **Deep**: `TeamCreate` (`opus`). All 4 axes active.
 

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -12,11 +12,11 @@ Lead requirements team. Goal: Transform problem statements into testable, non-va
 ## Specialist Mode
 - **Seeded**: Skip scope-class and file-scope confirmations.
 - **Keep**: AC derivation gates (quality is not delegated).
-- [Ref: specialist-mode]
+- Read `_shared/specialist-mode.md`
 
 ## I/O
 - **Input**: Problem statement (from /describe) or user description.
-- **Optional**: Prior-art brief (`problem_domain`, `existing_patterns`, `constraints`). Skip duplicate internal research if present. [Ref: composition]
+- **Optional**: Prior-art brief (`problem_domain`, `existing_patterns`, `constraints`). Skip duplicate internal research if present. See `_shared/composition.md`
 - **Output**: Numbered list of testable AC scenarios.
 
 ## Process
@@ -40,4 +40,4 @@ Lead requirements team. Goal: Transform problem statements into testable, non-va
 ## Rules
 - **Zero Vagueness**: No "fast", "user-friendly", or "appropriate". Every AC must be testable.
 - **Verification**: Fetch and confirm URLs/external claims before citing in specs.
-- [Ref: interviewing-rules]
+- Read `_shared/interviewing-rules.md`


### PR DESCRIPTION
Closes #112

Replaces the `[Ref: name]` shorthand notation with explicit `Read \`_shared/name.md\`` and `Read \`references/file.md\`` instructions across all skill files. Agents require an explicit path to know they should read the file — the shorthand was undefined behavior.

Also updates AUTHORING.md to document the new convention and remove the deprecated shorthand.