### PR TITLE
feat: rebuild verify and build as v2 L2 sub-skills

### DIFF
--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -9,29 +9,33 @@ layer: 2
 user-invocable: true
 allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 ---
-You are leading the build phase. Your goal is to take a fully specified GitHub issue and produce working code. Builds a feature from a GitHub issue using TDD. Produces implementation code in a worktree. Hands off via the worktree.
+## Role & Constraints
+Lead build phase. Goal: Take a fully specified GitHub issue and produce working code. Builds a feature using TDD. Produces implementation code in a worktree. Hands off via the worktree for review.
 
-## Input
-
-A GitHub issue number (with architecture/design decisions from /define) and any additional resources.
+## I/O
+- **Input**: A GitHub issue number (with architecture/design decisions from /define) and any additional resources.
+- **Output**: A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for /review.
 
 ## Specialist Assessment
-
 Invoke `Skill("build-specialist-assessment")` at entry (before spawning workers). It reads plan/AC from context and emits a `specialists:` list.
 
-## Process Overview
-
+## Process
 Read `references/process.md` for step-by-step process, TDD, context hygiene, and commit rules.
 
 1. Run pre-flight (repo/scope confirmation).
 2. Read the issue and linked sub-issues.
 3. Create worktree, init `./.claude/NOTES.md` with task list.
 4. Invoke `Skill("scope-assessment")` with work units derived from sub-issues and file groups → receive agent plan → spawn one agent per entry.
+5. Consider invoking `Skill("compaction-protocol")` for context management during long build sessions.
 
 ## Output
-
-A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for /review.
+```
+Branch: <branch>
+Worktree: <path>
+Status: All AC implemented, tests passing
+```
 
 ## Rules
-
 - **Always create a worktree** with `wt switch --create <branch>` before writing any code. Never code in the main repo directory.
+- **TDD**: Write tests before implementation code.
+- **Context Hygiene**: Keep NOTES.md updated with progress; use compaction when context limits are reached.

--- a/skills/build/SKILL.md
+++ b/skills/build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: build
 description: Build a feature from a GitHub issue. Creates a git worktree and codes against acceptance criteria using TDD.
-when_to_use: Use after /define has produced approved architecture decisions. Invoked automatically by /implement.
+when_to_use: Use to implement approved architecture decisions.
 argument-hint: "[issue#]"
 model: sonnet
 effort: high
@@ -13,8 +13,8 @@ allowed-tools: Agent Bash Read TaskCreate TaskUpdate
 Lead build phase. Goal: Take a fully specified GitHub issue and produce working code. Builds a feature using TDD. Produces implementation code in a worktree. Hands off via the worktree for review.
 
 ## I/O
-- **Input**: A GitHub issue number (with architecture/design decisions from /define) and any additional resources.
-- **Output**: A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for /review.
+- **Input**: A GitHub issue number (with architecture/design decisions) and any additional resources.
+- **Output**: A feature branch in a worktree with all acceptance criteria implemented, tests passing, and clean incremental commits. Ready for review.
 
 ## Specialist Assessment
 Invoke `Skill("build-specialist-assessment")` at entry (before spawning workers). It reads plan/AC from context and emits a `specialists:` list.

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -22,16 +22,11 @@ Invoke `Skill("specialist-mode")` at entry.
 - **Output**: QA report (pass/fail per AC with evidence).
 
 ## Specialist Assessment
-
 Invoke `Skill("verify-specialist-assessment")` at entry. It reads AC and diff from context and emits a `specialists:` list.
 
-## Team Shape
-
-Invoke `Skill("scope-assessment")` with work units — one per AC group. Receive agent plan; spawn one QA agent per disjoint group. Add any activated specialists to their relevant groups.
-
 ## Process
-
-Split AC across QA agents per `scope-assessment` output → each verifies independently → converge on unified report. Any activated specialists verify their domain-specific AC alongside the QA agents.
+1. Invoke `Skill("scope-assessment")` with work units — one per AC group. Receive agent plan; spawn one QA agent per disjoint group. Add any activated specialists to their relevant groups.
+2. Split AC across QA agents per `scope-assessment` output → each verifies independently → converge on unified report. Any activated specialists verify their domain-specific AC alongside the QA agents.
 
 ## Rules
 - **Separation**: Never fix issues during verification. Report failures in the verify output; fixes are a `/build` responsibility.


### PR DESCRIPTION
## Summary

Rebuilds verify (#141) and build (#142) as v2 layer-2 sub-skills following the conventions established by wrap-up and compound.

### Changes

- **verify** — restructured with consistent v2 section ordering. Preserves existing Skill() calls to specialist-mode, verify-specialist-assessment, and scope-assessment.
- **build** — restructured with consistent v2 section ordering. Preserves existing Skill() calls to build-specialist-assessment and scope-assessment.

Closes #141, closes #142
Part of #125 v2 rebuild track.
