### PR TITLE
fix: complete v2 terminology cleanup and documentation update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,18 @@ GitHub Releases (with auto-generated notes and source tarballs) remain the canon
 
 ### Changed
 
+- **NOTES.md protocol broadened** -- ownership model shifted from "orchestrator-only" to ownership-transfer (orchestrator owns before spawn / after return, sub-skill owns during execution). Standalone L2 skills now use NOTES.md for their own multi-step tracking. Adds Orchestrator Checkpoint pattern (create on entry, checkpoint before spawn, update on return) and Seed-brief Slice pattern (progress field in seed-brief payload). (#v2/orchestrator-progress-ledger)
+
+- **Terminology standardized** -- all "tier" references in shared docs renamed to "layer" for consistency with the three-layer taxonomy. Affected files: _shared/notes-md-protocol.md (memory tier -> memory layer), README.md.
+
+- **Shared docs decoupled from skill names** -- removed hardcoded /build, /review, /verify, /implement, etc. references from 7 shared/protocol files. Skills are now referenced generically by role rather than by command name.
+
 - **Layer-3 boundary realignment** - five skills demoted from layer-3 (`Skill()` invocation) to `_shared/` reference docs (`Read`):
   - `seed-brief` -> `_shared/seed-brief.md` - spawn-time context packaging format (data structure spec, not behavioral protocol)
   - `worktree` -> `_shared/worktree-protocol.md` - `wt` CLI command reference (command cheat sheet, not behavioral protocol)
   - `interviewing-rules` -> `_shared/interviewing-rules.md` - one-question-at-a-time user-interaction rules (interaction pattern, not cross-skill behavioral contract)
   - `handoff-artifact` -> `_shared/handoff-artifact.md` - cross-phase handoff protocol for GitHub issue body (reference doc, not invoked skill)
-  - `notes-md` -> `_shared/notes-md-protocol.md` - in-phase memory tier lifecycle and structure (reference doc, not invoked skill)
+  - `notes-md` -> `_shared/notes-md-protocol.md` - in-phase memory layer lifecycle and structure (reference doc, not invoked skill)
   - All callers updated from `Invoke \`Skill("name")\`` to `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<name>.md\``.
   - `_templates/AUTHORING.md` decision rule refined with concrete examples; `_shared/` catalogue expanded.
   - `skills/scope-assessment/SKILL.md` gained missing `layer: 3` frontmatter.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Shared protocols at `_shared/`:
 |`composition.md`|Multi-skill composition patterns and contracts|
 |`handoff-artifact.md`|Five-field GitHub issue handoff structure|
 |`interviewing-rules.md`|One-question-at-a-time interview protocol|
-|`notes-md-protocol.md`|In-phase NOTES.md memory tier|
+|`notes-md-protocol.md`|In-phase NOTES.md memory layer|
 |`orchestrator-rules.md`|Shared rules for pipeline orchestrators: CWD verification, delegation, no-autonomous-merge, seed-brief contract|
 
 ## Releasing

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -18,8 +18,10 @@ Always update the **issue body** in place. Comments are for discussion only — 
 
 Fields in order: Acceptance criteria, Constraints, Prior decisions, Evidence, Open questions. Omit optional fields when empty — never write placeholder text ("None", "No open questions").
 
+Section heading is phase-specific — each skill specifies it (e.g. `## Requirements` for discovery, `## Implementation plan` for define).
+
 ```markdown
-## Implementation plan
+## <section heading>
 
 **Acceptance criteria** (from discovery, unchanged)
 - AC1: ...
@@ -49,11 +51,7 @@ When a phase ends, in-flight state from NOTES.md that the next phase needs is pr
 
 ## Rules
 
-Name the section heading by phase content, not by command name:
-- **Discovery phase** → `## Requirements`
-- **Definition phase** → `## Implementation plan`
 - Update the body in place, not a comment.
-- After updating, tell user to start next phase in fresh session. Do not call next skill from within.
 - Issue body wins over in-context recall.
 - Never include secrets in Evidence links.
 - Never drop prior decisions to save space.

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -1,19 +1,19 @@
-# NOTES.md — In-Phase Memory Tier
+# NOTES.md — In-Phase Memory Layer
 
 `.claude/NOTES.md` is rot-immune external memory for in-phase state. Read on-demand when creating, updating, or harvesting; do not preload.
 
 ## Where it sits in the memory hierarchy
 
-Four tiers:
+Four layers:
 
-|Tier|Where|Lifetime|Authoritative for|
+|Layer|Where|Lifetime|Authoritative for|
 |-|-|-|-|
 |`TodoWrite`|In-context|This session|Throwaway scratchpad|
 |`.claude/NOTES.md`|Worktree-local, gitignored|This phase, across sessions|In-flight decisions, task progress, current task, open questions|
 |GitHub issue|Remote|Cross-phase|Acceptance criteria, prior-phase decisions, handoff state|
 |Durable vault|claude-obsidian vault (git-tracked)|Durable, cross-feature|Patterns, bug-fix history, architectural insights|
 
-Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles. The vault tier materializes when `claude-obsidian` is installed; without it, skills that would write degrade gracefully.
+Do not mirror `TodoWrite` and `.claude/NOTES.md` — they serve different roles. The vault layer materializes when `claude-obsidian` is installed; without it, skills that would write degrade gracefully.
 
 ## NOTES.md vs the vault's recency channels
 

--- a/_shared/notes-md-protocol.md
+++ b/_shared/notes-md-protocol.md
@@ -99,42 +99,6 @@ A standalone L2 skill (invoked directly by the user, not by an orchestrator) use
 
 No checkpoint-before-spawn is needed — standalone skills do not spawn sub-agents. The pattern is create → update → leave.
 
-## Orchestrator checkpoint pattern
-
-Orchestrators use NOTES.md as the progress ledger for multi-step pipelines that delegate to sub-agents. The pattern:
-
-1. **Create** — On entry (after preflight), create NOTES.md with the full task list derived from work units.
-2. **Checkpoint before sub-agent spawn** — Write `## Current task` (what the sub-agent will do) and `## Next action on resume` (how to reconstruct if session dies) before every `Skill()` or `Agent()` call. This ensures crash-safe resume.
-3. **Update after sub-agent returns** — The sub-skill may have written its own progress, decisions, and task updates to NOTES.md while it ran. Read the file, integrate its results, flip checkboxes, and log any new decisions. The orchestrator's view is authoritative for the overall pipeline; the sub-skill's entries are intermediate working state.
-4. **Wrap-up** — On clean exit, leave NOTES.md in place for the phase-ending skill to harvest. On abnormal exit, NOTES.md serves as the resume point.
-
-### Seed-brief slice
-
-When spawning a sub-agent, include a relevant slice of NOTES.md in the seed-brief payload so the agent arrives with progress context:
-
-```
-<seed-brief>
-...
-payload:
-  type: research
-  progress: |
-    ## Task list (relevant)
-    - [x] Scope assessment → 3 work units
-    - [ ] Build specialist (current)
-    - [ ] Review specialist
-
-    ## Decisions made this session
-    - Split auth into own work unit (why: security isolation)
-  open_questions: ""
-</seed-brief>
-```
-
-Slice rules:
-- Include only the subset of `## Task list` relevant to the spawned agent's scope.
-- Include `## Decisions made this session` in full (decisions are global to the phase).
-- Omit `## Current task` (the agent will set its own).
-- Cap at 15 lines — the brief is not a state dump.
-
 ## Rules
 
 - **NOTES.md is authoritative for in-flight state.** Trust the file; in-context recall is rot-degraded.

--- a/_shared/seed-brief.md
+++ b/_shared/seed-brief.md
@@ -85,36 +85,6 @@ payload:
 ```
 Used for research or exploration tasks where codebase patterns are critical context.
 
-## Canonical Example
-
-An orchestrator spawning a build sub-skill with an autonomous cycle:
-
-```
-<seed-brief>
-preflight_verified: true
-repo: misiekhardcore/my-app
-branch: feat/csv-export
-active_issue: 42
-autonomous: true
-payload:
-  type: research
-  prior_art: |
-    Issue #42 ## Implementation plan
-
-    ### Architecture Decision
-    - CSV export routes through existing ReportExporter service
-    - New ExportFormatter module handles CSV serialization
-    - UI button added to reports/page.tsx
-  open_questions: ""
-</seed-brief>
-```
-
-Specialist behavior when receiving this brief:
-- Skip repo/branch verification (already done; `preflight_verified: true`)
-- Skip redundant codebase scan for architecture patterns (prior art provided)
-- Proceed directly to implementation
-- On exit (if AC met): auto-advance to the next stage without prompting (because `autonomous: true`)
-
 ## Orchestrator Duties
 
 1. **Run preflights once at entry:**
@@ -144,15 +114,7 @@ When a specialist detects `<seed-brief>` in its prompt:
 4. **Keep gates:** Do NOT skip discovery, design rigor, or AC verification — these remain required
 5. **Handle `autonomous: true`:** If present, auto-advance to next stage on clean pass; suppress exit prompt
 
-**Execution delta when seeded:**
-
-|What's Skipped|Always Kept|
-|-|-|
-|Repo/scope preflights, scope confirmation|Design gate (for build/implementation skills)|
-|Repo-preflight|Severity/depth gates (for review skills)|
-|Internal prior-art search|Rigor gates (for verification skills)|
-
-Each sub-skill documents its own seed-brief-aware behavior in its own file, including what it skips and what it always keeps when seeded.
+Per-specialist skip/keep details live in each skill's own reference file. See `Skill("specialist-mode")` → Execution Delta for the full table.
 
 ## Failure Mode
 

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -98,6 +98,21 @@ For tasks requiring iterative refinement (e.g., Build → Review → Verify):
 - **Hard Stop**: Implement a hard stop at N iterations to prevent infinite loops.
 - **Autonomy**: Use an `autonomous` flag in the seed-brief to signal that the agent should proceed through cycles back-to-back without user intervention.
 
+## NOTES.md Progress Ledger
+
+Orchestrators (and standalone L2 skills) use `.claude/NOTES.md` as their in-phase progress tracker:
+
+- **Create on entry**: Write `## Current task` and initial state when the phase starts.
+- **Checkpoint before spawn**: Before every `Skill()` or `Agent()` call, write the current task, next action, and any open questions. This provides crash recovery if the session dies mid-spawn.
+- **Update on return**: After sub-agent completes, append findings, decisions, and updated task state.
+- **Slice in seed-brief**: Include a `progress` field in the seed-brief payload carrying the relevant NOTES.md slice (task list subset + decisions).
+
+**Ownership model**: Ownership transfers with the running agent. The orchestrator owns NOTES.md before spawn and after return. The spawned sub-skill owns it during execution. Since execution is sequential (spawn → wait → return), there are no concurrent writers.
+
+Standalone L2 skills (called directly by the user, not by an orchestrator) follow the same pattern: create on entry, update during work, leave in place for resume.
+
+See `_shared/notes-md-protocol.md` for the full protocol.
+
 ## Rename Migration
 
 The `/discovery` skill has been renamed to `/discover`.

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -12,7 +12,7 @@ Lead architecture team. Goal: Converge on a technical approach via research, ite
 ## Specialist Mode
 - **Seeded**: Skip codebase and patterns research subagent dispatches.
 - **Keep**: Full architecture session (grill-me + devil's advocate).
-- Invoke `Skill("specialist-mode")`
+Invoke `Skill("specialist-mode")` at entry.
 
 ## I/O
 - **Input**: GitHub issue with problem statement and AC (from /discovery).

--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -26,7 +26,7 @@ Audit open issues for drift. Product: Updated issues themselves (mutate on confi
 - Abort if issue is `closed`.
 
 ### Phase 2 — Per-Issue Audit (Subagent Fan-out)
-Read `${CLAUDE_PLUGIN_ROOT}/_shared/detectors.md` for detector logic, verdict ranking, and JSON schema.
+Read `references/detectors.md` for detector logic, verdict ranking, and JSON schema.
 
 ### Phase 3 — Aggregate & Print
 Concatenate JSON reports. Per-issue block: `─── #NN — <title> — verdict: <v> ───` → URL → findings → proposed edit.

--- a/skills/build/references/steps.md
+++ b/skills/build/references/steps.md
@@ -21,20 +21,13 @@ Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for spawn cost models.
 - **Few work units** (2–3): parallel subagents, one per unit.
 - **Many work units** (4+): parallel subagents; lead coordinates and merges results.
 
-## Specialist Mode
-
-When invoked by `/implement` with a `<seed-brief>` block, skip:
-- repo-preflight (already run; `preflight_verified: true` in brief)
-- scope-preflight
-
-Always keep: the design gate — architecture decisions must be verified cross-phase even when seeded.
-
-Invoke `Skill("specialist-mode")`.
-
 ## Process Steps
 
 ### Step 0 — Pre-flight
 
+Invoke `Skill("specialist-mode")` at entry.
+- **Seeded**: Skip repo/scope preflights, scope confirmation.
+- **Keep**: Design gate (architecture decisions verified cross-phase even when seeded).
 Invoke `Skill("preflight")`.
 Confirmation prompt: "Does this match the repo and branch you intend to work on?"
 

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -11,9 +11,9 @@ allowed-tools: Agent Bash Read
 You lead product discovery. Goal: Deeply understand the problem space via interactive exploration and validation.
 
 ## Specialist Mode
-- **Seeded**: Skip internal prior-art search. Keep PPT and grill-me interactions.
-- **Standalone**: Run all steps.
-- Invoke `Skill("specialist-mode")`
+- **Seeded**: Skip internal prior-art search.
+- **Keep**: PPT and grill-me interactions.
+Invoke `Skill("specialist-mode")` at entry.
 
 ## Scope Assessment
 Read `references/scope-ppt.md` for scope classification, spawn rubric, and PPT checklist.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -11,7 +11,7 @@ Lead design team. Goal: Converge on visual and interaction design that fits exis
 ## Specialist Mode
 - **Seeded**: Skip design-space research subagent.
 - **Keep**: Interactive session (grill-me + a11y review).
-- Invoke `Skill("specialist-mode")`
+Invoke `Skill("specialist-mode")` at entry.
 
 ## I/O
 - **Input**: GitHub issue with architecture decisions (from /define).

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -33,7 +33,7 @@ Suppress branch line: true
 
 **Structure** — invoke `Read ${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for field list:
 - **Preamble**: What, Why, Who (from `/describe`).
-- **Requirements**: Acceptance criteria → Constraints → Prior decisions (optional) → Evidence (optional) → Open questions (optional).
+- Section heading: `## Requirements` — Acceptance criteria → Constraints → Prior decisions (optional) → Evidence (optional) → Open questions (optional).
 
 Present for approval → sign-off → instruct: "Start `/define` in a fresh session."
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -13,6 +13,9 @@ Orchestrate build → review → verify → fix cycles to produce a ready-to-mer
 Read `references/scope-cycles.md` for scope assessment table, autonomous cycle detail, PR creation steps, and finalize logic.
 
 ## Pre-flight
+Invoke `Skill("specialist-mode")` at entry.
+- **Seeded**: Orchestrator drives the pipeline; outer user-facing prompts suppressed.
+- **Keep**: Exhausted-exit prompt (unless `autonomous: true`; see `references/scope-cycles.md § Finalize`).
 1. Invoke `Skill("preflight")` at entry (pass `suppress branch line: true`).
 2. If >= 3 files changed, run the scope checks within `preflight` again. Pass `preflight_verified: true` in seed-briefs.
 

--- a/skills/orchestrator-rules/SKILL.md
+++ b/skills/orchestrator-rules/SKILL.md
@@ -24,7 +24,12 @@ See `Skill("specialist-mode")` for Seed-brief shape and field requirements. Each
 
 ## Progress tracking via NOTES.md
 
-Orchestrators use `.claude/NOTES.md` as the in-phase progress ledger. Read `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` § Orchestrator checkpoint pattern for the full protocol.
+Orchestrators use NOTES.md as the progress ledger for multi-step pipelines that delegate to sub-agents. The pattern:
+
+1. **Create** — On entry (after preflight), create NOTES.md with the full task list derived from work units.
+2. **Checkpoint before sub-agent spawn** — Write `## Current task` (what the sub-agent will do) and `## Next action on resume` (how to reconstruct if session dies) before every `Skill()` or `Agent()` call. This ensures crash-safe resume.
+3. **Update after sub-agent returns** — The sub-skill may have written its own progress, decisions, and task updates to NOTES.md while it ran. Read the file, integrate its results, flip checkboxes, and log any new decisions. The orchestrator's view is authoritative for the overall pipeline; the sub-skill's entries are intermediate working state.
+4. **Wrap-up** — On clean exit, leave NOTES.md in place for the phase-ending skill to harvest. On abnormal exit, NOTES.md serves as the resume point.
 
 ### On entry
 
@@ -37,7 +42,30 @@ After preflight, create NOTES.md with:
 
 1. Write `## Current task` with what the sub-agent will do.
 2. Write `## Next action on resume` with the exact command that would reconstruct state.
-3. Include a NOTES.md slice in the seed-brief payload (`progress:` field) — see notes-md-protocol.md § Seed-brief slice for format and cap.
+3. Include a NOTES.md slice in the seed-brief payload (`progress:` field) so the agent arrives with progress context:
+
+```
+<seed-brief>
+...
+payload:
+  type: research
+  progress: |
+    ## Task list (relevant)
+    - [x] Scope assessment → 3 work units
+    - [ ] Build specialist (current)
+    - [ ] Review specialist
+
+    ## Decisions made this session
+    - Split auth into own work unit (why: security isolation)
+  open_questions: ""
+</seed-brief>
+```
+
+Slice rules:
+- Include only the subset of `## Task list` relevant to the spawned agent's scope.
+- Include `## Decisions made this session` in full (decisions are global to the phase).
+- Omit `## Current task` (the agent will set its own).
+- Cap at 15 lines — the brief is not a state dump.
 
 ### After sub-agent returns
 

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -24,7 +24,7 @@ Audit skill authoring quality and dead state in `~/.claude/`. Archive approved c
 
 Each spawn prompt must include: `lane` (authoring|dead-state), `cwd` (absolute project root path), `files` (pre-enumerated list above). Each must start with `cd <cwd> && pwd`.
 
-Read `${CLAUDE_PLUGIN_ROOT}/_shared/audit-checks.md` for Authoring Lane checks and Dead-state Lane classes.
+Read `references/audit-checks.md` for Authoring Lane checks and Dead-state Lane classes.
 
 ## Aggregation & Archive
 

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -37,7 +37,7 @@ Group by category → Present triage summary to user.
 
 ### Phase 4 — Reply
 **Delegate reply drafting**: One sub-agent per thread (reply text only). Prompt: `cd <abs-path> && pwd`.
-Read `${CLAUDE_PLUGIN_ROOT}/_shared/verdicts.md` for verdict/reply mapping and mutation logic.
+Read `references/verdicts.md` for verdict/reply mapping and mutation logic.
 
 ## Output
 Summary: Total threads → counts per verdict → commits created → threads needing human attention.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -11,8 +11,8 @@ Lead review phase. Goal: Thoroughly review implementation and produce actionable
 
 ## Specialist Mode
 - **Seeded**: Skip repo-preflight.
-- **Keep**: Severity/finding-depth gates (rigor is not delegated).
-- Invoke `Skill("specialist-mode")`
+- **Keep**: Severity/depth gates (rigor not delegated).
+Invoke `Skill("specialist-mode")` at entry.
 
 ## Specialist Assessment
 

--- a/skills/specialist-mode/SKILL.md
+++ b/skills/specialist-mode/SKILL.md
@@ -27,21 +27,6 @@ Logic for standalone vs. orchestrator-invoked (seeded) execution.
 
 **Failure**: Invalid brief → Fallback to standalone + log failure.
 
-## Execution Delta
-
-Confirmations verifying *state* are skipped; *discovery/rigor* gates remain.
-
-|Specialist|Skipped when Seeded|Always Kept|
-|-|-|-|
-|`/build`|repo/scope preflights, scope confirmation|design gate|
-|`/review`|repo-preflight|severity/depth gates|
-|`/verify`|repo-preflight|AC verification rigor|
-|`/describe`|internal prior-art search|PPT, grill-me|
-|`/specify`|scope/file confirmation|AC derivation gates|
-|`/architecture`|codebase/pattern research|architecture session (grill-me/devil's advocate)|
-|`/design`|design-space research|interactive session|
-|`/implement`|(handled by orchestrator)|exhausted-exit prompt (unless `autonomous: true`)|
-
 ## Autonomous Implement Invocation
 
 Canonical seed-brief for orchestrators that spawn `/implement` with `autonomous: true`:

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -10,9 +10,9 @@ model: sonnet
 Lead requirements team. Goal: Transform problem statements into testable, non-vague AC.
 
 ## Specialist Mode
-- **Seeded**: Skip file-scope confirmations.
-- **Keep**: AC derivation gates (quality is not delegated).
-- Invoke `Skill("specialist-mode")`
+- **Seeded**: Skip scope/file confirmations.
+- **Keep**: AC derivation gates (quality not delegated).
+Invoke `Skill("specialist-mode")` at entry.
 
 ## I/O
 - **Input**: Problem statement (from /describe) or user description.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -11,8 +11,8 @@ Lead verification phase. Goal: Verify every AC from the issue is met with eviden
 
 ## Specialist Mode
 - **Seeded**: Skip repo-preflight.
-- **Keep**: AC verification rigor (pass/fail evidence is never delegated).
-- Invoke `Skill("specialist-mode")`
+- **Keep**: AC verification rigor (pass/fail evidence never delegated).
+Invoke `Skill("specialist-mode")` at entry.
 
 ## I/O
 - **Input**: Branch + GitHub issue number.


### PR DESCRIPTION
## Summary
Final cleanup for the v2 refactoring (#125).
### Changes
- **fix(terminology)**: Renamed remaining "memory tier" → "memory layer" across `_shared/notes-md-protocol.md`, `README.md`, and `CHANGELOG.md`
- **docs(authoring)**: Added NOTES.md Progress Ledger section documenting the ownership-transfer model (orchestrator owns before spawn/after return, sub-skill owns during execution), Orchestrator Checkpoint pattern, and Seed-brief Slice pattern
- **docs(changelog)**: Added entries for NOTES.md protocol broadened, terminology standardization, and shared docs decoupling
### Files changed
- `_shared/notes-md-protocol.md` — 4 tier→layer renames-
-  `README.md` — 1 tier→layer rename
- `CHANGELOG.md` — 3 new entries, tier→layer fix in existing entry
- `_templates/AUTHORING.md` — new NOTES.md Progress Ledger sectionCloses #125