### PR TITLE
fix: enforce worktree creation for all build scopes

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -28,3 +28,7 @@ Read `references/scope.md` for scope assessment criteria and specialist mode ove
 ## Output
 
 A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for /review.
+
+## Rules
+
+- **Always create a worktree** with `wt switch --create <branch>` before writing any code — including Lightweight builds. Never code in the main repo directory.

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -20,7 +20,7 @@ Read `_shared/scope-cycles.md` for scope assessment table, autonomous cycle deta
 
 **Autonomy Contract**: Run cycles back-to-back without prompting. Only interrupt after PR is open if (a) clean, (b) 3 cycles exhausted, or (c) blocker hit.
 
-**Lightweight** (≤ 50 lines + no logic change): `/build` (inline) → inline AC check → PR. Skip `/review` and `/verify` teams.
+**Lightweight** (≤ 50 lines + no logic change): `/build` (single-agent, no team) → inline AC check → PR. Skip `/review` and `/verify` teams. A worktree is still created.
 
 **Standard / Deep**: Full Build → Review → Verify cycle. Repeat up to 3 times until clean or exhausted, then PR creation.
 

--- a/skills/implement/references/scope-cycles.md
+++ b/skills/implement/references/scope-cycles.md
@@ -4,7 +4,7 @@
 
 |Scope|Criteria|Action|
 |-|-|-|
-|**Lightweight**|≤ 50 lines, no logic change, 1-2 AC|`/build` (inline) → inline AC check → PR. Skip `/review` and `/verify` teams.|
+|**Lightweight**|≤ 50 lines, no logic change, 1-2 AC|`/build` (single-agent, no team) → inline AC check → PR. Skip `/review` and `/verify` teams. Worktree is still created.|
 |**Standard**|Typical multi-file, AC in one module|Full Build → Review → Verify cycle.|
 |**Deep**|Cross-module, security, migration, breaking|Full cycle + Deep review + extra critique iterations.|
 


### PR DESCRIPTION
## Context

Agents running `/implement` frequently coded in the main repo directory instead of a worktree. Two root causes:

1. **Deferred reading**: `/build` SKILL.md instructs agents to read `references/process.md` for the step-by-step process — but agents often skipped that deferred read and jumped straight to coding, missing the `wt switch --create` instruction entirely.
2. **Ambiguous "inline" label**: Both `/implement` SKILL.md and `scope-cycles.md` described the Lightweight path as `/build` **(inline)**. Agents interpreted "inline" as "code here, in the current directory", conflating "no team spawn" with "no worktree".

## Changes

- **`skills/build/SKILL.md`**: Added a `## Rules` section with an explicit "always create a worktree" rule directly in the SKILL.md body, visible without reading any reference file.
- **`skills/implement/SKILL.md`**: Replaced `(inline)` with `(single-agent, no team)` and appended "A worktree is still created." to the Lightweight description.
- **`skills/implement/references/scope-cycles.md`**: Same label and note applied to the Lightweight row in the scope table.

## Testing

Trigger `/implement` on a small (Lightweight) issue and confirm a worktree is created before any code is written.