### PR TITLE
refactor(wrap-up): extract procedure to references/procedure.md

### DIFF
--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -14,7 +14,7 @@ Current worktree path and branch. Optionally, an open PR number (used to verify 
 
 ## Process
 
-See `references/procedure.md` for the step-by-step removal procedure (Steps 1–5).
+Read `references/procedure.md` for the step-by-step removal procedure (Steps 1–5).
 
 ## Output
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -14,54 +14,7 @@ Current worktree path and branch. Optionally, an open PR number (used to verify 
 
 ## Process
 
-### Step 1 — Detect state
-
-Gather via:
-
-1. **Worktree path** — `git rev-parse --show-toplevel` or use path user provides.
-2. **Branch name** — `git rev-parse --abbrev-ref HEAD`.
-3. **Default branch** — `git symbolic-ref refs/remotes/origin/HEAD --short` (strips `origin/`). Fall back to `['main', 'master', 'develop']` only if symbolic-ref lookup fails; log the method used.
-4. **Worktree membership** — `wt list`. Confirm worktree path appears in list.
-5. **Working-tree cleanliness** — `git status --short` and `git log @{u}..HEAD --oneline` (unpushed commits not in PR).
-6. **PR state** — if user provided PR number, run `gh pr view <N> --json state,headRefName` to confirm it is open and points to current branch.
-
-### Step 2 — Apply state machine
-
-|Condition|Outcome|
-|-|-|
-|Branch matches default branch|**Refuse outright.** No proceed-anyway prompt|
-|Worktree path not in `wt list`|**Refuse outright.** Out-of-tree paths never managed by `/wrap-up`|
-|Worktree dirty (uncommitted changes or unpushed commits not in PR)|**Show state + proceed-anyway prompt** (Step 3)|
-|Worktree clean, feature branch, worktree in-tree|**Single confirmation** (Step 4)|
-
-### Step 3 — Dirty worktree: proceed-anyway prompt
-
-Show what is dirty (uncommitted files, unpushed commit list). Then ask:
-
-> The worktree has unsaved state (shown above). Proceed with removal anyway?
-> On yes, I will use `git branch -D` (force-delete) if unpushed commits would be lost.
-
-Stays inline: destructive sequential ops — low context cost; must confirm before each step.
-
-Wait for explicit confirmation. Do not proceed on silence.
-
-### Step 4 — Single confirmation (clean or dirty-with-override)
-
-Show the exact actions that will run:
-
-> I will:
-> - `wt remove <branch>` (removes the worktree directory, its contents including `.claude/NOTES.md` if present, and the branch)
->
-> Proceed?
-
-Wait for explicit confirmation. Do not proceed on silence.
-
-### Step 5 — Execute and report
-
-On confirm:
-
-1. `wt remove <branch>` (or `wt remove --force-delete <branch>` when dirty-worktree override was confirmed and commits would be lost).
-2. Report what was removed: worktree path, branch name, whether NOTES.md was present.
+See `references/procedure.md` for the step-by-step removal procedure (Steps 1–5).
 
 ## Output
 


### PR DESCRIPTION
## Summary

Removes the inlined step-by-step procedure from `skills/wrap-up/SKILL.md` and replaces it with a pointer to the already-existing `references/procedure.md`. Brings SKILL.md from 80 lines down to 33, satisfying the 50-line cap enforced by /prune.

## Testing notes

- `wc -l skills/wrap-up/SKILL.md` returns 33 (≤ 50) ✓
- `skills/wrap-up/references/procedure.md` unchanged, contains Steps 1–5 ✓
- SKILL.md `## Process` section now references the file instead of inlining content ✓

Closes #118