### PR TITLE
NOTES.md as orchestrator progress ledger with checkpoint/slice pattern

### DIFF
--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -6,7 +6,7 @@ Framework for orchestrating specialists and managing token/context budgets.
 - **Orchestrator**: Phase lead. Spawns specialists, coordinates, writes handoff. Model: `opus`.
 - **Specialist**: Bounded task. Receives seed-brief, reports findings. Model: `sonnet`.
 - **Interactive Primitive**: Inline behavior (e.g., `/grill-me`). No team/handoff. Model: `sonnet`.
-- **Utility**: Maintenance (e.g., `/compound`, `/prune`). No seed-brief contract.
+- **Utility**: Maintenance (e.g., compound, prune). No seed-brief contract.
 
 ## Composition Patterns
 - **Linear**: A → B → C (Strict dependency).

--- a/_shared/compound-on-exit.md
+++ b/_shared/compound-on-exit.md
@@ -1,6 +1,6 @@
 # Compound on Exit — Protocol
 
-Orchestrators (`/discover`, `/define`, `/implement`, `/resolve-pr-feedback`) invoke `/compound` once upon clean completion to capture session learnings into persistent wiki.
+Phase-ending orchestrators invoke `/compound` once upon clean completion to capture session learnings into persistent wiki.
 
 ## Directive
 
@@ -14,7 +14,7 @@ Skill("compound")
 
 - **Condition**: Clean completion only. No invocation on abort, refusal, or early exit.
 - **Frequency**: Exactly once per orchestrator run.
-- **Exclusion**: `/wrap-up` (post-session utility) does not invoke `/compound`.
+- **Exclusion**: Post-session utility skills do not invoke `/compound`.
 
 ## Assessment Gate
 

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -1,13 +1,13 @@
 # Handoff Artifact — Shared Template
 
-Phase-boundary skills (`/discovery`, `/define`) hand off state by updating the GitHub issue body. Read on-demand at handoff steps; do not preload.
+Phase-boundary skills hand off state by updating the GitHub issue body. Read on-demand at handoff steps; do not preload.
 
-`/implement` is terminal — its output is the PR, not an issue body update.
+The terminal phase-ending skill outputs the PR, not an issue body update.
 
 ## The five fields
 
-1. **Acceptance criteria** — testable scenarios from `/discovery`, unchanged. One line each. **Mandatory.**
-2. **Constraints** — files in scope/out of scope, non-negotiable decisions from `/define`. **Mandatory.**
+1. **Acceptance criteria** — testable scenarios from the discovery phase, unchanged. One line each. **Mandatory.**
+2. **Constraints** — files in scope/out of scope, non-negotiable decisions from the definition phase. **Mandatory.**
 3. **Prior decisions** — "chose X over Y because Z" entries with links to conversation/code. One line each. *(Optional — omit when empty.)*
 4. **Evidence** — links to commits, PRs, benchmarks, reviews, or approvals justifying decisions. *(Optional — omit when empty.)*
 5. **Open questions** — things next phase must resolve. Explicit, no "obviously will figure out later". *(Optional — omit when empty.)*
@@ -21,7 +21,7 @@ Fields in order: Acceptance criteria, Constraints, Prior decisions, Evidence, Op
 ```markdown
 ## Implementation plan
 
-**Acceptance criteria** (from /discovery, unchanged)
+**Acceptance criteria** (from discovery, unchanged)
 - AC1: ...
 - AC2: ...
 
@@ -49,12 +49,9 @@ When a phase ends, in-flight state from NOTES.md that the next phase needs is pr
 
 ## Rules
 
-|Phase|Section heading|
-|-|-|
-|`/discovery`|`## Requirements`|
-|`/define`|`## Implementation plan`|
-
-- Name sections by content, not command.
+Name the section heading by phase content, not by command name:
+- **Discovery phase** → `## Requirements`
+- **Definition phase** → `## Implementation plan`
 - Update the body in place, not a comment.
 - After updating, tell user to start next phase in fresh session. Do not call next skill from within.
 - Issue body wins over in-context recall.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -95,7 +95,7 @@ A standalone L2 skill (e.g. `/build` invoked directly by the user, not by an orc
 
 1. **Create** — On entry, create NOTES.md with `## Task list`, `## Decisions made this session`, and `## Next action on resume`.
 2. **Update** — Flip checkboxes as tasks complete, log decisions, update `## Current task` and `## Next action on resume` at each natural breakpoint.
-3. **Leave** — On exit, leave NOTES.md in place for `/implement` to harvest. Do not delete.
+3. **Leave** — On exit, leave NOTES.md in place. Do not delete.
 
 No checkpoint-before-spawn is needed — standalone skills do not spawn sub-agents. The pattern is create → update → leave.
 

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -26,20 +26,20 @@ Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles.
 
 - **While working** — log to `.claude/NOTES.md` (phase-local scratch).
 - **Between sessions on same feature** — resume from `.claude/NOTES.md` (authoritative in-flight state).
-- **Between features** — promote durable learnings to vault via `/compound`. That crosses the worktree boundary.
+- **Between features** — promote durable learnings to vault. That crosses the worktree boundary.
 - **For recent context across repo** — use vault's hot cache (curated, committed), not NOTES.md (raw, ephemeral).
 
-`/implement` is the harvest point: at PR creation it reads NOTES.md, flows the decisions and open questions into the PR body, then deletes NOTES.md after `/compound` has run.
+The phase-ending skill is the harvest point: at PR creation it reads NOTES.md, flows the decisions and open questions into the PR body, then deletes NOTES.md after promoting durable learnings to vault. See that skill's own file for details.
 
 ## Location and lifecycle
 
 - **Path:** `<worktree-root>/.claude/NOTES.md`.
-- **Created by the agent that starts the phase** — either an orchestrator (L1) or a standalone skill (L2 like `/build`).
+- **Created by the agent that starts the phase** — either an orchestrator (L1) or a standalone skill (L2).
 - **Ownership transfers with execution.** The running agent always owns NOTES.md. An orchestrator owns it before spawn and after return; the spawned sub-skill owns it during execution. Since execution is sequential (spawn → wait → return), there is no concurrent write conflict.
 - **Updated by the currently running agent** after each completed task, significant decision, or before spawning a further sub-agent (checkpoint). This applies equally to orchestrators and spawned sub-skills.
 - **Read on resume** — before re-reading the issue, reconstruct state from NOTES.md.
-- **Harvested by `/implement`** at PR-creation time. `## Decisions made this session` and `## Open questions` flow into PR body's `## Notes` section.
-- **Deleted by `/implement`** after `/compound` runs. If `/implement` exits abnormally, NOTES.md persists; `/wrap-up` cleans it up with worktree removal.
+- **Harvested at phase end** — `## Decisions made this session` and `## Open questions` flow into PR body's `## Notes` section.
+- **Deleted after harvest** by the phase-ending skill. If that skill exits abnormally, NOTES.md persists; cleanup happens with worktree removal.
 - **Left in place** by standalone skills — cleanup happens when worktree is removed.
 - **Not committed to git.** Ensure `/.claude/NOTES.md` is gitignored; add entry if missing.
 
@@ -75,8 +75,8 @@ Update at these points (bullet-level only):
 
 - **After each completed task** — flip checkbox, log any decision.
 - **After each significant decision** — one line with rationale.
-- **Before any `/compact`** — write Keep list first, so post-compaction summary can be diffed against external record.
-- **Before ending session normally** — `/implement` harvests at PR-creation time.
+- **Before any compaction** — write Keep list first, so post-compaction summary can be diffed against external record.
+- **Before ending session normally** — the phase-ending skill harvests at PR-creation time.
 
 Don't update for trivial moves (opening file, running test). Checkpoint log, not transcript.
 
@@ -91,7 +91,7 @@ When `.claude/NOTES.md` exists in worktree, it's a resume:
 
 ## Standalone skill pattern
 
-A standalone L2 skill (e.g. `/build` invoked directly by the user, not by an orchestrator) uses NOTES.md as a lightweight progress tracker:
+A standalone L2 skill (invoked directly by the user, not by an orchestrator) uses NOTES.md as a lightweight progress tracker:
 
 1. **Create** — On entry, create NOTES.md with `## Task list`, `## Decisions made this session`, and `## Next action on resume`.
 2. **Update** — Flip checkboxes as tasks complete, log decisions, update `## Current task` and `## Next action on resume` at each natural breakpoint.
@@ -106,7 +106,7 @@ Orchestrators use NOTES.md as the progress ledger for multi-step pipelines that 
 1. **Create** — On entry (after preflight), create NOTES.md with the full task list derived from work units.
 2. **Checkpoint before sub-agent spawn** — Write `## Current task` (what the sub-agent will do) and `## Next action on resume` (how to reconstruct if session dies) before every `Skill()` or `Agent()` call. This ensures crash-safe resume.
 3. **Update after sub-agent returns** — The sub-skill may have written its own progress, decisions, and task updates to NOTES.md while it ran. Read the file, integrate its results, flip checkboxes, and log any new decisions. The orchestrator's view is authoritative for the overall pipeline; the sub-skill's entries are intermediate working state.
-4. **Wrap-up** — On clean exit, leave NOTES.md in place for `/implement` to harvest. On abnormal exit, NOTES.md serves as the resume point.
+4. **Wrap-up** — On clean exit, leave NOTES.md in place for the phase-ending skill to harvest. On abnormal exit, NOTES.md serves as the resume point.
 
 ### Seed-brief slice
 
@@ -142,4 +142,4 @@ Slice rules:
 - **Ownership transfers with the running agent.** The agent currently executing owns NOTES.md — whether that's the orchestrator or a spawned sub-skill. On return, ownership passes back to the caller.
 - **Orchestrator checkpoints before every spawn** so NOTES.md contains enough state to reconstruct if the session dies mid-spawn (sub-skill never started or partially executed).
 - **Sub-skills use NOTES.md for their own multi-step tracking** while they run (same sections, same conventions). This is safe because execution is sequential — no concurrent writers.
-- **Deletion is `/implement`'s responsibility.** It deletes after `/compound` runs. Standalone skills leave in place.
+- **Deletion is the phase-ending skill's responsibility.** Standalone skills leave NOTES.md in place.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -34,8 +34,9 @@ Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles.
 ## Location and lifecycle
 
 - **Path:** `<worktree-root>/.claude/NOTES.md`.
-- **Created by orchestrator or sub-skill** at phase start, with initial task list derived from the issue or work units.
-- **Updated by orchestrator** after each completed task, returned agent result, significant decision, and before spawning a sub-agent (checkpoint).
+- **Created by the agent that starts the phase** — either an orchestrator (L1) or a standalone skill (L2 like `/build`). The creator owns the file.
+- **Updated by the owning agent** after each completed task, significant decision, returned sub-agent result, or before spawning a sub-agent (checkpoint).
+- **NOT managed by spawned sub-agents** — when an L2 skill is called by an orchestrator, it receives a NOTES.md slice via seed-brief `progress:` field but does **not** write to NOTES.md (the orchestrator owns it). Spawned skills use `TodoWrite` for their ephemeral scratchpad.
 - **Read on resume** — before re-reading the issue, reconstruct state from NOTES.md.
 - **Harvested by `/implement`** at PR-creation time. `## Decisions made this session` and `## Open questions` flow into PR body's `## Notes` section.
 - **Deleted by `/implement`** after `/compound` runs. If `/implement` exits abnormally, NOTES.md persists; `/wrap-up` cleans it up with worktree removal.
@@ -88,9 +89,19 @@ When `.claude/NOTES.md` exists in worktree, it's a resume:
 3. Resume from **Next action on resume**, or from first unchecked item in Task list if stale.
 4. Update **Current task** and **Next action on resume** before first real action.
 
+## Standalone skill pattern
+
+A standalone L2 skill (e.g. `/build` invoked directly by the user, not by an orchestrator) uses NOTES.md as a lightweight progress tracker:
+
+1. **Create** — On entry, create NOTES.md with `## Task list`, `## Decisions made this session`, and `## Next action on resume`.
+2. **Update** — Flip checkboxes as tasks complete, log decisions, update `## Current task` and `## Next action on resume` at each natural breakpoint.
+3. **Leave** — On exit, leave NOTES.md in place for `/implement` to harvest. Do not delete.
+
+No checkpoint-before-spawn is needed — standalone skills do not spawn sub-agents. The pattern is create → update → leave.
+
 ## Orchestrator checkpoint pattern
 
-Orchestrators use NOTES.md as the progress ledger for multi-step pipelines. The pattern:
+Orchestrators use NOTES.md as the progress ledger for multi-step pipelines that delegate to sub-agents. The pattern:
 
 1. **Create** — On entry (after preflight), create NOTES.md with the full task list derived from work units.
 2. **Checkpoint before sub-agent spawn** — Write `## Current task` (what the sub-agent will do) and `## Next action on resume` (how to reconstruct if session dies) before every `Skill()` or `Agent()` call. This ensures crash-safe resume.
@@ -128,5 +139,7 @@ Slice rules:
 
 - **NOTES.md is authoritative for in-flight state.** Trust the file; in-context recall is rot-degraded.
 - **Issue is authoritative for cross-phase state.** Acceptance criteria, locked decisions, prior-phase handoff live in issue, not file.
+- **The agent that creates NOTES.md owns it.** Standalone L2 skills own their own NOTES.md. Orchestrators own the NOTES.md their sub-agents receive slices of.
+- **Spawned sub-agents do not write to NOTES.md.** They receive context via the seed-brief `progress:` field and use `TodoWrite` for ephemeral state.
 - **Deletion is `/implement`'s responsibility.** It deletes after `/compound` runs. Standalone skills leave in place.
 - **Orchestrator checkpoints before every sub-agent spawn.** If the session dies mid-spawn, NOTES.md must contain enough state to reconstruct.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -9,7 +9,7 @@ Four tiers:
 |Tier|Where|Lifetime|Authoritative for|
 |-|-|-|-|
 |`TodoWrite`|In-context|This session|Throwaway scratchpad|
-|`.claude/NOTES.md`|Worktree-local, gitignored|This phase, across sessions|In-flight decisions, current task, open questions|
+|`.claude/NOTES.md`|Worktree-local, gitignored|This phase, across sessions|In-flight decisions, task progress, current task, open questions|
 |GitHub issue|Remote|Cross-phase|Acceptance criteria, prior-phase decisions, handoff state|
 |Durable vault|claude-obsidian vault (git-tracked)|Durable, cross-feature|Patterns, bug-fix history, architectural insights|
 
@@ -34,12 +34,12 @@ Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles.
 ## Location and lifecycle
 
 - **Path:** `<worktree-root>/.claude/NOTES.md`.
-- **Created by `/build`** at phase start, immediately after `wt switch --create`, with initial task list from issue.
-- **Updated by `/build`** after each completed task, significant decision, and before `/compact`.
-- **Read on resume by `/build`** — before re-reading the issue.
+- **Created by orchestrator or sub-skill** at phase start, with initial task list derived from the issue or work units.
+- **Updated by orchestrator** after each completed task, returned agent result, significant decision, and before spawning a sub-agent (checkpoint).
+- **Read on resume** — before re-reading the issue, reconstruct state from NOTES.md.
 - **Harvested by `/implement`** at PR-creation time. `## Decisions made this session` and `## Open questions` flow into PR body's `## Notes` section.
 - **Deleted by `/implement`** after `/compound` runs. If `/implement` exits abnormally, NOTES.md persists; `/wrap-up` cleans it up with worktree removal.
-- **Left in place** by standalone `/build`, `/review`, `/verify` — cleanup happens when worktree is removed.
+- **Left in place** by standalone skills — cleanup happens when worktree is removed.
 - **Not committed to git.** Ensure `/.claude/NOTES.md` is gitignored; add entry if missing.
 
 ## Required sections
@@ -88,8 +88,45 @@ When `.claude/NOTES.md` exists in worktree, it's a resume:
 3. Resume from **Next action on resume**, or from first unchecked item in Task list if stale.
 4. Update **Current task** and **Next action on resume** before first real action.
 
+## Orchestrator checkpoint pattern
+
+Orchestrators use NOTES.md as the progress ledger for multi-step pipelines. The pattern:
+
+1. **Create** — On entry (after preflight), create NOTES.md with the full task list derived from work units.
+2. **Checkpoint before sub-agent spawn** — Write `## Current task` (what the sub-agent will do) and `## Next action on resume` (how to reconstruct if session dies) before every `Skill()` or `Agent()` call. This ensures crash-safe resume.
+3. **Update after sub-agent returns** — Flip checkboxes, log results and decisions from the agent's findings report.
+4. **Wrap-up** — On clean exit, leave NOTES.md in place for `/implement` to harvest. On abnormal exit, NOTES.md serves as the resume point.
+
+### Seed-brief slice
+
+When spawning a sub-agent, include a relevant slice of NOTES.md in the seed-brief payload so the agent arrives with progress context:
+
+```
+<seed-brief>
+...
+payload:
+  type: research
+  progress: |
+    ## Task list (relevant)
+    - [x] Scope assessment → 3 work units
+    - [ ] Build specialist (current)
+    - [ ] Review specialist
+
+    ## Decisions made this session
+    - Split auth into own work unit (why: security isolation)
+  open_questions: ""
+</seed-brief>
+```
+
+Slice rules:
+- Include only the subset of `## Task list` relevant to the spawned agent's scope.
+- Include `## Decisions made this session` in full (decisions are global to the phase).
+- Omit `## Current task` (the agent will set its own).
+- Cap at 15 lines — the brief is not a state dump.
+
 ## Rules
 
 - **NOTES.md is authoritative for in-flight state.** Trust the file; in-context recall is rot-degraded.
 - **Issue is authoritative for cross-phase state.** Acceptance criteria, locked decisions, prior-phase handoff live in issue, not file.
-- **Deletion is `/implement`'s responsibility.** It deletes after `/compound` runs. Standalone `/build` leaves in place.
+- **Deletion is `/implement`'s responsibility.** It deletes after `/compound` runs. Standalone skills leave in place.
+- **Orchestrator checkpoints before every sub-agent spawn.** If the session dies mid-spawn, NOTES.md must contain enough state to reconstruct.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -34,9 +34,9 @@ Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles.
 ## Location and lifecycle
 
 - **Path:** `<worktree-root>/.claude/NOTES.md`.
-- **Created by the agent that starts the phase** — either an orchestrator (L1) or a standalone skill (L2 like `/build`). The creator owns the file.
-- **Updated by the owning agent** after each completed task, significant decision, returned sub-agent result, or before spawning a sub-agent (checkpoint).
-- **NOT managed by spawned sub-agents** — when an L2 skill is called by an orchestrator, it receives a NOTES.md slice via seed-brief `progress:` field but does **not** write to NOTES.md (the orchestrator owns it). Spawned skills use `TodoWrite` for their ephemeral scratchpad.
+- **Created by the agent that starts the phase** — either an orchestrator (L1) or a standalone skill (L2 like `/build`).
+- **Ownership transfers with execution.** The running agent always owns NOTES.md. An orchestrator owns it before spawn and after return; the spawned sub-skill owns it during execution. Since execution is sequential (spawn → wait → return), there is no concurrent write conflict.
+- **Updated by the currently running agent** after each completed task, significant decision, or before spawning a further sub-agent (checkpoint). This applies equally to orchestrators and spawned sub-skills.
 - **Read on resume** — before re-reading the issue, reconstruct state from NOTES.md.
 - **Harvested by `/implement`** at PR-creation time. `## Decisions made this session` and `## Open questions` flow into PR body's `## Notes` section.
 - **Deleted by `/implement`** after `/compound` runs. If `/implement` exits abnormally, NOTES.md persists; `/wrap-up` cleans it up with worktree removal.
@@ -105,7 +105,7 @@ Orchestrators use NOTES.md as the progress ledger for multi-step pipelines that 
 
 1. **Create** — On entry (after preflight), create NOTES.md with the full task list derived from work units.
 2. **Checkpoint before sub-agent spawn** — Write `## Current task` (what the sub-agent will do) and `## Next action on resume` (how to reconstruct if session dies) before every `Skill()` or `Agent()` call. This ensures crash-safe resume.
-3. **Update after sub-agent returns** — Flip checkboxes, log results and decisions from the agent's findings report.
+3. **Update after sub-agent returns** — The sub-skill may have written its own progress, decisions, and task updates to NOTES.md while it ran. Read the file, integrate its results, flip checkboxes, and log any new decisions. The orchestrator's view is authoritative for the overall pipeline; the sub-skill's entries are intermediate working state.
 4. **Wrap-up** — On clean exit, leave NOTES.md in place for `/implement` to harvest. On abnormal exit, NOTES.md serves as the resume point.
 
 ### Seed-brief slice
@@ -139,7 +139,7 @@ Slice rules:
 
 - **NOTES.md is authoritative for in-flight state.** Trust the file; in-context recall is rot-degraded.
 - **Issue is authoritative for cross-phase state.** Acceptance criteria, locked decisions, prior-phase handoff live in issue, not file.
-- **The agent that creates NOTES.md owns it.** Standalone L2 skills own their own NOTES.md. Orchestrators own the NOTES.md their sub-agents receive slices of.
-- **Spawned sub-agents do not write to NOTES.md.** They receive context via the seed-brief `progress:` field and use `TodoWrite` for ephemeral state.
+- **Ownership transfers with the running agent.** The agent currently executing owns NOTES.md — whether that's the orchestrator or a spawned sub-skill. On return, ownership passes back to the caller.
+- **Orchestrator checkpoints before every spawn** so NOTES.md contains enough state to reconstruct if the session dies mid-spawn (sub-skill never started or partially executed).
+- **Sub-skills use NOTES.md for their own multi-step tracking** while they run (same sections, same conventions). This is safe because execution is sequential — no concurrent writers.
 - **Deletion is `/implement`'s responsibility.** It deletes after `/compound` runs. Standalone skills leave in place.
-- **Orchestrator checkpoints before every sub-agent spawn.** If the session dies mid-spawn, NOTES.md must contain enough state to reconstruct.

--- a/_shared/seed-brief.md
+++ b/_shared/seed-brief.md
@@ -9,9 +9,9 @@ The seed-brief packages critical state—scope, repo, branch, active issue, prio
 ## When to Use
 
 Use seed-briefs when:
-- **Orchestrator spawning a sub-skill** (e.g., `/implement` spawning `/build`, `/review`, `/verify`)
+- **Orchestrator spawning a sub-skill** to delegate a unit of work
 - **Orchestrator spawning a worker agent** via `Agent()` to handle bulk work (research, code reviews, fixups)
-- **Autonomous cycles** within a phase (e.g., build → review → verify loops)
+- **Autonomous cycles** within a phase
 
 Do NOT use for:
 - **Mid-cycle state within the same worktree.** Use `.claude/NOTES.md` for findings, failing AC, prior decisions during the same phase.
@@ -48,7 +48,7 @@ payload:
 |`branch`|string|Format: `feat/<slug>`. Verified against `git rev-parse --abbrev-ref HEAD` by orchestrator.|
 |`active_issue`|int|GitHub issue ID (positive integer). Used for sanity checks and issue-link context.|
 |`payload`|object|Research, prior art, findings, or constraints. Shape depends on `payload.type` (see § Payload Types).|
-|`autonomous`|bool|Optional; default `false`. If `true`, suppresses exit/continuation prompts in `/implement`.|
+|`autonomous`|bool|Optional; default `false`. If `true`, suppresses exit/continuation prompts in the phase-ending skill.|
 
 ## Payload Types
 
@@ -58,11 +58,11 @@ The `payload` field is a dict with a required `type` key and type-specific conte
 ```yaml
 payload:
   type: research
-  prior_art: "<Issue #N ## Implementation plan (architecture and design from /define)>"
+  prior_art: "<Issue implementation plan, architecture, and design decisions>"
   progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
   open_questions: "<Unresolved constraints or empty string>"
 ```
-Used by `/implement` to spawn `/build`, `/review`, `/verify`. Contains high-level architecture decisions and known constraints. The optional `progress` field carries intra-orchestrator state from NOTES.md so the sub-agent arrives with task context.
+Used to spawn a build or implementation sub-skill. Contains high-level architecture decisions and known constraints. The optional `progress` field carries intra-orchestrator state from NOTES.md so the sub-agent arrives with task context.
 
 ### `type: fix`
 ```yaml
@@ -87,7 +87,7 @@ Used for research or exploration tasks where codebase patterns are critical cont
 
 ## Canonical Example
 
-An orchestrator (`/implement`) spawning `/build` with an autonomous cycle:
+An orchestrator spawning a build sub-skill with an autonomous cycle:
 
 ```
 <seed-brief>
@@ -113,7 +113,7 @@ Specialist behavior when receiving this brief:
 - Skip repo/branch verification (already done; `preflight_verified: true`)
 - Skip redundant codebase scan for architecture patterns (prior art provided)
 - Proceed directly to implementation
-- On exit (if AC met): auto-advance to `/review` without prompting (because `autonomous: true`)
+- On exit (if AC met): auto-advance to the next stage without prompting (because `autonomous: true`)
 
 ## Orchestrator Duties
 
@@ -144,18 +144,15 @@ When a specialist detects `<seed-brief>` in its prompt:
 4. **Keep gates:** Do NOT skip discovery, design rigor, or AC verification — these remain required
 5. **Handle `autonomous: true`:** If present, auto-advance to next stage on clean pass; suppress exit prompt
 
-**Execution delta (per `Skill("specialist-mode")`):**
+**Execution delta when seeded:**
 
-|Specialist|Skipped when Seeded|Always Kept|
-|-|-|-|
-|`/build`|repo/scope preflights, scope confirmation|design gate|
-|`/review`|repo-preflight|severity/depth gates|
-|`/verify`|repo-preflight|AC verification rigor|
-|`/describe`|internal prior-art search|grill-me, devil's advocate|
-|`/specify`|scope/file confirmation|AC derivation gates|
-|`/architecture`|codebase/pattern research|architecture session|
-|`/design`|design-space research|interactive session|
-|`/implement`|(handled by orchestrator)|exhausted-exit prompt (unless `autonomous: true`)|
+|What's Skipped|Always Kept|
+|-|-|
+|Repo/scope preflights, scope confirmation|Design gate (for build/implementation skills)|
+|Repo-preflight|Severity/depth gates (for review skills)|
+|Internal prior-art search|Rigor gates (for verification skills)|
+
+Each sub-skill documents its own seed-brief-aware behavior in its own file, including what it skips and what it always keeps when seeded.
 
 ## Failure Mode
 

--- a/_shared/seed-brief.md
+++ b/_shared/seed-brief.md
@@ -59,9 +59,10 @@ The `payload` field is a dict with a required `type` key and type-specific conte
 payload:
   type: research
   prior_art: "<Issue #N ## Implementation plan (architecture and design from /define)>"
+  progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
   open_questions: "<Unresolved constraints or empty string>"
 ```
-Used by `/implement` to spawn `/build`, `/review`, `/verify`. Contains high-level architecture decisions and known constraints.
+Used by `/implement` to spawn `/build`, `/review`, `/verify`. Contains high-level architecture decisions and known constraints. The optional `progress` field carries intra-orchestrator state from NOTES.md so the sub-agent arrives with task context.
 
 ### `type: fix`
 ```yaml
@@ -70,8 +71,9 @@ payload:
   failing_ac: "<Failed acceptance criterion(s)>"
   findings: "file.js:42 — function does not handle edge case\nfile.ts:15 — type mismatch"
   prior_decisions: "<Prior architectural decisions or design constraints>"
+  progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
 ```
-Used when spawning a specialist to fix a specific failure. Contains line-specific findings and the AC to address.
+Used when spawning a specialist to fix a specific failure. Contains line-specific findings and the AC to address. The optional `progress` field carries intra-orchestrator state from NOTES.md.
 
 ### `type: prior-art`
 ```yaml
@@ -122,9 +124,13 @@ Specialist behavior when receiving this brief:
 2. **Construct seed-brief** with `preflight_verified: true`:
    - Include repo, branch, active_issue for sanity checks in spawned agents
    - Build `payload` from prior research, failing AC, or architectural decisions
+   - Include a `progress` slice from NOTES.md (task list subset + decisions) for intra-orchestrator context — see notes-md-protocol.md § Seed-brief slice
    - Set `autonomous: true` only if orchestrator will handle next stage (no user prompt)
 
-3. **Pass to every specialist spawn:**
+3. **Checkpoint NOTES.md before constructing the brief:**
+   Write `## Current task` and `## Next action on resume` before every `Skill()` or `Agent()` call so NOTES.md contains enough state to reconstruct if the session dies mid-spawn.
+
+4. **Pass to every specialist spawn:**
    - Orchestrator always passes the brief to every sub-skill or worker invocation
    - Specialists detect it and skip redundant research
 

--- a/_shared/worktree-protocol.md
+++ b/_shared/worktree-protocol.md
@@ -19,4 +19,4 @@ wt list
 
 ## Remove
 
-Handled by `/wrap-up`. Do not remove manually unless instructed.
+Handled by the phase-ending skill. Do not remove manually unless instructed.

--- a/_templates/SKILL.orchestrator.template.md
+++ b/_templates/SKILL.orchestrator.template.md
@@ -28,15 +28,18 @@ See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for spawn cost models.
 ## Process
 
 1. Read input; build work-unit list for `scope-assessment`.
-2. **Research** (parallel subagents; multi-area only):
+2. **Init NOTES.md** — create `.claude/NOTES.md` with task list (one checkbox per work unit or step) and `## Decisions made this session`, `## Next action on resume`. See `Skill("orchestrator-rules")` § Progress tracking via NOTES.md.
+3. **Research** (parallel subagents; multi-area only):
    - **Codebase research** — tech stack, modules, patterns. Outputs research brief.
    - **Prior art** — vault, project docs, external sources.
-3. **Specialists** (parallel subagents), seeded with research. Width = scope. Include only needed specialists:
+   - Checkpoint NOTES.md before each spawn; update on return.
+4. **Specialists** (parallel subagents), seeded with research. Width = scope. Include only needed specialists:
    - **Specialist A** — `/<skill>` to <do thing>. Seeded; skips research.
    - **Specialist B** — `/<skill>` to <do thing>.
-4. <Serialization rule — which specialist first and why.>
-5. **Handoff artifact** — update GitHub issue body in place with decisions and five-field block.
-6. Present output; require explicit approval. After sign-off, tell user to start next phase fresh.
+   - Checkpoint NOTES.md before each spawn (write `## Current task`, `## Next action on resume`); include NOTES.md slice in seed-brief payload. Update on return.
+5. <Serialization rule — which specialist first and why.>
+6. **Handoff artifact** — update GitHub issue body in place with decisions and five-field block.
+7. Present output; require explicit approval. After sign-off, tell user to start next phase fresh.
 
 ## Output
 

--- a/skills/orchestrator-rules/SKILL.md
+++ b/skills/orchestrator-rules/SKILL.md
@@ -12,7 +12,7 @@ Invoke `Skill("preflight")` at entry. Echo resolved `owner/repo` before every do
 
 ## Delegation
 
-Each stage delegates to the designated sub-skill. Do not reimplement logic owned by `/implement`, `/resolve-pr-feedback`, `/compound`, `/wrap-up`, or any other sub-skill.
+Each stage delegates to the designated sub-skill. Do not reimplement logic owned by phase-ending or sub-skills — each has a defined scope; respect it.
 
 ## No autonomous merge
 
@@ -20,7 +20,7 @@ Merging is always a human action. Exit cleanly at the awaiting-merge stage; neve
 
 ## Seed-brief contract
 
-See `Skill("specialist-mode")` § Autonomous Implement Invocation for seed-brief shape and field requirements.
+See `Skill("specialist-mode")` for Seed-brief shape and field requirements. Each sub-skill documents its expected seed-brief fields in its own file.
 
 ## Progress tracking via NOTES.md
 
@@ -47,7 +47,7 @@ After preflight, create NOTES.md with:
 
 ### On exit
 
-- **Clean exit**: Leave NOTES.md in place for `/implement` to harvest.
+- **Clean exit**: Leave NOTES.md in place for the phase-ending skill to harvest.
 - **Abnormal exit**: NOTES.md preserves resume state — do not delete.
 
 ### Rules

--- a/skills/orchestrator-rules/SKILL.md
+++ b/skills/orchestrator-rules/SKILL.md
@@ -21,3 +21,37 @@ Merging is always a human action. Exit cleanly at the awaiting-merge stage; neve
 ## Seed-brief contract
 
 See `Skill("specialist-mode")` § Autonomous Implement Invocation for seed-brief shape and field requirements.
+
+## Progress tracking via NOTES.md
+
+Orchestrators use `.claude/NOTES.md` as the in-phase progress ledger. Read `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` § Orchestrator checkpoint pattern for the full protocol.
+
+### On entry
+
+After preflight, create NOTES.md with:
+- `## Task list` — one checkbox per work unit or pipeline step, in order.
+- `## Decisions made this session` — empty initially.
+- `## Next action on resume` — the first step to take if session dies.
+
+### Before spawning a sub-agent
+
+1. Write `## Current task` with what the sub-agent will do.
+2. Write `## Next action on resume` with the exact command that would reconstruct state.
+3. Include a NOTES.md slice in the seed-brief payload (`progress:` field) — see notes-md-protocol.md § Seed-brief slice for format and cap.
+
+### After sub-agent returns
+
+1. Flip checkbox(es) for completed work.
+2. Log key results and decisions from the findings report.
+3. Set `## Next action on resume` to the next step.
+
+### On exit
+
+- **Clean exit**: Leave NOTES.md in place for `/implement` to harvest.
+- **Abnormal exit**: NOTES.md preserves resume state — do not delete.
+
+### Rules
+
+- **Checkpoint before every `Skill()` or `Agent()` call.** If the session dies mid-spawn, NOTES.md is the sole resume source.
+- **No issue body updates for intra-orchestrator state.** Phase boundaries use the handoff-artifact; everything else stays in NOTES.md.
+- **Keep under 1k tokens.** If the decision log grows, promote stable decisions to the issue body and trim NOTES.md.


### PR DESCRIPTION
## Summary

Rebuilds the wrap-up skill as a Layer 2 specialist with dual-mode seed-brief support, per the L3 boundary realignment for v2 (#125, Option C3).

### Changes

**skills/wrap-up/SKILL.md**
- Add layer: 2 frontmatter
- Add seed-brief awareness with confirmed:true dual-mode (standalone vs orchestrated)
- Align with SKILL.specialist template structure
- Add Read reference to _shared/seed-brief.md

**skills/wrap-up/references/procedure.md**
- Add dual-mode preamble: Steps 2-4 skipped when confirmed:true

**skills/issue-autopilot/references/stage-5.md**
- Update caller to pass seed-brief with confirmed:true
- Add safety note

Closes #125 (Phase A: wrap-up rebuild)
