### PR TITLE
docs(authoring): establish lazy-loading standard for skill reference files

### DIFF
--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -27,7 +27,7 @@ All skills map to one of these five roles (extending the team-composition model;
 
 1. **Single responsibility**: One concern per reference file. Name reflects the phase or topic (e.g. `scope.md`, `process.md`, `gates.md`).
 2. **Lazy loading**: Each `Read` instruction appears at the point of need in `SKILL.md` — not unconditionally at the top. A skill with two phases loads each reference file when entering that phase.
-3. **DRY**: Promote a protocol to `_shared/` when more than one skill references it. Keep under `skills/<name>/references/` below that threshold.
+3. **DRY**: Promote a protocol to `_shared/` when ≥3 skills reference it. Keep under `skills/<name>/references/` below that threshold.
 4. **Composition**: Reference `_shared/` files on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` within skill bodies — never preload.
 
 ### Split heuristics
@@ -58,7 +58,11 @@ Reference on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\``:
 - `handoff-artifact.md`: Issue body state.
 - `interviewing-rules.md`: User interaction.
 - `notes-md-protocol.md`: `.claude/NOTES.md` state.
+- `orchestrator-rules.md`: Pipeline orchestrator rules (CWD verification, delegation, no-merge contract).
+- `repo-preflight.md`: Repo/branch confirmation before `gh` or `git push`.
+- `scope-preflight.md`: File-list confirmation before bulk edits (≥3 files).
 - `specialist-mode.md`: Seed-brief logic.
+- `worktree-protocol.md`: `wt` CLI commands for creating and managing worktrees.
 
 Use explicit read instructions inline: `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/composition.md\`` instead of shorthand `[Ref: composition]`.
 

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -27,7 +27,7 @@ All skills map to one of these five roles (extending the team-composition model;
 
 1. **Single responsibility**: One concern per reference file. Name reflects the phase or topic (e.g. `scope.md`, `process.md`, `gates.md`).
 2. **Lazy loading**: Each `Read` instruction appears at the point of need in `SKILL.md` — not unconditionally at the top. A skill with two phases loads each reference file when entering that phase.
-3. **DRY**: Promote a protocol to `_shared/` when ≥3 skills reference it. Keep under `skills/<name>/references/` below that threshold.
+3. **DRY**: Promote a protocol to `_shared/` when more than one skill references it. Keep under `skills/<name>/references/` below that threshold.
 4. **Composition**: Reference `_shared/` files on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` within skill bodies — never preload.
 
 ### Split heuristics

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -13,13 +13,57 @@ All skills map to one of these five roles (extending the team-composition model;
 |**Interactive Primitive**|Inline behavior; no team or handoff.|`/grill-me`|`sonnet`|`SKILL.primitive`|
 |**Utility**|Maintenance/post-work. No seed-brief or handoff.|`/compound`, `/prune`|`sonnet`/`haiku`|`SKILL.specialist`|
 
+## File architecture
+
+### File type hierarchy
+
+| File type | Location | Line cap | Notes |
+|-|-|-|-|
+| Entry-point | `skills/<name>/SKILL.md` | ≤150 lines | Cap applies here only |
+| Reference | `skills/<name>/references/<concern>.md` | No limit | Single concern; named after phase or topic |
+| Shared protocol | `_shared/<concern>.md` | No limit | Promote when ≥3 skills reference it |
+
+### Design principles
+
+1. **Single responsibility**: One concern per reference file. Name reflects the phase or topic (e.g. `scope.md`, `process.md`, `gates.md`).
+2. **Lazy loading**: Each `Read` instruction appears at the point of need in `SKILL.md` — not unconditionally at the top. A skill with two phases loads each reference file when entering that phase.
+3. **DRY**: Promote a protocol to `_shared/` when ≥3 skills reference it. Keep under `skills/<name>/references/` below that threshold.
+4. **Composition**: Reference `_shared/` files on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` within skill bodies — never preload.
+
+### Split heuristics
+
+Split a reference file when two sections are loaded at different execution points (e.g. pre-flight vs. execution start) or one section runs on every invocation while another runs only in specific stages.
+
+Do **not** split when all steps always run in linear order (one concern, no branching) or the file is already under ~50 lines.
+
+### Example — two-phase skill
+
+```
+## Scope Assessment
+Read `references/scope.md` for scope classification criteria.
+...
+
+## Process Overview
+...
+Step 4: Read `references/process.md` for step-by-step TDD flow and commit rules.
+```
+
+`scope.md` loads only during scope assessment. `process.md` loads only when execution begins.
+
+### `_shared/` file catalogue
+
+Reference on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\``:
+- `compaction-protocol.md`: In-phase context management.
+- `composition.md`: Team/sub-agent cost and shape.
+- `handoff-artifact.md`: Issue body state.
+- `interviewing-rules.md`: User interaction.
+- `notes-md-protocol.md`: `.claude/NOTES.md` state.
+- `specialist-mode.md`: Seed-brief logic.
+
+Use explicit read instructions inline: `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/composition.md\`` instead of shorthand `[Ref: composition]`.
+
 ## Structure & Density
 **Goal**: Maximize info-density. Replace narrative with constraints.
-
-### Modularity
-- **Entry-point cap**: Keep skill bodies ≤150 lines. Push stable reference material (schemas, syntax tables, field lists) into `skills/<name>/references/<file>.md`.
-- **`_shared/` promotion**: Promote a doc to `_shared/` when ≥3 skills reference it. Otherwise keep under `skills/<name>/references/`.
-- **On-demand loading**: Never preload `_shared/` files at skill start. Reference via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` only where needed in the Process steps. Use inline read instructions: `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/composition.md\`` not `[Ref: composition]`.
 
 ### Frontmatter
 Order: `name` → `description` → `when_to_use` → `argument-hint` → `model` → `effort` → `allowed-tools` → `user-invocable` → `disable-model-invocation`.
@@ -63,17 +107,6 @@ Agents dispatched inside a plugin context run with constrained tool access by de
 5. **Spawn Justification**: Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for team-composition rubric (Pivot, Disjoint, Parallel, Payoff).
 6. **Process**: Step-by-step imperative flow.
 7. **Rules**: Hard constraints plus interaction rules (read `${CLAUDE_PLUGIN_ROOT}/_shared/interviewing-rules.md`).
-
-## `_shared/` Integration
-Do not preload. Reference on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\`` within skill bodies:
-- `handoff-artifact.md`: Issue body state.
-- `interviewing-rules.md`: User interaction.
-- `notes-md-protocol.md`: `.claude/NOTES.md` state.
-- `specialist-mode.md`: Seed-brief logic.
-- `compaction-protocol.md`: In-phase context management.
-- `composition.md`: Team/sub-agent cost and shape.
-
-Use explicit read instructions inline: `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/composition.md\`` instead of shorthand `[Ref: composition]`.
 
 ## Compaction Checklist
 Before declaring any compaction (density pass, context-hygiene trim) complete:

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -19,10 +19,12 @@ Read `references/scope.md` for scope classification criteria and specialist mode
 
 ## Process Overview
 
+Read `references/process.md` for step-by-step process, TDD, context hygiene, and commit rules.
+
 1. Run pre-flight (repo/scope confirmation).
 2. Read the issue and linked sub-issues.
 3. Create worktree, init `./.claude/NOTES.md` with task list.
-4. Read `references/process.md` for step-by-step TDD flow, context hygiene, and commit rules.
+4. Spawn workers per scope assessment (Lightweight: inline; Standard: subagents; Deep: TeamCreate).
 
 ## Output
 

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -13,17 +13,16 @@ You are leading the build phase. Your goal is to take a fully specified GitHub i
 
 A GitHub issue number (with architecture/design decisions from /define) and any additional resources.
 
+## Scope Assessment
+
+Read `references/scope.md` for scope classification criteria and specialist mode overrides.
+
 ## Process Overview
 
-Read `references/scope.md` for scope assessment criteria and specialist mode overrides. When ready to execute, read `references/process.md` for step-by-step process, TDD, context hygiene, and commit rules.
-
-**Quick summary:**
 1. Run pre-flight (repo/scope confirmation).
 2. Read the issue and linked sub-issues.
 3. Create worktree, init `./.claude/NOTES.md` with task list.
-4. For Standard builds: spawn workers as parallel subagents (2 splits) or TeamCreate (≥3 splits). For Lightweight: code inline. For Deep: TeamCreate.
-5. Workers follow TDD, verify before marking done, simplify as they go.
-6. Coordinate via shared task list; commit incrementally.
+4. Read `references/process.md` for step-by-step TDD flow, context hygiene, and commit rules.
 
 ## Output
 

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -20,9 +20,10 @@ Always **Deep** — fanout orchestrator with sub-agent delegation. See `${CLAUDE
 
 ## Process
 
-Read `references/gates.md` for resume detection, stage gates (Stages 1–3), exit (Stage 5), and resume logic. When entering Stage 4, Read `references/autonomous-phase.md` for branch creation, dependency-tier computation, parallel dispatch, settlement, and epic PR creation.
-
-Stage 0 detects resume point. Stages 1–3 require explicit user approval at gates. Stage 4 autonomous (no prompts). Stage 5 exits.
+1. **Stage 0 — Resume detection**: Read `references/detection.md` to detect prior state and determine entry stage.
+2. **Stages 1–3 — Interactive gates**: Read `references/gates.md` for stage gate procedures. Require explicit user approval at each gate; silence is not approval.
+3. **Stage 4 — Autonomous phase**: Read `references/autonomous-phase.md` for branch creation, dependency-tier computation, parallel dispatch, settlement, and epic PR creation. No human prompts.
+4. **Stage 5 — Exit**: Print exit summary to stdout. Run is complete when all sub-PRs are open and epic PR is open. Merging is left to humans.
 
 **Key behaviors:**
 - Skip /discovery if epic has ≥3 acceptance criteria

--- a/skills/epic-autopilot/references/detection.md
+++ b/skills/epic-autopilot/references/detection.md
@@ -1,0 +1,21 @@
+# Epic-Autopilot: Stage 0 — Resume Detection
+
+## Stage 0 — Resume detection
+
+On every invocation, read the epic issue body and any sub-issue bodies first; consult the **Resume logic** table below to decide which stage to enter.
+
+## Resume logic
+
+On re-invocation with the same epic issue number, epic-autopilot detects prior state and skips completed phases:
+
+|State detected|Action|
+|-|-|
+|No `## Requirements` in epic body|Re-run from Stage 1|
+|`## Requirements` but no `## Implementation plan`|Re-run from Stage 2|
+|`## Implementation plan` present|Skip Stages 1–2; check sub-issues|
+|Sub-issue has `## Implementation plan`|Skip per-sub-issue /define for that sub-issue|
+|Sub-issue has open PR on its branch|Sub-task settled; skip|
+|Sub-issue has branch but no PR|Re-run `/implement` in existing worktree|
+|Sub-issue has neither branch nor PR|Fresh sub-task spawn|
+
+A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be re-attempted on every resume. To skip it permanently, delete the branch and mark the sub-issue with a `skip` label before re-invoking.

--- a/skills/epic-autopilot/references/gates.md
+++ b/skills/epic-autopilot/references/gates.md
@@ -1,8 +1,4 @@
-# Epic-Autopilot: Stage Gates and Resume Logic
-
-## Stage 0 — Resume detection
-
-On every invocation, read the epic issue body and any sub-issue bodies first; consult the **Resume logic** table at the bottom to decide which stage to enter.
+# Epic-Autopilot: Stage Gates (Stages 1–3)
 
 ## Stage 1 — Discovery gate
 
@@ -34,23 +30,3 @@ For each sub-issue in order (ascending issue number):
 4. Wait for explicit approval before moving to next sub-issue.
 
 Once every sub-issue has an approved `## Implementation plan`, proceed to **Stage 4 — Autonomous phase**. No further human prompts until exit.
-
-## Stage 5 — Exit
-
-Print exit summary to stdout and exit. The run is complete when all sub-PRs have been opened and the epic PR is open. Merging is left to humans.
-
-## Resume logic
-
-On re-invocation with the same epic issue number, epic-autopilot detects prior state and skips completed phases:
-
-|State detected|Action|
-|-|-|
-|No `## Requirements` in epic body|Re-run from Stage 1|
-|`## Requirements` but no `## Implementation plan`|Re-run from Stage 2|
-|`## Implementation plan` present|Skip Stages 1–2; check sub-issues|
-|Sub-issue has `## Implementation plan`|Skip per-sub-issue /define for that sub-issue|
-|Sub-issue has open PR on its branch|Sub-task settled; skip|
-|Sub-issue has branch but no PR|Re-run `/implement` in existing worktree|
-|Sub-issue has neither branch nor PR|Fresh sub-task spawn|
-
-A permanently-FAILED sub-task (branch exists, no PR, two prior retries) will be re-attempted on every resume. To skip it permanently, delete the branch and mark the sub-issue with a `skip` label before re-invoking.

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -18,7 +18,7 @@ A brief statement from the author of what the skill should do — or nothing, in
 
 2. **Interview the author** — ask ONE question at a time. See `skills/new-skill/references/interview-steps.md` for the question sequence.
 
-   Use `AskUserQuestion` for bounded option sets (c–k); plain prompt for free-text (a, b). Place recommended option first with ` (Recommended)` — derive from step (b).
+   Use `AskUserQuestion` for bounded option sets (c–k); plain prompt for free-text (a, b, l). Place recommended option first with ` (Recommended)` — derive from step (b).
 
 3. **Select template** based on role: Orchestrator → `SKILL.orchestrator.template.md`; Specialist/Utility → `SKILL.specialist.template.md`; Primitive → `SKILL.primitive.template.md`.
 

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -1,6 +1,6 @@
 # Interview steps for new-skill
 
-This file details the 11-step interview sequence that new-skill conducts with the author, one question at a time.
+This file details the 12-step interview sequence that new-skill conducts with the author, one question at a time.
 
 ## Step (a): Name
 

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -127,3 +127,11 @@ Then a second `AskUserQuestion` call: `header: "Composition"`, question: "Does t
 - **Personal (Recommended)** — `~/.claude/skills/<name>/SKILL.md` (individual use)
 - **Project** — `<cwd>/.claude/skills/<name>/SKILL.md` (committed to the current repo)
 - **Plugin** — `${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md` (contributing to this plugin; dogfooding)
+
+## Step (l): Reference file loading phases
+
+**Plain prompt**: "Does this skill load reference files at different execution points? If yes, describe the natural phases (e.g. 'pre-flight assesses scope, then execution begins'). Type 'no' or 'single phase' to skip."
+
+- If the author describes **2+ distinct phases**: scaffold one reference file stub per phase under `skills/<name>/references/`. Name each stub after the phase or topic (e.g. `scope.md`, `process.md`).
+- If the author describes **1 phase** (or says "no"): scaffold a single reference file stub if the entry-point would exceed 150 lines; otherwise skip reference scaffolding entirely.
+- Do **not** force per-phase stubs on simple skills — if the skill body fits ≤150 lines without references, skip entirely.


### PR DESCRIPTION
## Summary

Establishes a one-concern-per-file, read-at-point-of-need standard for skill reference files. Replaces scattered guidance with a unified `## File architecture` section in AUTHORING.md and audits existing skills against it.

## Changes

**AUTHORING.md** — unified `## File architecture` section replaces `### Modularity` + `## _shared/ Integration`. Covers file type hierarchy (with the ≤150-line cap clarified as SKILL.md-only), four design principles, split heuristics, a two-phase example, and the `_shared/` file catalogue.

**new-skill interview** — step (l) asks authors to identify loading phases before scaffolding reference stubs. Single-phase and simple skills skip scaffolding entirely; two+ phases produce one stub per phase.

**build/SKILL.md** — `## Process Overview` split into `## Scope Assessment` (reads `scope.md`) and `## Process Overview` (reads `process.md` at step 4, not unconditionally at top).

**epic-autopilot** — `## Process` rewritten with per-stage Read instructions. Stage 0 + resume logic extracted to new `references/detection.md`; `references/gates.md` trimmed to Stages 1–3; Stage 5 inlined into SKILL.md.

## Testing notes

- Verify `_templates/AUTHORING.md` has `## File architecture` section with hierarchy table, two-phase example, and `_shared/` catalogue; `## _shared/ Integration` and `### Modularity` are gone.
- Open `skills/new-skill/references/interview-steps.md`; confirm step (l) follows step (k).
- Open `skills/build/SKILL.md`; confirm `## Scope Assessment` section reads `scope.md` and `## Process Overview` step 4 reads `process.md`.
- Open `skills/epic-autopilot/SKILL.md`; confirm each numbered step has its own `Read` instruction at point of need.
- Open `skills/epic-autopilot/references/gates.md`; confirm only Stages 1–3 remain.
- Open `skills/epic-autopilot/references/detection.md`; confirm Stage 0 + resume logic table are present.

Closes #115