### PR TITLE
feat: rebuild find-skills and review as v2 L2 sub-skills

### DIFF
--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -8,12 +8,10 @@ allowed-tools: Agent Bash WebFetch WebSearch
 layer: 2
 user-invocable: true
 ---
-Discover and install skills from the open agent ecosystem.
+## Role & Constraints
+Lead skill discovery and installation. Goal: Find and install agent skills from the open ecosystem when the user wants to extend capabilities. Discovery sub-agent (haiku) handles search + leaderboard fetch; main thread handles confirmation + install.
 
-Discovery sub-agent (haiku) for search + leaderboard fetch (payoff ≥3×; retrieval-only). Main thread: confirmation + install. Spawn prompt: `cd <cwd> && pwd`.
-
-## When to Use This Skill
-
+## When to Use
 Use this skill when the user:
 - Asks "how do I do X" where X might be a common task with an existing skill
 - Says "find a skill for X" or "is there a skill for X"
@@ -21,17 +19,19 @@ Use this skill when the user:
 - Expresses interest in extending agent capabilities or mentions needing help with a specific domain
 - Searches for tools, templates, workflows, or examples to use
 
-## The Skills CLI
+## I/O
+- **Input**: User query about capabilities or specific skill needs.
+- **Output**: Installed skill(s) or search results with install confirmation.
 
-The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Key commands:
-- `npx skills find [query]` — search for skills
-- `npx skills add <package>` — install a skill
-- `npx skills check` / `npx skills update` — check/update all skills
+## Process
+1. Read `references/search-guide.md` for search strategy and `references/categories.md` for category guidance and fallback options.
+2. Dispatch a discovery sub-agent (haiku) to check the leaderboard at https://skills.sh/ and run `npx skills find [query]`.
+3. Sub-agent verifies quality — install count, source reputation, and GitHub stars.
+4. Present candidate skills to the user with name, description, install count, and source.
+5. On confirmation, install with `npx skills add <package> -g -y`.
+6. Report what was installed.
 
-Browse at https://skills.sh/
-
-## How to Help Users Find Skills
-
-Read `references/search-guide.md`.
-
-For search strategy tips, skill categories, and fallback guidance (when no skills are found), see `references/categories.md`.
+## Rules
+- Discovery is sub-agent only — never install without user confirmation.
+- Prefer skills from verified sources (official orgs, 1K+ installs, 100+ GitHub stars).
+- When no matching skills are found, offer to help directly or suggest `npx skills init` (see `references/categories.md`).

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -17,10 +17,7 @@ Lead review phase. Goal: Thoroughly review implementation against requirements a
 Invoke `Skill("specialist-mode")` at entry.
 
 ## Specialist Assessment
-
 Invoke `Skill("review-specialist-assessment")` at entry. It reads diff/AC from context and emits a `specialists:` list (always includes `reviewer-correctness` and `reviewer-standards`; conditionally adds `reviewer-security`, `reviewer-perf`, `reviewer-migration`).
-
-Spawn one agent per specialist in the list using parallel `Agent()` calls (see `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`). Pass diff and AC to each. Collect findings and merge per `references/dispatch-process.md § Merge & Dedup`.
 
 ## I/O
 - **Input**: Branch (+ seed brief), Branch (standalone + issue#), or PR argument (PR# or URL).
@@ -29,9 +26,16 @@ Spawn one agent per specialist in the list using parallel `Agent()` calls (see `
 
 Read `references/dispatch-process.md` for dispatch modes, process steps, and PR posting logic.
 
-## Personas (see `references/personas.md`)
+## Process
+1. Acquire review package per dispatch mode (see `references/dispatch-process.md`).
+2. Triage: analyze diff → `Skill("review-specialist-assessment")` → build `specialists:` list; record which gates fired.
+3. Spawn one agent per specialist using parallel `Agent()` calls (see `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`). Pass diff and AC to each.
+4. Collect findings and merge per `references/dispatch-process.md § Merge & Dedup`.
+5. Emit output per dispatch mode (fix brief, findings report, or posted GitHub review).
+
+### Personas (see `references/personas.md`)
 - **Always-on**: Correctness, Standards.
-- **Conditional**: Security, Performance, Migration, Docs Consistency, Architecture/Scope-creep. (Activate only if gate fires).
+- **Conditional**: Security, Performance, Migration, Docs Consistency, Architecture/Scope-creep. (Activate only if gate fires.)
 
 ## Rules
 - **Separation**: Never fix issues during review. Report findings in the review output; fixes happen in a subsequent `/build` cycle.


### PR DESCRIPTION
## Summary

Rebuilds find-skills (#147) and review (#140) as v2 layer-2 sub-skills following the conventions established by wrap-up and compound.

### Changes

- **find-skills** — restructured with Role & Constraints, I/O, Process, and Rules sections. Preserves existing references and logic.
- **review** — restructured with consistent v2 section ordering. Preserves existing Skill() calls to specialist-mode and review-specialist-assessment.

Closes #147, closes #140
Part of #125 v2 rebuild track.
