### PR TITLE
feat: add user-invocable frontmatter and caller contracts to review/verify/build

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -11,6 +11,10 @@ allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ---
 You are leading the build phase. Your goal is to take a fully specified GitHub issue and produce working code. Builds a feature from a GitHub issue using TDD. Produces implementation code in a worktree. Hands off via the worktree.
 
+## Caller Contract
+
+Called by `/implement` during the implementation cycle. Can run standalone with an issue number. Builds a feature from a GitHub issue using TDD. Produces implementation code in a worktree. Hands off to `/review` via the worktree.
+
 ## Input
 
 A GitHub issue number (with architecture/design decisions from /define) and any additional resources.

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -33,6 +33,10 @@ Read `references/dispatch-process.md` for dispatch modes, process steps, and PR 
 - **Always-on**: Correctness, Standards.
 - **Conditional**: Security, Performance, Migration, Docs Consistency, Architecture/Scope-creep. (Activate only if gate fires).
 
+## Caller Contract
+
+Called by `/implement` during the implementation cycle. Can run standalone with a PR URL. Reviews implementation against requirements. Produces inline GitHub review comments. Hands off findings to `/implement` via seed-brief for fix cycles.
+
 ## Rules
 - **Separation**: Never fix issues during review. Report findings in the review output; fixes happen in a subsequent `/build` cycle.
 - **Consensus**: All reviewers must agree before finalizing.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -33,6 +33,10 @@ Invoke `Skill("scope-assessment")` with work units — one per AC group. Receive
 
 Split AC across QA agents per `scope-assessment` output → each verifies independently → converge on unified report. Any activated specialists verify their domain-specific AC alongside the QA agents.
 
+## Caller Contract
+
+Called by `/implement` during the implementation cycle. Can run standalone with an issue number. QA-verifies implementation against acceptance criteria. Reports pass/fail per criterion. Hands off findings to `/implement` via seed-brief for fix cycles.
+
 ## Rules
 - **Separation**: Never fix issues during verification. Report failures in the verify output; fixes are a `/build` responsibility.
 - **Evidence-Based**: No "it works" — every criterion needs evidence.


### PR DESCRIPTION
## Summary

Adds `user-invocable: true` frontmatter and explicit caller contract sections to 3 medium-complexity L2 skills (review, verify, build) per the v2 rebuild conventions (#138-#147).

### Changes

- **review, verify, build** — added `user-invocable: true` to frontmatter and documented caller contracts (who calls them, when, what they produce, where they hand off). These skills already invoke L3 protocols via `Skill()`.

Part of #125 v2 rebuild track.
