### PR TITLE
feat(wrap-up): rebuild as L2 specialist with dual-mode seed-brief

### DIFF
--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -24,9 +24,9 @@ Tally total token usage as ~N × single-session baseline.
 |All specialists (parallel subagents)|Cross-module, security, arch|~(N+1)× where N = activated specialists|
 
 ### Decision Ladder
-Escalate only when the lower tier is insufficient:
+Escalate only when the lower level is insufficient:
 
-|Tier|When|Example|
+|Level|When|Example|
 |-|-|-|
 |**Inline**|1-4 items, fit in lead context|Audit 2 open issues|
 |**Sub-agent**|>= 5 items or verbose I/O (overrun boundary)|Fan-out across 8 issues|

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -16,7 +16,7 @@ Autonomous epic-to-PR orchestrator. Takes an epic issue or description and produ
 
 ## Team Shape
 
-Always multi-tier fan-out — dispatches one sub-agent per topological tier of sub-issues. See `_shared/composition.md` for spawn justification.
+Always multi-layer fan-out — dispatches one sub-agent per topological layer of sub-issues. See `_shared/composition.md` for spawn justification.
 
 ## Process
 

--- a/skills/issue-autopilot/references/stage-5.md
+++ b/skills/issue-autopilot/references/stage-5.md
@@ -5,9 +5,20 @@
 **Entry condition**: PR for `feat/issue-<N>` is merged.
 
 1. Echo resolved repo `owner/repo`.
-2. Run `/wrap-up` from the worktree root — preserves its interactive confirms (worktree removal is destructive).
+2. Construct a seed-brief with `confirmed: true` and pass it to `/wrap-up` from the worktree root:
+
+   ```
+   <seed-brief>
+   preflight_verified: true
+   repo: <owner/repo>
+   branch: feat/issue-<N>
+   confirmed: true
+   </seed-brief>
+   ```
 3. Print:
 
    > Ship complete: PR merged, worktree cleaned.
 
 **Exit.**
+
+> **Note**: wrap-up's `confirmed: true` mode skips user confirmations. This is safe because by Stage 5 the PR is merged, so the worktree is committed, pushed, and ready for cleanup.

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -40,7 +40,7 @@ Only generate `when_to_use` frontmatter when the author answers Yes; omit otherw
 **If Orchestrator:** Ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?"
 
 **Options:**
-- **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator tier (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
+- **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator layer (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
 - **Coordinator** — sequences sub-skills in a loop; research happens upstream or in the sub-skills (e.g. `/implement`). Defaults model to `sonnet`, no `effort`.
 
 This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps e/f).

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -3,17 +3,37 @@ name: wrap-up
 description: Clean up local state after a PR is open — remove the worktree, delete the branch, and clear NOTES.md.
 when_to_use: Run when ready to discard the feature worktree after a PR is open.
 model: sonnet
+layer: 2
 allowed-tools: Bash Read
 ---
-You safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md — confirming before destructive actions and refusing when the operation would destroy protected state.
+Safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md. In standalone mode, confirms before destructive actions and refuses when the operation would destroy protected state. In orchestrated mode, accepts `confirmed: true` from an orchestrator seed-brief and executes directly.
 
 ## Input
 
-Current worktree path and branch. Optionally, an open PR number (used to verify unpushed-commit safety).
+- Current worktree path and branch.
+- Optional: seed-brief from orchestrator with `confirmed: true`. When present, skip user confirmations and proceed directly to removal.
+
+  ```
+  <seed-brief>
+  preflight_verified: true
+  repo: owner/repo
+  branch: feat/my-branch
+  confirmed: true
+  </seed-brief>
+  ```
+
+  Read `${CLAUDE_PLUGIN_ROOT}/_shared/seed-brief.md` for the full seed-brief format.
+
+- Optional: PR number (used to verify unpushed-commit safety in standalone mode).
 
 ## Process
 
-Read `references/procedure.md` for the step-by-step removal procedure (Steps 1–5).
+1. Check for seed-brief with `confirmed: true`.
+2. Read `references/procedure.md` for the step-by-step removal procedure (Steps 1–5).
+3. Run Step 1 (detect state) in all cases.
+4. If seed-brief has `confirmed: true`: skip to Step 5 (execute removal). If worktree is dirty in this mode, **refuse** — the orchestrator should only send `confirmed: true` when state is verified clean.
+5. Otherwise (standalone mode): run Steps 2–4 (state machine + user confirmations), then Step 5.
+6. Report what was removed using the Output format.
 
 ## Output
 
@@ -26,7 +46,7 @@ NOTES.md removed with worktree (was present / was already absent)
 ## Rules
 
 - Refuse outright when branch is default branch or worktree path not in `wt list`.
-- Use `wt remove --force-delete` only when dirty-worktree override was explicitly confirmed.
-- Single confirmation covers all removals — do not ask separately for each artifact.
+- Use `wt remove --force-delete` only when dirty-worktree override was explicitly confirmed (standalone mode only).
+- Single confirmation covers all removals in standalone mode — do not ask separately for each artifact.
 - Do not write to GitHub issue body. Use `/compound` to capture learnings into the wiki instead.
 - Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time.

--- a/skills/wrap-up/references/procedure.md
+++ b/skills/wrap-up/references/procedure.md
@@ -1,5 +1,7 @@
 # Cleanup Procedure for wrap-up
 
+Steps 2–4 (state machine + confirmations) apply only in **standalone mode**. When invoked via seed-brief with `confirmed: true`, skip directly to Step 5 after Step 1.
+
 ## Step 1 — Detect state
 
 Gather via:


### PR DESCRIPTION
## Summary

Rebuilds the wrap-up skill as a Layer 2 specialist with dual-mode seed-brief support, per the L3 boundary realignment for v2 (#125, Option C3).

### Changes

**skills/wrap-up/SKILL.md**
- Add layer: 2 frontmatter
- Add seed-brief awareness with confirmed:true dual-mode (standalone vs orchestrated)
- Align with SKILL.specialist template structure
- Add Read reference to _shared/seed-brief.md

**skills/wrap-up/references/procedure.md**
- Add dual-mode preamble: Steps 2-4 skipped when confirmed:true

**skills/issue-autopilot/references/stage-5.md**
- Update caller to pass seed-brief with confirmed:true
- Add safety note

Closes #125 (Phase A: wrap-up rebuild)
