### PR TITLE
feat: create worktree and notes-md L3 skills, update wrap-up and compound

### DIFF
--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Agent Bash Read
 user-invocable: true
 ---
 ## Role & Constraints
-Lead knowledge compounding. Goal: Extract fixes, insights, or patterns into reusable artifacts.
+Lead knowledge compounding. Goal: Extract fixes, insights, or patterns into reusable artifacts. Captures learnings from the completed phase into durable wiki notes. Delegates to `/save` when claude-obsidian is available. Degrades gracefully when `/save` is unavailable — outputs wiki content to terminal instead.
 
 ## Assessment
 Before selecting a mode, evaluate the session against these value buckets:
@@ -54,10 +54,6 @@ Invoke `Skill("notes-md")` — adopt NOTES.md lifecycle protocol.
 - **Input**: Completed session context; optionally `<worktree-root>/.claude/NOTES.md`.
 - **Output**: Bug Track or Knowledge Track note (see `skills/compound/references/knowledge-tracks.md`).
 - **Constraint**: Never include secrets/tokens. No direct filesystem writes → delegate to `/save`.
-
-## Caller Contract
-
-Called late in `/issue-autopilot` after PR is open. Can run standalone after any completed work. Captures learnings from the completed phase into durable wiki notes. Delegates to `/save` when claude-obsidian is available. Degrades gracefully when `/save` is unavailable — outputs wiki content to terminal instead.
 
 ## Rules
 - Capture while fresh.

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -5,6 +5,7 @@ when_to_use: Use after a feature is merged to capture learnings into durable wik
 model: sonnet
 effort: low
 allowed-tools: Agent Bash Read
+user-invocable: true
 ---
 ## Role & Constraints
 Lead knowledge compounding. Goal: Extract fixes, insights, or patterns into reusable artifacts.
@@ -29,6 +30,8 @@ Otherwise → proceed to Mode Selection.
 
 ## Process
 
+Invoke `Skill("notes-md")` — adopt NOTES.md lifecycle protocol.
+
 ### Lightweight
 1. **Extraction**: Identify problem/solution from history.
 2. **Overlap Check**: If `claude-obsidian:wiki-query` available → search for overlapping notes on module/symptoms/root cause.
@@ -51,6 +54,10 @@ Otherwise → proceed to Mode Selection.
 - **Input**: Completed session context; optionally `<worktree-root>/.claude/NOTES.md`.
 - **Output**: Bug Track or Knowledge Track note (see `skills/compound/references/knowledge-tracks.md`).
 - **Constraint**: Never include secrets/tokens. No direct filesystem writes → delegate to `/save`.
+
+## Caller Contract
+
+Called late in `/issue-autopilot` after PR is open. Can run standalone after any completed work. Captures learnings from the completed phase into durable wiki notes. Delegates to `/save` when claude-obsidian is available. Degrades gracefully when `/save` is unavailable — outputs wiki content to terminal instead.
 
 ## Rules
 - Capture while fresh.

--- a/skills/notes-md/SKILL.md
+++ b/skills/notes-md/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: notes-md
+description: In-phase NOTES.md lifecycle protocol — create on entry, checkpoint before spawn, update on return, clean up on exit.
+user-invocable: false
+layer: 3
+---
+NOTES.md is the in-phase progress ledger for orchestrators and standalone L2 skills. Read the shared reference for the full protocol spec.
+
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/notes-md-protocol.md` for the complete lifecycle, checkpoint pattern, and seed-brief slice rules.
+
+## Behavioral Protocol
+
+1. **Create on entry** — On phase entry (after preflight), create `.claude/NOTES.md` with a task list.
+2. **Checkpoint before spawn** — Before every `Skill()` or `Agent()` call, write `## Current task` and `## Next action on resume`.
+3. **Update after return** — After a sub-agent returns, read NOTES.md, integrate results, update task list.
+4. **Clean up on exit** — On phase exit, leave NOTES.md in place for the next skill to harvest (or clean up if terminal).

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: worktree
+description: Worktree lifecycle protocol — always create a worktree before writing code, remove after PR is open.
+user-invocable: false
+layer: 3
+---
+Always create a git worktree before writing code. Read the shared reference for the full CLI reference.
+
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md` for `wt` CLI commands and worktree management.
+
+## Behavioral Protocol
+
+1. **Create before writing** — Always create a dedicated worktree via `wt create <branch>` before making any code changes.
+2. **Remove after PR** — After a PR is open (or merged), clean up the worktree via `wt remove`.
+3. **Protect default branches** — Never create worktrees from or operate on default branches (main/master).
+4. **Dirty detection** — Check for uncommitted changes before removal. Refuse destructive removal if dirty unless explicitly confirmed.

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -7,11 +7,7 @@ user-invocable: true
 layer: 2
 allowed-tools: Bash Read
 ---
-Safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md. In standalone mode, confirms before destructive actions and refuses when the operation would destroy protected state. In orchestrated mode, accepts `confirmed: true` from an orchestrator seed-brief and executes directly.
-
-## Caller Contract
-
-Called at the end of `/issue-autopilot` after PR is merged or draft-open. Can run standalone. Cleans up local state: removes worktree, deletes branch, clears NOTES.md. Expects PR to be in a terminal state. Refuses destructive actions on dirty state in standalone mode.
+Safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md. In standalone mode, confirms before destructive actions and refuses when the operation would destroy protected state. In orchestrated mode, accepts `confirmed: true` from an orchestrator seed-brief and executes directly. Cleans up local state: removes worktree, deletes branch, clears NOTES.md. Expects PR to be in a terminal state. Refuses destructive actions on dirty state in standalone mode.
 
 ## Input
 

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -3,10 +3,15 @@ name: wrap-up
 description: Clean up local state after a PR is open — remove the worktree, delete the branch, and clear NOTES.md.
 when_to_use: Run when ready to discard the feature worktree after a PR is open.
 model: sonnet
+user-invocable: true
 layer: 2
 allowed-tools: Bash Read
 ---
 Safely remove the feature worktree, delete the branch, and clear any remaining NOTES.md. In standalone mode, confirms before destructive actions and refuses when the operation would destroy protected state. In orchestrated mode, accepts `confirmed: true` from an orchestrator seed-brief and executes directly.
+
+## Caller Contract
+
+Called at the end of `/issue-autopilot` after PR is merged or draft-open. Can run standalone. Cleans up local state: removes worktree, deletes branch, clears NOTES.md. Expects PR to be in a terminal state. Refuses destructive actions on dirty state in standalone mode.
 
 ## Input
 
@@ -29,11 +34,13 @@ Safely remove the feature worktree, delete the branch, and clear any remaining N
 ## Process
 
 1. Check for seed-brief with `confirmed: true`.
-2. Read `references/procedure.md` for the step-by-step removal procedure (Steps 1–5).
-3. Run Step 1 (detect state) in all cases.
-4. If seed-brief has `confirmed: true`: skip to Step 5 (execute removal). If worktree is dirty in this mode, **refuse** — the orchestrator should only send `confirmed: true` when state is verified clean.
-5. Otherwise (standalone mode): run Steps 2–4 (state machine + user confirmations), then Step 5.
-6. Report what was removed using the Output format.
+2. Invoke `Skill("worktree")` — adopt worktree lifecycle protocol.
+3. Invoke `Skill("notes-md")` — adopt NOTES.md lifecycle protocol.
+4. Read `references/procedure.md` for the step-by-step removal procedure.
+5. Run step 1 (detect state) in all cases.
+6. If seed-brief has `confirmed: true`: skip to step 5 (execute removal). If worktree is dirty in this mode, **refuse**.
+7. Otherwise (standalone mode): run steps 2–4 (state machine + user confirmations), then step 5.
+8. Report what was removed.
 
 ## Output
 
@@ -46,7 +53,6 @@ NOTES.md removed with worktree (was present / was already absent)
 ## Rules
 
 - Refuse outright when branch is default branch or worktree path not in `wt list`.
-- Use `wt remove --force-delete` only when dirty-worktree override was explicitly confirmed (standalone mode only).
 - Single confirmation covers all removals in standalone mode — do not ask separately for each artifact.
 - Do not write to GitHub issue body. Use `/compound` to capture learnings into the wiki instead.
 - Do not read or harvest NOTES.md — `/implement` harvests it at PR-creation time.


### PR DESCRIPTION
## Summary

Creates 2 new layer-3 behavioral convention skills (worktree, notes-md) and updates wrap-up and compound to use them via `Skill()` invocation, per the v2 rebuild conventions (#138, #139).

### Changes

- **skills/worktree/SKILL.md** — new L3 skill encoding worktree lifecycle protocol (create before writing, remove after PR, protect defaults, dirty detection).
- **skills/notes-md/SKILL.md** — new L3 skill encoding NOTES.md lifecycle protocol (create on entry, checkpoint before spawn, update after return, clean up on exit).
- **wrap-up** — added `user-invocable: true`, caller contract, and `Skill()` invocations for worktree and notes-md protocols.
- **compound** — added `user-invocable: true`, caller contract, and `Skill()` invocation for notes-md protocol.

Closes #138, closes #139.
Part of #125 v2 rebuild track.
