### PR TITLE
feat(compound): add compound-on-exit protocol and assessment gate

### DIFF
--- a/_shared/compound-on-exit.md
+++ b/_shared/compound-on-exit.md
@@ -1,0 +1,21 @@
+# Compound on Exit — Protocol
+
+Orchestrators (`/discover`, `/define`, `/implement`, `/resolve-pr-feedback`) invoke `/compound` once upon clean completion to capture session learnings into persistent wiki.
+
+## Directive
+
+After the final phase completes, invoke the `compound` skill:
+
+```
+Skill("compound")
+```
+
+## Scope
+
+- **Condition**: Clean completion only. No invocation on abort, refusal, or early exit.
+- **Frequency**: Exactly once per orchestrator run.
+- **Exclusion**: `/wrap-up` (post-session utility) does not invoke `/compound`.
+
+## Assessment Gate
+
+`/compound` self-assesses whether the session contains learnings worth capturing. If not, it exits silently. The orchestrator does not gate this decision.

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -9,6 +9,16 @@ allowed-tools: Agent Bash Read
 ## Role & Constraints
 Lead knowledge compounding. Goal: Extract fixes, insights, or patterns into reusable artifacts.
 
+## Assessment
+Before selecting a mode, evaluate the session against these value buckets:
+- **Novel decisions** — design, architecture, or tradeoff choices made during this session.
+- **Non-obvious fixes** — subtle bugs or root causes others will hit again.
+- **Reusable patterns** — generalizable techniques or preventive measures.
+
+Skip if the work was routine edits, mechanical refactors, or changes already captured in existing notes.
+If none of the buckets yield content → print `Nothing to compound.` and exit.
+Otherwise → proceed to Mode Selection.
+
 ## Mode Selection
 |Mode|Criteria|Action|
 |-|-|-|


### PR DESCRIPTION
## Context

Orchestrators (`/discover`, `/define`, `/implement`, `/resolve-pr-feedback`) exit without capturing learnings. `/compound` always proceeds when invoked, with no way to say there is nothing worth capturing.

This PR wires the two missing pieces: a shared protocol that tells orchestrators to invoke `/compound` on clean exit, and a self-assessment gate inside `/compound` that makes it safe to call unconditionally.

## Changes

**`_shared/compound-on-exit.md`** (new file)
A shared directive for orchestrators. After the final phase completes cleanly, the orchestrator calls `Skill("compound")` once. `/compound` decides for itself whether the session is worth capturing — the orchestrator does not gate this decision. Fires on clean completion only; excluded from `/wrap-up`.

**`skills/compound/SKILL.md`** (edited)
New `## Assessment` section inserted before `## Mode Selection`. Three value buckets to evaluate before doing any extraction work:
- Novel decisions (design/architecture/tradeoff)
- Non-obvious fixes (root causes others will hit)
- Reusable patterns (generalizable techniques)

Skip criteria: routine edits, mechanical refactors, work already in existing notes.
Early-exit path: `Nothing to compound.` printed and skill exits before mode selection.

## Acceptance criteria

- [x] `_shared/compound-on-exit.md` exists with orchestrator invocation directive
- [x] `## Assessment` section present before `## Mode Selection` in `/compound`
- [x] Assessment lists the three value buckets with skip criteria and early-exit
- [ ] Issues #130, #131, #132, #135 reference this issue in their Evidence section (done at spec-approval time, not in this diff)

Closes #151