### PR TITLE
feat: add user-invocable frontmatter and caller contracts to simple L2 skills

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -5,6 +5,8 @@ when_to_use: Use to produce architectural decisions for a feature. Invoked by /d
 model: opus
 effort: high
 allowed-tools: Agent Bash Read WebSearch WebFetch
+layer: 2
+user-invocable: true
 ---
 ## Role & Constraints
 Lead architecture team. Goal: Converge on a technical approach via research, iterative analysis, and critique.
@@ -38,6 +40,10 @@ Invoke `Skill("specialist-mode")` at entry.
    - Code structure preview (dirs/interfaces).
    - Rationale for recommendation.
 4. **Deepening**: Scan for vague language or thin sections → dispatch focused deepening agents (<= 2 rounds).
+
+## Caller Contract
+
+Called by `/define` during the Definition phase. Can run standalone. Produces architectural decisions (components, data flow, APIs, dependencies). Hands off to `/design` via GitHub issue body under `## Implementation plan`.
 
 ## Rules
 - **Code-First**: Never propose architecture without reading existing code.

--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -6,6 +6,8 @@ argument-hint: "[issue# | description]"
 model: opus
 effort: high
 allowed-tools: Agent Bash Read
+layer: 2
+user-invocable: true
 ---
 ## Role & Constraints
 You lead product discovery. Goal: Deeply understand the problem space via interactive exploration and validation.
@@ -41,6 +43,10 @@ Read `references/scope-ppt.md` for scope classification, spawn rubric, and PPT c
 - **Boundaries**: In-scope vs Out-of-scope.
 
 → Handoff to `/specify` for requirements.
+
+## Caller Contract
+
+Called by `/discovery` during the Discovery phase. Can also run standalone before `/specify`. Produces a shared understanding of the problem (user stories, visualizations). Hands off to `/define` via GitHub issue body under `## Requirements`.
 
 ## Rules
 - Recommend an answer for every question.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -4,6 +4,8 @@ description: Explore visual and UX design (UI layouts, interaction flows, compon
 when_to_use: Use to produce UI/UX design decisions. Invoked by /define; can run standalone.
 model: sonnet
 allowed-tools: Agent Bash Read
+layer: 2
+user-invocable: true
 ---
 ## Role & Constraints
 Lead design team. Goal: Converge on visual and interaction design that fits existing systems.
@@ -38,6 +40,10 @@ Invoke `Skill("specialist-mode")` at entry.
 ## Applicability
 - **Apply**: Visual aspects (UI, frontend, webview).
 - **Skip**: Purely backend/infra work (use `/architecture` instead).
+
+## Caller Contract
+
+Called by `/define` after `/architecture`. Can run standalone. Produces UI/UX design decisions. Hands off to `/implement` via GitHub issue body under `## Implementation plan`.
 
 ## Rules
 - **Consistency**: Follow existing design system/component patterns unless diverging.

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -5,10 +5,16 @@ when_to_use: Use when the user asks whether Claude can do something or wants to 
 model: haiku
 effort: low
 allowed-tools: Agent Bash WebFetch WebSearch
+layer: 2
+user-invocable: true
 ---
 Discover and install skills from the open agent ecosystem.
 
 Discovery sub-agent (haiku) for search + leaderboard fetch (payoff ≥3×; retrieval-only). Main thread: confirmation + install. Spawn prompt: `cd <cwd> && pwd`.
+
+## Caller Contract
+
+User-invocable standalone skill. Not called by any orchestrator. Discovers and installs skills from the registry.
 
 ## When to Use This Skill
 

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -3,6 +3,8 @@ name: specify
 description: Turn a problem statement into precise, testable acceptance criteria.
 when_to_use: Use after /describe. Invoked by /discovery; can run standalone.
 model: sonnet
+layer: 2
+user-invocable: true
 ---
 <!-- Stays inline: interactive — requires back-and-forth with user. -->
 
@@ -36,6 +38,10 @@ Invoke `Skill("specialist-mode")` at entry.
    - Requirement matrices (feature × scenario).
    - State diagrams for stateful behavior.
 6. **Prioritization**: Categorize as must-have vs. nice-to-have.
+
+## Caller Contract
+
+Called by `/discovery` after `/describe`. Can run standalone after a problem statement exists. Produces testable acceptance criteria. Hands off to `/define` via GitHub issue body under `## Requirements`.
 
 ## Rules
 - **Zero Vagueness**: No "fast", "user-friendly", or "appropriate". Every AC must be testable.


### PR DESCRIPTION
## Summary

Adds `user-invocable: true` frontmatter and explicit caller contract sections to 5 simple L2 skills per the v2 rebuild conventions (#138-#147).

### Changes

- **describe, specify, architecture, design, find-skills** — added `user-invocable: true` to frontmatter and documented caller contracts (who calls them, when, what they produce, where they hand off).

Part of #125 v2 rebuild track.
