### PR TITLE
feat: decouple shared docs — move per-skill details into owning skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ GitHub Releases (with auto-generated notes and source tarballs) remain the canon
 
 ### Changed
 
+- **Shared docs refactored (v2/shared-refactor)** -- per-skill details moved out of `_shared/` protocol docs into the skills that own them:
+
+  - **`_shared/handoff-artifact.md`** trimmed to the general five-field protocol (purpose, shape, precedence, rules). Section-heading names (`## Requirements` for `/discovery`, `## Implementation plan` for `/define`) and the final-pass checklist inlined into their respective skill files. (#v2/shared-refactor)
+
+  - **`_shared/seed-brief.md`** trimmed to the universal protocol spec (purpose, format, required fields, orchestrator duties, specialist behavior, failure mode). Payload type definitions (`type: research`, `type: fix`, `type: prior-art`) and the canonical example moved to `skills/specialist-mode/SKILL.md`. (#v2/shared-refactor)
+
+  - **Per-skill handoff instructions added**: `/discovery` now declares its `## Requirements` section heading and final-pass checklist inline; `/define` declares its `## Implementation plan` heading and field requirements. (#v2/shared-refactor)
+
+  - **README**: Added `seed-brief.md` to the `_shared/` protocol table; updated `handoff-artifact.md` description to reflect the protocol-only scope.
+
 - **NOTES.md protocol broadened** -- ownership model shifted from "orchestrator-only" to ownership-transfer (orchestrator owns before spawn / after return, sub-skill owns during execution). Standalone L2 skills now use NOTES.md for their own multi-step tracking. Adds Orchestrator Checkpoint pattern (create on entry, checkpoint before spawn, update on return) and Seed-brief Slice pattern (progress field in seed-brief payload). (#v2/orchestrator-progress-ledger)
 
 - **Terminology standardized** -- all "tier" references in shared docs renamed to "layer" for consistency with the three-layer taxonomy. Affected files: _shared/notes-md-protocol.md (memory tier -> memory layer), README.md.

--- a/README.md
+++ b/README.md
@@ -158,10 +158,11 @@ Shared protocols at `_shared/`:
 |-|-|
 |`compaction-protocol.md`|Context editing → delegation → /compact order|
 |`composition.md`|Multi-skill composition patterns and contracts|
-|`handoff-artifact.md`|Five-field GitHub issue handoff structure|
+|`handoff-artifact.md`|Five-field GitHub issue handoff protocol; per-skill section headings defined in each producing skill|
 |`interviewing-rules.md`|One-question-at-a-time interview protocol|
 |`notes-md-protocol.md`|In-phase NOTES.md memory layer|
 |`orchestrator-rules.md`|Shared rules for pipeline orchestrators: CWD verification, delegation, no-autonomous-merge, seed-brief contract|
+|`seed-brief.md`|Spawn-time context packaging (YAML-in-XML) for orchestrator→specialist handoff; payload types defined in `specialist-mode`|
 
 ## Releasing
 

--- a/_shared/handoff-artifact.md
+++ b/_shared/handoff-artifact.md
@@ -1,16 +1,16 @@
-# Handoff Artifact — Shared Template
+# Handoff Artifact — Protocol
 
 Phase-boundary skills hand off state by updating the GitHub issue body. Read on-demand at handoff steps; do not preload.
 
-The terminal phase-ending skill outputs the PR, not an issue body update.
+Each skill that produces a handoff artifact documents its own section heading and field requirements in its own file.
 
 ## The five fields
 
-1. **Acceptance criteria** — testable scenarios from the discovery phase, unchanged. One line each. **Mandatory.**
-2. **Constraints** — files in scope/out of scope, non-negotiable decisions from the definition phase. **Mandatory.**
-3. **Prior decisions** — "chose X over Y because Z" entries with links to conversation/code. One line each. *(Optional — omit when empty.)*
-4. **Evidence** — links to commits, PRs, benchmarks, reviews, or approvals justifying decisions. *(Optional — omit when empty.)*
-5. **Open questions** — things next phase must resolve. Explicit, no "obviously will figure out later". *(Optional — omit when empty.)*
+1. **Acceptance criteria** — testable scenarios, unchanged from prior phase. One line each. **Mandatory.**
+2. **Constraints** — files in scope/out of scope, non-negotiable decisions. **Mandatory.**
+3. **Prior decisions** — "chose X over Y because Z" entries with links to conversation/code. *(Optional — omit when empty.)*
+4. **Evidence** — links to commits, PRs, benchmarks, reviews, or approvals. *(Optional — omit when empty.)*
+5. **Open questions** — things next phase must resolve. *(Optional — omit when empty.)*
 
 ## Shape
 
@@ -23,7 +23,7 @@ Section heading is phase-specific — each skill specifies it (e.g. `## Requirem
 ```markdown
 ## <section heading>
 
-**Acceptance criteria** (from discovery, unchanged)
+**Acceptance criteria** (from prior phase, unchanged)
 - AC1: ...
 - AC2: ...
 

--- a/_shared/seed-brief.md
+++ b/_shared/seed-brief.md
@@ -47,43 +47,10 @@ payload:
 |`repo`|string|Format: `owner/repo`. Verified against `git remote -v` by orchestrator before spawning.|
 |`branch`|string|Format: `feat/<slug>`. Verified against `git rev-parse --abbrev-ref HEAD` by orchestrator.|
 |`active_issue`|int|GitHub issue ID (positive integer). Used for sanity checks and issue-link context.|
-|`payload`|object|Research, prior art, findings, or constraints. Shape depends on `payload.type` (see § Payload Types).|
+|`payload`|object|Research, prior art, findings, or constraints. Shape depends on `payload.type` (see `Skill("specialist-mode")` § Payload Types).|
 |`autonomous`|bool|Optional; default `false`. If `true`, suppresses exit/continuation prompts in the phase-ending skill.|
 
-## Payload Types
-
-The `payload` field is a dict with a required `type` key and type-specific contents:
-
-### `type: research`
-```yaml
-payload:
-  type: research
-  prior_art: "<Issue implementation plan, architecture, and design decisions>"
-  progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
-  open_questions: "<Unresolved constraints or empty string>"
-```
-Used to spawn a build or implementation sub-skill. Contains high-level architecture decisions and known constraints. The optional `progress` field carries intra-orchestrator state from NOTES.md so the sub-agent arrives with task context.
-
-### `type: fix`
-```yaml
-payload:
-  type: fix
-  failing_ac: "<Failed acceptance criterion(s)>"
-  findings: "file.js:42 — function does not handle edge case\nfile.ts:15 — type mismatch"
-  prior_decisions: "<Prior architectural decisions or design constraints>"
-  progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
-```
-Used when spawning a specialist to fix a specific failure. Contains line-specific findings and the AC to address. The optional `progress` field carries intra-orchestrator state from NOTES.md.
-
-### `type: prior-art`
-```yaml
-payload:
-  type: prior-art
-  problem_domain: "<Brief problem statement>"
-  existing_patterns: "<Codebase patterns, libraries, or conventions relevant to this task>"
-  constraints: "<Non-negotiable constraints from requirements or architecture>"
-```
-Used for research or exploration tasks where codebase patterns are critical context.
+Each skill documents its own payload types and usage in its own file. See `Skill("specialist-mode")` for the canonical contract and payload type definitions.
 
 ## Orchestrator Duties
 

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -31,7 +31,7 @@ Per scope-assessment output:
 Invoke `Skill("preflight")` before `gh issue`.
 Suppress branch line: true
 
-**Structure** — invoke `Read ${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for field list:
+**Structure** — use the `## Requirements` section heading. Invoke `Read ${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md` for field list:
 - **Preamble**: What, Why, Who (from `/describe`).
 - Section heading: `## Requirements` — Acceptance criteria → Constraints → Prior decisions (optional) → Evidence (optional) → Open questions (optional).
 

--- a/skills/specialist-mode/SKILL.md
+++ b/skills/specialist-mode/SKILL.md
@@ -9,6 +9,7 @@ Logic for standalone vs. orchestrator-invoked (seeded) execution.
 ## Detection
 
 `specialist_mode = True` if `<seed-brief>` block exists in prompt.
+
 - **Seeded**: Verified fields replace preflights.
 - **Standalone**: All prompts active.
 
@@ -22,10 +23,51 @@ Logic for standalone vs. orchestrator-invoked (seeded) execution.
 |`repo`|string|Yes|`owner/repo` (verified vs `git remote -v`)|
 |`branch`|string|Yes|`feat/<slug>` (verified vs `git rev-parse`)|
 |`active_issue`|int|Yes|GitHub issue ID|
-|`payload`|object|Yes|`{ type: fix\|research\|prior-art, ... }` (see `${CLAUDE_PLUGIN_ROOT}/_shared/seed-brief.md` for payload types)|
+|`payload`|object|Yes|`{ type: fix\|research\|prior-art, ... }` (see § Payload Types below)|
 |`autonomous`|bool|No|Default `false`. If `true`, suppresses `/implement` exit prompt|
 
 **Failure**: Invalid brief → Fallback to standalone + log failure.
+
+### Payload Types
+
+The `payload` field is a dict with a required `type` key and type-specific contents. Examples:
+
+#### `type: research`
+
+Used to spawn a build or implementation sub-skill. Contains high-level architecture decisions and known constraints. The optional `progress` field carries intra-orchestrator state from NOTES.md so the sub-agent arrives with task context.
+
+```yaml
+payload:
+  type: research
+  prior_art: "<Issue implementation plan, architecture, and design decisions>"
+  progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
+  open_questions: "<Unresolved constraints or empty string>"
+```
+
+#### `type: fix`
+
+Used when spawning a specialist to fix a specific failure. Contains line-specific findings and the AC to address. The optional `progress` field carries intra-orchestrator state from NOTES.md.
+
+```yaml
+payload:
+  type: fix
+  failing_ac: "<Failed acceptance criterion(s)>"
+  findings: "file.js:42 — function does not handle edge case\nfile.ts:15 — type mismatch"
+  prior_decisions: "<Prior architectural decisions or design constraints>"
+  progress: "<NOTES.md slice — task list subset + decisions; see notes-md-protocol.md § Seed-brief slice>"
+```
+
+#### `type: prior-art`
+
+Used for research or exploration tasks where codebase patterns are critical context.
+
+```yaml
+payload:
+  type: prior-art
+  problem_domain: "<Brief problem statement>"
+  existing_patterns: "<Codebase patterns, libraries, or conventions relevant to this task>"
+  constraints: "<Non-negotiable constraints from requirements or architecture>"
+```
 
 ## Autonomous Implement Invocation
 


### PR DESCRIPTION
## Summary

Decouples the `_shared/` protocol docs by moving per-skill details into the skills that own them. This is the next step after the layer-3 boundary realignment (#156) and terminology cleanup (#159).

### Changes

- **`_shared/handoff-artifact.md`** — trimmed to protocol-only (five-field format, shape, precedence, rules). Removed phase-specific section heading names and final-pass checklist; these are now inline in each producing skill.
- **`_shared/seed-brief.md`** — trimmed to universal protocol spec. Payload type definitions (`type: research`, `type: fix`, `type: prior-art`) and canonical example moved to `skills/specialist-mode/SKILL.md`.
- **`skills/discovery/SKILL.md`** — added `## Requirements` section heading and final-pass checklist inline.
- **`skills/define/SKILL.md`** — cleaned handoff instructions to reference the five-field format and `## Implementation plan` heading.
- **`skills/implement/SKILL.md`** — clarified section heading origins (`## Requirements` from discovery, `## Implementation plan` from define).
- **`skills/specialist-mode/SKILL.md`** — added Payload Types section (moved from seed-brief) and Execution Delta table documenting seeded vs standalone behavior per specialist.
- **`README.md`** — added `seed-brief.md` to the `_shared/` protocol table; updated `handoff-artifact.md` description.
- **`CHANGELOG.md`** — added shared docs refactored entry.

Closes #125