### PR TITLE
feat: add layer declarations to remaining v2 skills

### DIFF
--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: audit-issues
 description: Audit open GitHub issues for drift against repo state. Flags broken refs, stale claims, and contradictions.
+layer: 1
 when_to_use: Use when auditing a GitHub repo's open issues for drift, broken refs, or stale claims.
 argument-hint: "[owner/repo | #NN | owner/repo#NN]"
 model: sonnet

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: compound
 description: Capture learnings from completed work into durable wiki notes. Delegates to /save when claude-obsidian is available.
+layer: 2
 when_to_use: Use after a feature is merged to capture learnings into durable wiki notes.
 model: sonnet
 effort: low

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: define
 description: Lead definition phase. Resolves architecture and design technical decisions.
+layer: 1
 when_to_use: Use after /discovery produces an approved issue with AC. Precedes /implement.
 argument-hint: "[issue#]"
 model: opus

--- a/skills/discovery/SKILL.md
+++ b/skills/discovery/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: discovery
 description: Full discovery phase — explore a problem and produce a GitHub issue with AC.
+layer: 1
 when_to_use: Start of any new feature or vague problem. Precedes /define.
 argument-hint: "[issue# | description]"
 model: opus

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: epic-autopilot
 description: Autonomous epic-to-PR pipeline. Chains /discovery → /define → /implement end-to-end for each sub-issue, opening draft PRs.
+layer: 1
 when_to_use: Use when you have an epic issue number or a free-text description and want the full cycle automated.
 argument-hint: "[epic# | description]"
 model: opus

--- a/skills/grill-me/SKILL.md
+++ b/skills/grill-me/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: grill-me
 description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree.
+layer: 1
 when_to_use: Use when the user wants to stress-test a plan, get grilled on a design, or mentions "grill me".
 model: sonnet
 ---

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: implement
 description: Full implementation cycle — build, review, and verify, then open a PR.
+layer: 1
 when_to_use: Use to run the full implementation cycle (build → review → verify → PR) from an approved issue.
 argument-hint: "[issue#]"
 model: sonnet

--- a/skills/issue-autopilot/SKILL.md
+++ b/skills/issue-autopilot/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: issue-autopilot
 description: Single-issue equivalent of /epic-autopilot. Chains /define → /implement → /resolve-pr-feedback → /compound → /wrap-up for one issue.
+layer: 1
 when_to_use: Use when you have a single GitHub issue and want the full lifecycle automated end-to-end with natural pause points for human review and merge.
 argument-hint: <issue#>
 model: opus

--- a/skills/new-skill/SKILL.md
+++ b/skills/new-skill/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: new-skill
 description: Scaffold a new skill conforming to the authoring standard. Interviews the author, generates a SKILL.md, and writes it to the chosen location.
+layer: 1
 when_to_use: Use when creating a new skill for personal use, a project, or this plugin.
 model: haiku
 effort: low

--- a/skills/prune/SKILL.md
+++ b/skills/prune/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: prune
 description: Audit skill authoring quality and prune dead state from ~/.claude/. Vault health is delegated to /lint.
+layer: 1
 model: haiku
 effort: low
 allowed-tools: Agent AskUserQuestion Bash Read

--- a/skills/resolve-pr-feedback/SKILL.md
+++ b/skills/resolve-pr-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: resolve-pr-feedback
 description: Process PR review feedback in bulk — triage, fix in parallel, and reply with verdicts.
+layer: 1
 when_to_use: PR has review comments or given thread URL.
 argument-hint: "[thread-URL]"
 model: sonnet


### PR DESCRIPTION
Adds `layer:` frontmatter to all skills still missing it:- L1 (pipeline + maintenance): implement, prune, audit-issues, resolve-pr-feedback, discovery, define, epic-autopilot, issue-autopilot, grill-me, new-skill- L2 (sub-skill): compoundAll 26 skills now have a layer declaration. Part of #125.