### PR TITLE
v2: apply dispatch primitives framework — taxonomy, skill reclassification, issue audit

### DIFF
--- a/_shared/composition.md
+++ b/_shared/composition.md
@@ -4,9 +4,9 @@ Framework for orchestrating specialists and managing token/context budgets.
 
 ## Roles
 - **Orchestrator**: Phase lead. Spawns workers, coordinates, writes handoff. Model: `opus`.
-- **Runner**: Autonomous core of a Tier 2 skill. Receives input in spawn prompt, does the work, reports findings. Model: `sonnet`.
-- **Interactive Primitive**: Inline behavior (e.g., `/grill-me`). No team/handoff. Model: `sonnet`.
-- **Utility**: Maintenance (e.g., compound, prune). No seed-brief contract.
+- **Worker**: Background/isolated task execution. Receives input in spawn prompt, does the work, reports findings. Model: `sonnet` or `haiku`.
+- **Interaction**: Inline user-interaction behavior (e.g., `/grill-me`). No delegation. Model: `sonnet`.
+- **Protocol**: Behavioral rules adopted by calling agent, not spawned. No seed-brief contract.
 
 ## Composition Patterns
 - **Linear**: A → B → C (Strict dependency).
@@ -45,10 +45,10 @@ Every skill has a primary consumption contract. Callers must use the correct inv
 |-|-|-|-|-|
 |**Runner (autonomous)**|`Agent("skill/agents/runner.md")`|Isolated|None|`implement-runner`, `review-runner`|
 |**Worker (autonomous)**|`Agent("skill/agents/worker.md")`|Isolated|Parallel|`build-worker`, `reviewer-correctness`|
-|**Shell (interactive)**|`Skill("name")`|Caller's session|Full|`implement`, `build`, `review`|
-|**Forked (autonomous)**|`Skill("name")` + `context: fork`|Isolated|None|`compound`, `audit-issues`|
+|**Shell (interactive)**|`Skill("name")`|Caller's session|Full|`implement`, `build`, `review`, `audit-issues`, `find-skills`|
+|**Worker Skill**|`Skill("name")` + `context: fork`|Isolated|Task confirmations only|`compound`, `verify`, `scope-assessment`|
 
-> **Layer 3 skills** (`user-invocable: false`) are exclusively Autonomous — never `Skill()`-invoked.
+> **Protocol skills** (`user-invocable: false`) are adopted by the calling agent — never `Skill()`-invoked.
 
 ### Rules
 

--- a/_shared/dispatch-decision.md
+++ b/_shared/dispatch-decision.md
@@ -1,0 +1,41 @@
+# Dispatch Decision Reference
+
+Condensed tables for dispatch decisions at authoring time and runtime. Full framework: `${CLAUDE_PLUGIN_ROOT}/docs/dispatch-primitives.md`.
+
+## Role taxonomy
+
+|Role|Runs in|User interaction|Dispatches|`context: fork`|
+|-|-|-|-|-|
+|**Orchestrator**|Main context|Yes|Optionally: other Orchestrators and/or Workers|Never|
+|**Interaction**|Main context|Yes — only|Never|Never|
+|**Worker**|Background/isolated|Task confirmations only|Optionally: other Workers|Always (Skill); implied (Agent file)|
+|**Protocol**|Caller's context|N/A|Never|Never|
+
+## `context: fork` — use when ALL hold
+
+1. Explicit, argument-driven task (not behavioral guidelines).
+2. No user deliberation during execution (task-level confirmations are fine).
+3. Does not own orchestration state or user decision loops.
+
+Never use on Orchestrators, Interactions, or Protocols.
+
+## `agent:` selection (only with `context: fork`)
+
+|Task type|`agent:`|
+|-|-|
+|Read-only, computation, pure reasoning over prompt input|`Explore` — Haiku model, no CLAUDE.md|
+|Read-only: planning-phase analysis|`Plan` — no CLAUDE.md|
+|Agent dispatch required, writes required, or `gh` mutations|`general-purpose`|
+
+Always specify `agent:` explicitly — never rely on the silent `general-purpose` default.
+
+## Worker Agent vs Worker Skill
+
+|Use|When|
+|-|-|
+|Worker Skill (`context: fork`)|Task is user-invocable OR meaningful as its own skill directory|
+|Worker Agent (`agents/*.md`)|Internal implementation detail, never user-invocable|
+
+## `isolation: worktree`
+
+Add to `Agent()` calls when spawning 2+ parallel agents with overlapping file scope. Skip when `/scope-assessment` guarantees disjoint scope.

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -2,47 +2,47 @@
 
 This document defines the structural and behavioral conventions for building skills in `claude-workflow` v2.
 
-## Three-Layer Hierarchy
+## Role Taxonomy
 
-Skills are organized into three layers based on their role and visibility.
+Skills are classified by execution context and responsibility. See `${CLAUDE_PLUGIN_ROOT}/docs/dispatch-primitives.md` for the full decision framework.
 
-|Layer|Role|`user-invocable`|Description|
-|-|-|-|-|
-|**Layer 1**|Orchestrator|`true`|High-level workflows that coordinate multiple sub-skills and agents.|
-|**Layer 2**|Sub-skill|`true`|Specialized, reusable functional blocks that perform a distinct part of a workflow.|
-|**Layer 3**|Behavioral Convention|`false`|Internal rules, protocols, and constraints that govern how agents behave during a task.|
+|Role|Runs in|User interaction|Dispatches|`context: fork`|
+|-|-|-|-|-|
+|**Orchestrator**|Main context|Yes|Optionally: other Orchestrators and/or Workers|Never|
+|**Interaction**|Main context|Yes — only|Never|Never|
+|**Worker**|Background/isolated|Task confirmations only|Optionally: other Workers|Always (Skill); implied (Agent file)|
+|**Protocol**|Caller's context|N/A|Never|Never|
 
-### Layer vs. Reference File
+### Skill vs. Reference File
 
 Skills and reference files serve different purposes and require different access patterns. Use this table to choose the right artifact and syntax.
 
 |What you're accessing|When to use|How to access|
 |-|-|-|
-|Layer-3 behavioral skill|Runtime protocol agents must actively adopt|`Invoke \`Skill("<name>")\``|
+|Protocol or Worker skill|Runtime behavior agents must adopt or execute|`Invoke \`Skill("<name>")\``|
 |Per-skill reference doc|Static tables, checklists, or context scoped to one skill|`Read \`references/<file>.md\``|
 |Shared reference doc|Static tables, checklists, or context shared across skills|`Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\``|
 
-**Decision rule**: If the file encodes a behavioral constraint agents must actively operate under → layer-3 skill. If the file contains format tables, field lists, CLI command references, or read-only lookup context → `_shared/` doc. The instruction "agents must do X" is a layer-3 skill; "here is the YAML format for field Z" is a shared reference doc.
+**Decision rule**: If the file encodes a behavioral constraint agents must actively operate under → Protocol skill. If the file contains format tables, field lists, CLI command references, or read-only lookup context → `_shared/` doc. The instruction "agents must do X" is a Protocol skill; "here is the YAML format for field Z" is a shared reference doc.
 
-## Layer 3: Behavioral Convention Skills
+## Protocol Skills
 
-Layer-3 skills encode internal protocols, rules, and behavioral constraints. They do not perform domain work themselves; instead, they communicate behavioral expectations to the calling agent.
+Protocol skills encode internal rules and behavioral constraints. They do not perform domain work themselves; instead, they communicate behavioral expectations to the calling agent.
 
-### When to Create a Layer-3 Skill
+### When to Create a Protocol Skill
 
-Create a layer-3 skill when you have:
+Create a Protocol skill when you have:
 1. **Structured behavioral protocol** — A protocol or set of rules that must be adopted by agents during their task (e.g., how to handle seed-briefs, CWD verification, orchestration rules).
 2. **Cross-skill reuse** — The protocol is referenced by 3+ other skills or sub-agents.
 3. **Conditional invocation** — The protocol is invoked based on conditions detected at runtime (e.g., checking for a seed-brief in the input).
 
 Use `_shared/<file>.md` instead when the content is a format template, field list, or lookup table that callers simply read — not a behavioral constraint they must actively operate under.
 
-### Layer-3 Skill Design
+### Protocol Skill Design
 
 **Frontmatter:**
 ```yaml
 user-invocable: false
-layer: 3
 ```
 
 **Content Structure:**
@@ -50,17 +50,17 @@ layer: 3
 - Divide into sections: **Contract**, **Behavior**, **Verification** (as appropriate).
 - Document entry conditions, exit behaviors, and any state mutations.
 
-### Layer-3 Skills in `claude-workflow`
+### Protocol Skills in `claude-workflow`
 
-The current layer-3 skill catalog lives in `skills/`. Consult `ls skills/` for a list of available protocols. Each skill directory contains a `SKILL.md` with the authoritative protocol definition.
+The current Protocol skill catalog lives in `skills/`. Consult `ls skills/` for a list of available protocols. Each skill directory contains a `SKILL.md` with the authoritative protocol definition.
 
-## Layer 1: Orchestrator Constraints
+## Orchestrator Constraints
 
 Orchestrators must remain "thin" to avoid context bloat and logic drift.
 
 - **SKILL.md Limit**: Must be ≤ 150 lines.
 - **No Inline Domain Work**: Orchestrators should not perform the actual task (e.g., writing code, auditing files).
-- **Delegation**: All domain work must be delegated via `Skill()` (for layer-2/3 skills) or `Agent()` (for workers).
+- **Delegation**: All domain work must be delegated via `Skill()` (for Worker or Protocol skills) or `Agent()` (for Worker Agents).
 
 ## Worker-Agent Dispatch Pattern
 
@@ -122,13 +122,13 @@ The `/discovery` skill has been renamed to `/discover`.
 
 ## Skill Roles & Templates
 
-Each skill maps to one of three templates. Use the corresponding template from `_templates/`.
+Each skill maps to one of the following templates. Use the corresponding template from `_templates/`.
 
 |Role|Definition|Example|Model|Template|
 |-|-|-|-|-|
-|**Orchestrator** (Layer 1)|Coordinates sub-skills and agents; manages loop and phase sequencing.|`/implement`, `/issue-autopilot`|`sonnet`/`opus`|`SKILL.orchestrator`|
-|**Specialist** (Layer 2)|Bounded task with seed-brief input and findings report output.|`/build`, `/review`, `/verify`|`sonnet`|`SKILL.specialist`|
-|**Interactive Primitive** (Layer 2)|Inline behavior; no delegation or handoff.|`/grill-me`|`sonnet`|`SKILL.primitive`|
+|**Orchestrator**|Coordinates sub-skills and agents; manages loop and phase sequencing.|`/implement`, `/issue-autopilot`|`sonnet`/`opus`|`SKILL.orchestrator`|
+|**Worker**|Bounded task with seed-brief input and findings report output. Runs isolated via `context: fork`.|`/verify`, `/scope-assessment`|`haiku`/`sonnet`|`SKILL.worker`|
+|**Interaction**|Inline user-interaction behavior; no delegation.|`/grill-me`|`sonnet`|`SKILL.primitive`|
 
 ## Orchestrator Decomposition
 
@@ -145,6 +145,7 @@ Document the orchestrator's specific definition of "work unit" (what counts as a
 Reference on-demand via `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<file>.md\``:
 
 - `composition.md` — team/sub-agent cost and shape
+- `dispatch-decision.md` — condensed role taxonomy and `context: fork` decision table
 - `handoff-artifact.md` — five-field issue-body structure for phase handoffs
 - `interviewing-rules.md` — one-question-at-a-time interviewing protocol for user-interactive discovery
 - `notes-md-protocol.md` — `.claude/NOTES.md` lifecycle, shape, and update cadence

--- a/_templates/AUTHORING.md
+++ b/_templates/AUTHORING.md
@@ -4,14 +4,7 @@ This document defines the structural and behavioral conventions for building ski
 
 ## Role Taxonomy
 
-Skills are classified by execution context and responsibility. See `${CLAUDE_PLUGIN_ROOT}/docs/dispatch-primitives.md` for the full decision framework.
-
-|Role|Runs in|User interaction|Dispatches|`context: fork`|
-|-|-|-|-|-|
-|**Orchestrator**|Main context|Yes|Optionally: other Orchestrators and/or Workers|Never|
-|**Interaction**|Main context|Yes — only|Never|Never|
-|**Worker**|Background/isolated|Task confirmations only|Optionally: other Workers|Always (Skill); implied (Agent file)|
-|**Protocol**|Caller's context|N/A|Never|Never|
+Skills are classified by execution context and responsibility. See `${CLAUDE_PLUGIN_ROOT}/docs/dispatch-primitives.md` for the canonical taxonomy and `${CLAUDE_PLUGIN_ROOT}/_shared/dispatch-decision.md` for the condensed runtime reference.
 
 ### Skill vs. Reference File
 

--- a/docs/dispatch-primitives.md
+++ b/docs/dispatch-primitives.md
@@ -1,23 +1,6 @@
 # Dispatch Primitives — Decision Framework
 
-This document establishes when to use each dispatch mechanism in `claude-workflow` (`Skill`, `Agent`, `context: fork`, `agent:`, `isolation: worktree`), defines the canonical role taxonomy (Orchestrator, Interaction, Worker, Protocol), and audits all 26 skills against those rules. It replaces the layer-number terminology in `AUTHORING.md` as the human-facing classification system. The `layer:` frontmatter field remains until tooling is updated — see Tooling Note.
-
-## Deliverables
-
-This spec drives the following changes:
-
-| File | Action |
-|---|---|
-| `docs/dispatch-primitives.md` | This document |
-| `_shared/dispatch-decision.md` | New — condensed runtime-readable table for agents to consult when making dispatch decisions |
-| `_templates/AUTHORING.md` | Update — replace layer-number role descriptions with new taxonomy; add pointer to this doc |
-| `_shared/composition.md` | Update — fix "None" user interaction claim in consumption contracts table |
-| `skills/audit-issues/SKILL.md` | Edit — remove `context: fork` |
-| `skills/find-skills/SKILL.md` | Edit — remove `context: fork` |
-| `skills/compound/SKILL.md` | Edit — add `context: fork` + `agent: general-purpose` |
-| `skills/scope-assessment/SKILL.md` | Edit — add `context: fork` + `agent: Explore` |
-| `skills/verify/SKILL.md` | Edit — add `context: fork` + `agent: general-purpose` |
-| GitHub v2 issues | Audit — update open v2 issues to reflect new taxonomy and architecture; create issues for gaps; close issues made irrelevant by this design |
+This document establishes when to use each dispatch mechanism in `claude-workflow` (`Skill`, `Agent`, `context: fork`, `agent:`, `isolation: worktree`) and defines the canonical role taxonomy (Orchestrator, Interaction, Worker, Protocol). It replaces the layer-number terminology in `AUTHORING.md` as the human-facing classification system.
 
 ## Core Principle
 
@@ -90,69 +73,3 @@ When to use Worker Agent vs Worker Skill:
 ### `isolation: worktree`
 
 Parameter on `Agent()` calls. Gives the spawned agent its own git worktree to prevent filesystem race conditions. Use when spawning 2+ parallel agents and disjoint file scope cannot be guaranteed after `/scope-assessment`. Skip when scope is cleanly disjoint.
-
-## Correction to `composition.md`
-
-The "User Interaction" column in `composition.md`'s consumption contracts table is incorrect. Specifically, the row for "Forked (autonomous)" claims `None` — the correct characterization is "No conversation history". Task-level user confirmations (within an autonomous task, not requiring conversation history) are allowed. The distinction is subtle but load-bearing: Orchestrators deliberate with users interactively; Workers may confirm with users procedurally.
-
-Update required: fix the consumption contracts table in `_shared/composition.md` to clarify that `context: fork` skills have "Task confirmations only, no conversation history" rather than "None".
-
-## Skills Audit
-
-Complete table of all 26 skills with assigned role and required changes:
-
-| Skill | Role | `context: fork` | `agent:` | Required change |
-|---|---|---|---|---|
-| `architecture` | Orchestrator | — | — | Verify all research phases use background `Agent()` calls |
-| `audit-issues` | Orchestrator | ❌ remove | ❌ remove | Remove `context: fork` — has interactive Phase 4; this is an Orchestrator |
-| `build` | Orchestrator | — | — | None |
-| `compaction-protocol` | Protocol | — | — | None |
-| `compound` | Worker Skill | ✅ add | `general-purpose` | Add `context: fork` + `agent: general-purpose` |
-| `define` | Orchestrator | — | — | None |
-| `describe` | Orchestrator | — | — | Verify domain-researcher uses background `Agent()` |
-| `design` | Orchestrator | — | — | Verify ux-researcher and reviewer use background `Agent()` |
-| `discovery` | Orchestrator | — | — | Verify prior-art scouts use background `Agent()` |
-| `epic-autopilot` | Orchestrator | — | — | None |
-| `find-skills` | Orchestrator | ❌ remove | ❌ remove | Remove `context: fork` — has user confirmation step; this is an Orchestrator |
-| `grill-me` | Interaction | — | — | None |
-| `implement` | Orchestrator | — | — | None |
-| `issue-autopilot` | Orchestrator | — | — | None |
-| `new-skill` | Orchestrator | — | — | None |
-| `notes-md` | Protocol | — | — | None |
-| `orchestrator-rules` | Protocol | — | — | None |
-| `preflight` | Protocol | — | — | None |
-| `prune` | Orchestrator | — | — | None |
-| `resolve-pr-feedback` | Orchestrator | — | — | None |
-| `review` | Orchestrator | — | — | Calls `preflight` (user interaction) — stays in main context |
-| `scope-assessment` | Worker Skill | ✅ add | `Explore` | Reclassify from Protocol; add `context: fork` + `agent: Explore` — pure computation, no tools needed |
-| `specify` | Interaction | — | — | None |
-| `verify` | Worker Skill | ✅ add | `general-purpose` | Add `context: fork` + `agent: general-purpose` |
-| `worktree` | Protocol | — | — | None |
-| `wrap-up` | Orchestrator | — | — | None |
-
-No new agent files are required for these changes. The "Verify" items are audit checkpoints; any gaps found feed the restructuring epic.
-
-## GitHub Issue Audit
-
-All open v2 issues must be reconciled against this design before implementation begins.
-
-Actions:
-- **Update**: Issues referencing layer numbers, "Specialist", "Behavioral Convention", or the old context:fork semantics must be reworded to use the new taxonomy.
-- **Create**: New issues for each skill change in the audit table (one issue per skill that requires a frontmatter edit or reclassification); one issue for the `_shared/dispatch-decision.md` new file; one issue for the AUTHORING.md and composition.md updates; one issue for the `layer:` tooling dependency cleanup.
-- **Close**: Issues that described work now superseded by this design (e.g., any prior plan to add `context: fork` based on different criteria, or issues proposing a different taxonomy).
-
-The restructuring epic (deferred below) should be tracked as a milestone containing both the issue audit sub-issues and the follow-up skill restructuring sub-issues.
-
-## Deferred: Restructuring Epic
-
-Skills like `architecture` currently mix research dispatch with interactive grill-me. The new taxonomy does not require those to be broken apart now — `architecture` is an Orchestrator and can own both. A follow-up restructuring epic will:
-
-- Identify skills where the interactive component could be lifted to the calling Orchestrator to enable deeper background execution.
-- Create GitHub sub-issues per skill.
-- Update the v2 milestone to reflect the new architecture.
-
-This document is the spec that drives that epic. No agent files are created or modified in the current deliverable.
-
-## Tooling Note
-
-The `layer:` frontmatter field (values 1/2/3) is used by `bin/list-prune-files` for the `prune` skill. Before removing it from skill frontmatter, that tooling dependency must be resolved. The field is deprecated as human-facing taxonomy (replaced by the role names in this doc) but should remain in frontmatter until the tooling is updated. File a sub-issue in the restructuring epic.

--- a/docs/dispatch-primitives.md
+++ b/docs/dispatch-primitives.md
@@ -1,0 +1,158 @@
+# Dispatch Primitives — Decision Framework
+
+This document establishes when to use each dispatch mechanism in `claude-workflow` (`Skill`, `Agent`, `context: fork`, `agent:`, `isolation: worktree`), defines the canonical role taxonomy (Orchestrator, Interaction, Worker, Protocol), and audits all 26 skills against those rules. It replaces the layer-number terminology in `AUTHORING.md` as the human-facing classification system. The `layer:` frontmatter field remains until tooling is updated — see Tooling Note.
+
+## Deliverables
+
+This spec drives the following changes:
+
+| File | Action |
+|---|---|
+| `docs/dispatch-primitives.md` | This document |
+| `_shared/dispatch-decision.md` | New — condensed runtime-readable table for agents to consult when making dispatch decisions |
+| `_templates/AUTHORING.md` | Update — replace layer-number role descriptions with new taxonomy; add pointer to this doc |
+| `_shared/composition.md` | Update — fix "None" user interaction claim in consumption contracts table |
+| `skills/audit-issues/SKILL.md` | Edit — remove `context: fork` |
+| `skills/find-skills/SKILL.md` | Edit — remove `context: fork` |
+| `skills/compound/SKILL.md` | Edit — add `context: fork` + `agent: general-purpose` |
+| `skills/scope-assessment/SKILL.md` | Edit — add `context: fork` + `agent: Explore` |
+| `skills/verify/SKILL.md` | Edit — add `context: fork` + `agent: general-purpose` |
+| GitHub v2 issues | Audit — update open v2 issues to reflect new taxonomy and architecture; create issues for gaps; close issues made irrelevant by this design |
+
+## Core Principle
+
+Main context is the conductor. Background agents are the orchestra.
+
+The main conversation handles human interaction (approvals, grill-me, confirmations), dispatch (spawning Workers, calling sub-Orchestrators), response analysis (merging findings from Workers), and summary. All actual work — research, file scanning, code analysis, verification, knowledge extraction — runs in background Workers. Nothing that can be delegated should run inline in the main context.
+
+## Role Taxonomy
+
+Four roles define the dispatch contract and execution context:
+
+| Role | Runs in | User interaction | Dispatches | `context: fork` |
+|---|---|---|---|---|
+| **Orchestrator** | Main context | Yes | Optionally: other Orchestrators and/or Workers | Never |
+| **Interaction** | Main context | Yes — only | Never | Never |
+| **Worker** | Background/isolated | Task confirmations only | Optionally: other Workers | Always (Skill); implied (Agent file) |
+| **Protocol** | Caller's context | N/A | Never | Never |
+
+Worker sub-types — same role, different packaging:
+
+| Sub-type | Format | Invocation | User-invocable |
+|---|---|---|---|
+| Worker Skill | SKILL.md + `context: fork` | `Skill("name")` | Can be |
+| Worker Agent | `agents/*.md` file | `Agent("path.md")` | Never |
+
+Key distinctions:
+
+- **Orchestrators CAN have sub-Orchestrators**: Architecture calls grill-me; define calls architecture. Each is an Orchestrator with no `context: fork` required.
+- **Interaction skills are simple Orchestrators**: They interact with user but never dispatch. `grill-me` and `specify` are the examples.
+- **Workers run isolated from conversation history**: They may still exchange messages with the user for task-level confirmations (NOT for deliberation requiring conversation context).
+- **Protocols are adopted, not spawned**: They modify the calling agent's behavior.
+
+## Dispatch Primitives
+
+### `Skill("name")` — in-context invocation
+
+Runs in caller's session. Use for Orchestrators and Interactions. The skill shares conversation history with the caller.
+
+### `context: fork` — isolated Worker Skill
+
+Add to SKILL.md frontmatter when the skill is a Worker. The skill's markdown becomes the task prompt for a subagent. No conversation history. Always pair with `agent:`.
+
+Criterion — use when ALL hold:
+
+1. Explicit, argument-driven task (not behavioral guidelines).
+2. No user deliberation during execution (task-level confirmations are fine).
+3. Does not own orchestration state or user decision loops.
+
+Never use on Orchestrators, Interactions, or Protocols.
+
+### `agent:` — subagent type selector (only with `context: fork`)
+
+Always specify explicitly — never rely on the silent `general-purpose` default.
+
+| Task type | `agent:` |
+|---|---|
+| Read-only or pure computation: file scan, codebase research, lookups, structured reasoning over prompt input | `Explore` — Haiku model, no CLAUDE.md loaded |
+| Read-only: planning-phase analysis | `Plan` — no CLAUDE.md |
+| Agent dispatch required, writes required, or gh mutations | `general-purpose` |
+
+### `Agent("path.md")` — Worker Agent dispatch
+
+Use for parallel fan-out and bulk I/O workers. Worker Agents are defined as `agents/*.md` files within a skill directory. They always run isolated (autonomous, no user interaction). Standard frontmatter: `disallowedTools: [Agent, AskUserQuestion]` (prevents recursive spawning and interactive prompts).
+
+When to use Worker Agent vs Worker Skill:
+
+- Worker Skill: task is user-invocable OR meaningful enough to stand as its own skill directory.
+- Worker Agent: internal implementation detail of a parent skill, never invoked directly by users.
+
+### `isolation: worktree`
+
+Parameter on `Agent()` calls. Gives the spawned agent its own git worktree to prevent filesystem race conditions. Use when spawning 2+ parallel agents and disjoint file scope cannot be guaranteed after `/scope-assessment`. Skip when scope is cleanly disjoint.
+
+## Correction to `composition.md`
+
+The "User Interaction" column in `composition.md`'s consumption contracts table is incorrect. Specifically, the row for "Forked (autonomous)" claims `None` — the correct characterization is "No conversation history". Task-level user confirmations (within an autonomous task, not requiring conversation history) are allowed. The distinction is subtle but load-bearing: Orchestrators deliberate with users interactively; Workers may confirm with users procedurally.
+
+Update required: fix the consumption contracts table in `_shared/composition.md` to clarify that `context: fork` skills have "Task confirmations only, no conversation history" rather than "None".
+
+## Skills Audit
+
+Complete table of all 26 skills with assigned role and required changes:
+
+| Skill | Role | `context: fork` | `agent:` | Required change |
+|---|---|---|---|---|
+| `architecture` | Orchestrator | — | — | Verify all research phases use background `Agent()` calls |
+| `audit-issues` | Orchestrator | ❌ remove | ❌ remove | Remove `context: fork` — has interactive Phase 4; this is an Orchestrator |
+| `build` | Orchestrator | — | — | None |
+| `compaction-protocol` | Protocol | — | — | None |
+| `compound` | Worker Skill | ✅ add | `general-purpose` | Add `context: fork` + `agent: general-purpose` |
+| `define` | Orchestrator | — | — | None |
+| `describe` | Orchestrator | — | — | Verify domain-researcher uses background `Agent()` |
+| `design` | Orchestrator | — | — | Verify ux-researcher and reviewer use background `Agent()` |
+| `discovery` | Orchestrator | — | — | Verify prior-art scouts use background `Agent()` |
+| `epic-autopilot` | Orchestrator | — | — | None |
+| `find-skills` | Orchestrator | ❌ remove | ❌ remove | Remove `context: fork` — has user confirmation step; this is an Orchestrator |
+| `grill-me` | Interaction | — | — | None |
+| `implement` | Orchestrator | — | — | None |
+| `issue-autopilot` | Orchestrator | — | — | None |
+| `new-skill` | Orchestrator | — | — | None |
+| `notes-md` | Protocol | — | — | None |
+| `orchestrator-rules` | Protocol | — | — | None |
+| `preflight` | Protocol | — | — | None |
+| `prune` | Orchestrator | — | — | None |
+| `resolve-pr-feedback` | Orchestrator | — | — | None |
+| `review` | Orchestrator | — | — | Calls `preflight` (user interaction) — stays in main context |
+| `scope-assessment` | Worker Skill | ✅ add | `Explore` | Reclassify from Protocol; add `context: fork` + `agent: Explore` — pure computation, no tools needed |
+| `specify` | Interaction | — | — | None |
+| `verify` | Worker Skill | ✅ add | `general-purpose` | Add `context: fork` + `agent: general-purpose` |
+| `worktree` | Protocol | — | — | None |
+| `wrap-up` | Orchestrator | — | — | None |
+
+No new agent files are required for these changes. The "Verify" items are audit checkpoints; any gaps found feed the restructuring epic.
+
+## GitHub Issue Audit
+
+All open v2 issues must be reconciled against this design before implementation begins.
+
+Actions:
+- **Update**: Issues referencing layer numbers, "Specialist", "Behavioral Convention", or the old context:fork semantics must be reworded to use the new taxonomy.
+- **Create**: New issues for each skill change in the audit table (one issue per skill that requires a frontmatter edit or reclassification); one issue for the `_shared/dispatch-decision.md` new file; one issue for the AUTHORING.md and composition.md updates; one issue for the `layer:` tooling dependency cleanup.
+- **Close**: Issues that described work now superseded by this design (e.g., any prior plan to add `context: fork` based on different criteria, or issues proposing a different taxonomy).
+
+The restructuring epic (deferred below) should be tracked as a milestone containing both the issue audit sub-issues and the follow-up skill restructuring sub-issues.
+
+## Deferred: Restructuring Epic
+
+Skills like `architecture` currently mix research dispatch with interactive grill-me. The new taxonomy does not require those to be broken apart now — `architecture` is an Orchestrator and can own both. A follow-up restructuring epic will:
+
+- Identify skills where the interactive component could be lifted to the calling Orchestrator to enable deeper background execution.
+- Create GitHub sub-issues per skill.
+- Update the v2 milestone to reflect the new architecture.
+
+This document is the spec that drives that epic. No agent files are created or modified in the current deliverable.
+
+## Tooling Note
+
+The `layer:` frontmatter field (values 1/2/3) is used by `bin/list-prune-files` for the `prune` skill. Before removing it from skill frontmatter, that tooling dependency must be resolved. The field is deprecated as human-facing taxonomy (replaced by the role names in this doc) but should remain in frontmatter until the tooling is updated. File a sub-issue in the restructuring epic.

--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -6,7 +6,6 @@ when_to_use: Use when auditing a GitHub repo's open issues for drift, broken ref
 argument-hint: "[owner/repo | #NN | owner/repo#NN]"
 model: sonnet
 allowed-tools: Bash Read
-context: fork
 ---
 ## Role & Constraints
 Audit open issues for drift. Product: Updated issues themselves (mutate on confirm).

--- a/skills/compound/SKILL.md
+++ b/skills/compound/SKILL.md
@@ -7,6 +7,8 @@ model: sonnet
 effort: low
 allowed-tools: Agent Bash Read
 user-invocable: true
+context: fork
+agent: general-purpose
 ---
 ## Role & Constraints
 Lead knowledge compounding. Goal: Extract fixes, insights, or patterns into reusable artifacts. Captures learnings from the completed phase into durable wiki notes. Delegates to `/save` when claude-obsidian is available. Degrades gracefully when `/save` is unavailable — outputs wiki content to terminal instead.

--- a/skills/find-skills/SKILL.md
+++ b/skills/find-skills/SKILL.md
@@ -7,7 +7,6 @@ effort: low
 allowed-tools: Agent Bash WebFetch WebSearch
 layer: 2
 user-invocable: true
-context: fork
 ---
 ## Role & Constraints
 Lead skill discovery and installation. Goal: Find and install agent skills from the open ecosystem when the user wants to extend capabilities. Discovery sub-agent (haiku) handles search + leaderboard fetch; main thread handles confirmation + install.

--- a/skills/scope-assessment/SKILL.md
+++ b/skills/scope-assessment/SKILL.md
@@ -4,6 +4,8 @@ description: Given a list of work units (each with an id and resource list), gro
 model: haiku
 user-invocable: false
 layer: 3
+context: fork
+agent: Explore
 ---
 ## Input
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -8,6 +8,8 @@ effort: low
 layer: 2
 user-invocable: true
 allowed-tools: Agent Bash Read TaskCreate TaskUpdate
+context: fork
+agent: general-purpose
 ---
 ## Role & Constraints
 Lead verification phase. Goal: Verify every AC from the issue is met with evidence. Report pass/fail per criterion.


### PR DESCRIPTION
## Summary

Apply the dispatch primitives framework (docs/dispatch-primitives.md) across documentation, skill frontmatter, and GitHub issues. This is the architectural foundation for the v2 rebuild tracked in #125.

## Changes

### Documentation
- **docs/dispatch-primitives.md** — new: decision framework with role taxonomy (Orchestrator, Interaction, Worker, Protocol) and dispatch primitives reference
- **_shared/dispatch-decision.md** — new: condensed runtime reference for agents making dispatch decisions
- **_shared/composition.md** — fix: rename "Forked" to "Worker Skill", correct "None" user-interaction claim to "Task confirmations only", update examples to reflect reclassified skills
- **_templates/AUTHORING.md** — update: replace layer-number taxonomy (Layer 1/2/3) with role taxonomy throughout

### Skill Reclassifications
| Skill | Change | Role |
|---|---|---|
| audit-issues | Remove context: fork | Orchestrator |
| find-skills | Remove context: fork | Orchestrator |
| compound | Add context: fork + agent: general-purpose | Worker Skill |
| scope-assessment | Add context: fork + agent: Explore | Worker Skill |
| verify | Add context: fork + agent: general-purpose | Worker Skill |

### GitHub Issue Audit
- Updated 10 open v2 issues (#128-#137) with new taxonomy (title + body)
- Created 6 new issues for identified gaps:
  - #173-#176: audit research-phase delegation for architecture, describe, design, discovery
  - #177: remove layer: tooling dependency from bin/list-prune-files
  - #178: restructuring epic — lift interactive steps into orchestrators

Closes #125
