### PR TITLE
feat(epic-autopilot): run /compound at end of stage 4 for epic-level learnings

### DIFF
--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -40,4 +40,4 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/orchestrator-rules.md` for CWD, delegation, a
 - User must not modify epic/sub-issue bodies during Stage 4
 - Branch names follow `feat/epic-<N>-sub-<M>` exactly
 - `autonomous: true` reserved for sub-task spawns from this skill only
-- `/compound` and `/wrap-up` remain user-invoked utilities
+- `/compound` runs automatically at end of Stage 4 (epic-level pass; sub-issue implementation passes are covered by `/implement`). `/wrap-up` remains user-invoked.

--- a/skills/epic-autopilot/references/autonomous-phase.md
+++ b/skills/epic-autopilot/references/autonomous-phase.md
@@ -104,3 +104,4 @@ EOF
 ```
 
 3. Print epic PR URL and full sub-issue/sub-PR summary table to stdout.
+4. Run `/compound` — epic-level learnings pass (autonomous). Epic-scoped context (architecture decisions, decomposition trade-offs, cross-sub-issue insights from Stages 1–4) is warm at this point.


### PR DESCRIPTION
## Summary

- Adds a `/compound` call at the end of Stage 4e, after the epic PR is created and the summary table is printed.
- Updates the SKILL.md rule to reflect that `/compound` is now called automatically for the epic-level pass, while `/wrap-up` remains user-invoked.

Sub-issue implementation passes are already covered by `/implement`. The gap was epic-scoped context — architecture decisions, decomposition trade-offs, and cross-sub-issue insights accumulated across Stages 1–4. That context lives in the main session and is warm at the end of Stage 4 (no reinvocation gap).

## Test plan

- [ ] After epic PR creation (step 4e.3), `/compound` is invoked for the epic-level pass.
- [ ] SKILL.md rule no longer states `/compound` is user-invoked; `/wrap-up` still does.

Closes #123