### PR TITLE
feat: rebuild describe and specify as v2 L2 sub-skills

### DIFF
--- a/skills/describe/SKILL.md
+++ b/skills/describe/SKILL.md
@@ -9,8 +9,10 @@ allowed-tools: Agent Bash Read
 layer: 2
 user-invocable: true
 ---
+Lead product discovery. Explores problems interactively, builds shared understanding via visualizations and user stories, and hands off structured problem statements to /specify.
+
 ## Role & Constraints
-You lead product discovery. Goal: Deeply understand the problem space via interactive exploration and validation. Produces a shared understanding of the problem (user stories, visualizations). Hands off via GitHub issue body under `## Requirements`.
+Goal: Deeply understand the problem space via interactive exploration and validation. Produces a shared understanding of the problem (user stories, visualizations). Hands off via GitHub issue body under `## Requirements`.
 
 ## Specialist Mode
 - **Seeded**: Skip internal prior-art search.
@@ -19,30 +21,26 @@ Invoke `Skill("specialist-mode")` at entry.
 
 ## Scope Assessment
 Read `references/scope-ppt.md` for scope classification, spawn rubric, and PPT checklist.
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for team sizing and composition patterns.
+
+## I/O
+- **Input**: Issue reference or problem description from user.
+- **Output**: Structured problem statement (What, Why, Who, Boundaries). Handoff to `/specify`.
 
 ## Process
 
 ### Multi-area or complex problem
-1. **Elicitation**: Ask user for problem/goal.
-2. **Exploration**: Dispatch agents → Lead analyst runs interactively via `/grill-me`.
-3. **PPT**: Run Product Pressure Test (see `references/scope-ppt.md`) before synthesizing.
-4. **Visualization**: Produce Mermaid/ASCII for user journeys, feature comparisons, system boundaries.
-5. **Validation**: Confirm understanding of each visual.
-6. **Synthesis**: Create structured problem statement.
+1. **Elicitation** — Ask user for problem/goal.
+2. **Exploration** — Dispatch agents via `/grill-me` for interactive analysis.
+3. **PPT** — Run Product Pressure Test (see `references/scope-ppt.md`) before synthesizing.
+4. **Visualization** — Produce Mermaid/ASCII for user journeys, feature comparisons, system boundaries.
+5. **Validation** — Confirm understanding of each visual.
+6. **Synthesis** — Create structured problem statement.
 
 ### Narrow, single-area problem
 1. Confirm problem/outcome.
 2. Brief codebase validation.
 3. Direct problem statement production.
-
-## I/O
-**Output**: Structured problem statement:
-- **What**: 1-2 sentence summary.
-- **Why**: Problem it solves.
-- **Who**: Target user/persona.
-- **Boundaries**: In-scope vs Out-of-scope.
-
-→ Handoff to `/specify` for requirements.
 
 ## Rules
 - Recommend an answer for every question.

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -8,8 +8,10 @@ user-invocable: true
 ---
 <!-- Stays inline: interactive — requires back-and-forth with user. -->
 
+Lead requirements team. Transforms problem statements into testable, non-vague acceptance criteria. Hands off via GitHub issue body under `## Requirements`.
+
 ## Role & Constraints
-Lead requirements team. Goal: Transform problem statements into testable, non-vague AC. Produces testable acceptance criteria. Hands off to via GitHub issue body under `## Requirements`.
+Goal: Transform problem statements into testable, non-vague acceptance criteria. Produces testable AC. Hands off via GitHub issue body under `## Requirements`.
 
 ## Specialist Mode
 - **Seeded**: Skip scope/file confirmations.
@@ -18,16 +20,16 @@ Invoke `Skill("specialist-mode")` at entry.
 
 ## I/O
 - **Input**: Problem statement (from /describe) or user description.
-- **Optional**: Prior-art brief (`problem_domain`, `existing_patterns`, `constraints`). Skip duplicate internal research if present. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`
+- **Optional**: Prior-art brief (`problem_domain`, `existing_patterns`, `constraints`). Skip duplicate internal research if present. See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
 - **Output**: Numbered list of testable AC scenarios.
 
 ## Process
-1. **Review**: Analyze problem statement/description.
+1. **Review** — Analyze problem statement/description.
 2. **Grill-me Passes** (Sequential, lead session):
    - **Happy-path**: Normal flows, expected behavior, performance.
    - **Edge-case**: Boundaries, error states, security, failure modes.
-3. **Synthesis**: Challenge assumptions across both passes.
-4. **Scenario Production**: For each requirement, write:
+3. **Synthesis** — Challenge assumptions across both passes.
+4. **Scenario Production** — For each requirement, write:
    ```
    GIVEN <precondition>
    WHEN <action>
@@ -37,7 +39,7 @@ Invoke `Skill("specialist-mode")` at entry.
    - Decision trees for complex logic.
    - Requirement matrices (feature × scenario).
    - State diagrams for stateful behavior.
-6. **Prioritization**: Categorize as must-have vs. nice-to-have.
+6. **Prioritization** — Categorize as must-have vs. nice-to-have.
 
 ## Rules
 - **Zero Vagueness**: No "fast", "user-friendly", or "appropriate". Every AC must be testable.


### PR DESCRIPTION
## Summary

Rebuilds describe (#143) and specify (#144) as v2 layer-2 sub-skills following the conventions established by wrap-up and compound.

### Changes

- **describe** — restructured with Role & Constraints, I/O, Process, and Rules sections. Preserves existing Skill() calls to specialist-mode and specialist-assessment protocols.
- **specify** — restructured with Role & Constraints, I/O, Process, and Rules sections. Preserves existing Skill() calls to specialist-mode.

Closes #143, closes #144
Part of #125 v2 rebuild track.
