### PR TITLE
feat: author /scope-assessment as shared tier-3 skill

### DIFF
--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -91,6 +91,18 @@ Each skill maps to one of three templates. Use the corresponding template from `
 
 ---
 
+## Orchestrator Decomposition
+
+When an orchestrator must decide how to fan out work across agents, use `/scope-assessment` as the canonical decomposition step:
+
+1. Build a `work_units` list — one entry per issue, file group, or bounded task, each with an `id` and `resources` list.
+2. Invoke `/scope-assessment`; receive back a disjoint agent plan.
+3. Dispatch one agent per entry in the plan.
+
+Document the orchestrator's specific definition of "work unit" (what counts as an input, what its `resources` list must contain) in the orchestrator's own `references/scope.md`. The tier-3 skill encodes the algorithm only; per-caller variation lives at the call site.
+
+---
+
 ## `_shared/` File Catalogue
 
 Reference on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\``:

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -96,7 +96,7 @@ Each skill maps to one of three templates. Use the corresponding template from `
 When an orchestrator must decide how to fan out work across agents, use `/scope-assessment` as the canonical decomposition step:
 
 1. Build a `work_units` list — one entry per issue, file group, or bounded task, each with an `id` and `resources` list.
-2. Invoke `/scope-assessment`; receive back a disjoint agent plan.
+2. Invoke `/scope-assessment`; receive back an agent plan where each entry covers a set of work units that share no resources with any other entry.
 3. Dispatch one agent per entry in the plan.
 
 Document the orchestrator's specific definition of "work unit" (what counts as an input, what its `resources` list must contain) in the orchestrator's own `references/scope.md`. The tier-3 skill encodes the algorithm only; per-caller variation lives at the call site.

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -99,7 +99,7 @@ When an orchestrator must decide how to fan out work across agents, use `/scope-
 2. Invoke `/scope-assessment`; receive back an agent plan where each entry covers a set of work units that share no resources with any other entry.
 3. Dispatch one agent per entry in the plan.
 
-Document the orchestrator's specific definition of "work unit" (what counts as an input, what its `resources` list must contain) in the orchestrator's own `references/scope.md`. The tier-3 skill encodes the algorithm only; per-caller variation lives at the call site.
+Document the orchestrator's specific definition of "work unit" (what counts as an input, what its `resources` list must contain) in the orchestrator's own `references/scope.md`. That file must also cite `/scope-assessment` as the canonical decomposition algorithm. The tier-3 skill encodes the algorithm only; per-caller variation lives at the call site.
 
 ---
 

--- a/skills/scope-assessment/SKILL.md
+++ b/skills/scope-assessment/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: scope-assessment
+description: Decompose a caller-supplied list of work units into a disjoint agent plan.
+model: haiku
+user-invocable: false
+---
+
+## Input
+
+Caller sets `work_units` in context before invoking. Each unit must have:
+
+```yaml
+work_units:
+  - id: "<identifier>"
+    resources: [<file_or_path>, ...]
+```
+
+`id` is a human-readable label (issue number, file name, task description). `resources` is the exhaustive list of files or paths the unit reads or writes.
+
+## Process
+
+1. Receive `work_units` list from caller context.
+2. Build a resource-to-unit index: for each resource, record which units reference it.
+3. Identify overlapping pairs: two units overlap when they share at least one resource.
+4. Merge overlapping units into a single group — repeat until no two groups share a resource (transitive closure).
+5. For each resulting disjoint group, produce one agent entry:
+   - `scope`: one sentence describing what this agent will do, derived from the group's unit IDs.
+   - `resources`: deduplicated, sorted union of all resources in the group.
+6. Output the agent plan (see Output).
+
+## Output
+
+```yaml
+agents:
+  - scope: "<one sentence>"
+    resources: [<file_or_path>, ...]
+```
+
+- One entry per disjoint group.
+- `scope` is a single sentence; no bullet lists or sub-items.
+- `resources` is a flat, deduplicated, sorted list.
+- No Lightweight / Standard / Deep labels — output is agent-consumable only.
+
+## Rules
+
+- Never produce complexity labels (Lightweight, Standard, Deep, or equivalents).
+- Never infer resources not explicitly listed in the input — callers own resource enumeration.
+- When all work units are disjoint, output N agents (one per unit).
+- When all work units overlap, output 1 agent covering the full resource union.
+- Output only the YAML block; no prose explanation unless the caller explicitly requests one.

--- a/skills/scope-assessment/SKILL.md
+++ b/skills/scope-assessment/SKILL.md
@@ -39,11 +39,11 @@ agents:
 - One entry per disjoint group.
 - `scope` is a single sentence; no bullet lists or sub-items.
 - `resources` is a flat, deduplicated, sorted list.
-- No Lightweight / Standard / Deep labels — output is agent-consumable only.
+- No sizing or complexity labels — output is agent-consumable only.
 
 ## Rules
 
-- Never produce complexity labels (Lightweight, Standard, Deep, or equivalents).
+- Never produce sizing or complexity labels of any kind.
 - Never infer resources not explicitly listed in the input — callers own resource enumeration.
 - When all work units are disjoint, output N agents (one per unit).
 - When all work units overlap, output 1 agent covering the full resource union.

--- a/skills/scope-assessment/SKILL.md
+++ b/skills/scope-assessment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scope-assessment
-description: Decompose a caller-supplied list of work units into a disjoint agent plan.
+description: Given a list of work units (each with an id and resource list), group them by shared resources and output one agent entry per conflict-free group. Use when an orchestrator needs to fan out work without resource conflicts.
 model: haiku
 user-invocable: false
 ---


### PR DESCRIPTION
## Context

Closes #149

Adds `/scope-assessment` as a new tier-3 skill (`user-invocable: false`) that encodes the task-driven decomposition algorithm shared across all orchestrators. Callers supply a `work_units` list; the skill identifies disjoint resource groups (merging until no two groups share a resource) and returns a structured YAML agent plan.

Also updates `_templates/AUTHORING.md` to document `/scope-assessment` as the canonical decomposition step for orchestrators and instructs them to define their work-unit domain in their own `references/scope.md`.

## Acceptance Criteria

- AC1 ✅ `skills/scope-assessment/SKILL.md` exists with `user-invocable: false` frontmatter.
- AC2 ✅ Skill encodes: accept `work_units` → index resources → merge overlapping groups → output disjoint agent plan.
- AC3 ✅ No Lightweight/Standard/Deep labels anywhere in the skill.
- AC4 ✅ Output contract is explicit: `agents[].scope` (one sentence) + `agents[].resources` (deduplicated sorted list).
- AC5 ✅ `_templates/AUTHORING.md` documents `/scope-assessment` as canonical decomposition step and instructs orchestrators to cite it from `references/scope.md`.