### PR TITLE
fix(issue-autopilot): move /compound review-time pass from stage 5 to stage 3

### DIFF
--- a/skills/issue-autopilot/SKILL.md
+++ b/skills/issue-autopilot/SKILL.md
@@ -31,4 +31,4 @@ Orchestrate the single-issue ship pipeline. Take a GitHub issue number and drive
 See `${CLAUDE_PLUGIN_ROOT}/_shared/orchestrator-rules.md` for CWD verification, delegation, no-autonomous-merge, and seed-brief contract.
 
 - **Loop-break**: In Stage 3, break if unresolved thread count non-zero and unchanged after one pass.
-- **Compound**: `/implement` invokes `/compound` at PR creation (implementation-time pass). Stage 5 re-invokes after merge for review-time learnings — two passes, no dedup needed.
+- **Compound**: `/implement` invokes `/compound` at PR creation (implementation-time pass). Stage 3 re-invokes when all threads resolve for review-time learnings — two passes, no dedup needed.

--- a/skills/issue-autopilot/references/stage-3.md
+++ b/skills/issue-autopilot/references/stage-3.md
@@ -21,6 +21,6 @@
    | Result | Action |
    |-|-|
    | `/resolve-pr-feedback` returned any `needs-human` verdicts | Print needs-human summary listing remaining threads and verdicts. Exit with: "Needs human review — see threads above. Re-invoke `/issue-autopilot <N>` after addressing them." |
-   | Final count == 0 | Proceed immediately to Stage 4 in this invocation |
+   | Final count == 0 | Run `/compound` (review-time learnings pass; context is warm). Then proceed immediately to Stage 4 in this invocation. |
    | Final count > 0 and decreased | Print "Partial progress: `<before>` → `<after>` unresolved threads. Re-invoke `/issue-autopilot <N>` after the next review pass." Exit. |
    | Final count > 0 and unchanged | Print needs-human summary listing remaining threads. Exit with: "Needs human review — see threads above. Re-invoke `/issue-autopilot <N>` after addressing them." |

--- a/skills/issue-autopilot/references/stage-5.md
+++ b/skills/issue-autopilot/references/stage-5.md
@@ -5,10 +5,9 @@
 **Entry condition**: PR for `feat/issue-<N>` is merged.
 
 1. Echo resolved repo `owner/repo`.
-2. Run `/compound` — review-time learnings pass (autonomous; pass NOTES.md context if present).
-3. Run `/wrap-up` from the worktree root — preserves its interactive confirms (worktree removal is destructive).
-4. Print:
+2. Run `/wrap-up` from the worktree root — preserves its interactive confirms (worktree removal is destructive).
+3. Print:
 
-   > Ship complete: PR merged, learnings filed, worktree cleaned.
+   > Ship complete: PR merged, worktree cleaned.
 
 **Exit.**


### PR DESCRIPTION
## Summary

- Stage 5 (post-merge) ran `/compound` in a cold session — context is cleared between autopilot invocations, leaving nothing to extract.
- Moves the review-time learnings pass to Stage 3, where it runs immediately after all PR threads are resolved and the review context is still warm.
- Removes `/compound` from Stage 5 and updates the exit message accordingly.

## Test plan

- [ ] When Stage 3 resolves all threads (final count == 0), `/compound` is invoked before proceeding to Stage 4.
- [ ] Stage 5 no longer calls `/compound`; exit message reads "Ship complete: PR merged, worktree cleaned."
- [ ] SKILL.md `## Rules` bullet correctly references Stage 3 instead of Stage 5.

Closes #121