### PR TITLE
fix: replace stale specialist-mode reference in epic-autopilot

### DIFF
--- a/skills/epic-autopilot/references/autonomous-phase.md
+++ b/skills/epic-autopilot/references/autonomous-phase.md
@@ -46,7 +46,7 @@ For each tier in ascending order:
 2. Dispatch all sub-tasks in current tier as parallel `Task` sub-agents **in a single message**. For each sub-issue M:
    - Emit: `[sub-issue #<M>] dispatched (tier <T>)`
    - Create worktree for branch `feat/epic-<N>-sub-<M>` on base `<base-branch>`. Invoke the worktree protocol (`Read ${CLAUDE_PLUGIN_ROOT}/_shared/worktree-protocol.md`).
-   - Pass seed brief to sub-agent's `/implement` invocation. Invoke `Skill("specialist-mode")` with overrides:
+   - Dispatch `Agent("skills/implement/agents/implement-runner.md")` with seed brief:
      - `branch`: `feat/epic-<N>-sub-<M>`
      - `active_issue`: `<M>`
      - `payload.prior_art`: `"Sub-issue #<M>'s ## Implementation plan (architecture and design decisions from /define)"`


### PR DESCRIPTION
Replaces the last `Skill("specialist-mode")` reference (deleted in #167) with the correct v2 pattern: `Agent("skills/implement/agents/implement-runner.md")`.Only 1 file changed. Part of #125.