### PR TITLE
cleanup: remove stale /discovery references and post-redesign leftovers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,12 +28,12 @@ Pick the lightest path that fits the task:
 |Size|Path|
 |-|-|
 |Trivial fix|`/implement` directly|
-|Medium feature|`/discovery` → `/implement`|
-|Large feature / epic|`/discovery` → `/define` → `/implement`|
+|Medium feature|`/discover` → `/implement`|
+|Large feature / epic|`/discover` → `/define` → `/implement`|
 
 Building blocks: `/describe`, `/specify`, `/architecture`, `/design`, `/build`, `/review`, `/verify`, `/grill-me`, `/wrap-up`, `/prune`, `/compound`. For the full lifecycle see `${CLAUDE_PLUGIN_ROOT}/docs/workflow.md`.
 
-During `/define` or `/discovery` exploration: time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
+During `/define` or `/discover` exploration: time-box codebase reading to 3–5 tool calls, then ask the user a focused question.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,3 +80,4 @@ Token budgets per artifact/phase, CLAUDE.md placement rules, `@`-imports: `${CLA
 - Orchestrator SKILL.md must be ≤ 150 lines. No inline domain work — delegate.
 - Worker agents should include `disallowedTools: [Agent]` to prevent recursive spawning.
 - **Persist lessons to AGENTS.md**: When you discover a project-level convention, gotcha, or architecture rule that future agents would benefit from, add it to this file under the relevant section. NOTES.md is ephemeral session scratch — durable knowledge lives here.
+- **Update docs with code**: Any change to a skill, agent, or command must update all related docs (README.md, docs/*.md, AGENTS.md, other skills referencing it) in the same commit. Stale docs rot faster than dead code.

--- a/README.md
+++ b/README.md
@@ -9,12 +9,11 @@ flowchart TB
         direction TB
         Start([feature request]) --> Discovery
 
-        subgraph Discovery["/discovery — explore & scope"]
+        subgraph Discovery["/discover — explore & scope"]
             direction LR
             D_Describe["/describe — problem space"]
             D_Specify["/specify — acceptance criteria"]
-            D_Scout["Prior-Art Scout"]
-            D_Scout -.seed brief.-> D_Describe
+
         end
 
         subgraph Define["/define — solution architecture"]
@@ -97,10 +96,10 @@ Then enable it in your project or globally in Claude Code settings.
 
 |Skill|Description|
 |-|-|
-|`/discovery`|Explore a problem and produce a GitHub issue with acceptance criteria|
+|`/discover`|Explore a problem and produce a GitHub issue with acceptance criteria|
 |`/define`|Plan architecture and design; produces the implementation handoff|
 |`/implement`|Full build→review→verify cycle, ends with a draft PR|
-|`/epic-autopilot`|Autonomous epic→PR pipeline; chains `/discovery → /define → /implement` per sub-issue|
+|`/epic-autopilot`|Autonomous epic→PR pipeline; chains `/discover → /define → /implement` per sub-issue|
 |`/issue-autopilot`|Single-issue end-to-end pipeline: `/define` → `/implement` → `/resolve-pr-feedback` → `/compound` → `/wrap-up`|
 |`/build`|Code against an issue's acceptance criteria using TDD|
 |`/review`|Review an implementation or external PR; correctness, standards, and conditional specialists|
@@ -133,8 +132,8 @@ Without `claude-obsidian`, every skill still runs; vault operations are skipped 
 |Task size|Path|
 |-|-|
 |Trivial fix|`/implement` directly|
-|Medium feature|`/discovery` → `/implement`|
-|Large feature / epic|`/discovery` → `/define` → `/implement`|
+|Medium feature|`/discover` → `/implement`|
+|Large feature / epic|`/discover` → `/define` → `/implement`|
 
 Full lifecycle walkthrough: [`docs/workflow.md`](docs/workflow.md)
 

--- a/docs/token-budgets.md
+++ b/docs/token-budgets.md
@@ -29,7 +29,7 @@ Full session context â€” system prompt + CLAUDE.md + prior turns + tool output â
 
 |Phase boundary|Target|Verification|
 |-|-|-|
-|End of `/discovery`|**<15k tokens**|`/context` after issue body is written, before reset|
+|End of `/discover`|**<15k tokens**|`/context` after issue body is written, before reset|
 |End of `/define`|**<15k tokens**|After implementation plan is written into issue|
 |End of `/implement`|**<20k tokens**|After draft PR is opened|
 
@@ -96,10 +96,10 @@ Each `/skill` invocation loads the full skill body verbatim. Multiple invocation
 
 **Anti-pattern**:
 ```
-/discovery   # writes issue #482
+/discover   # writes issue #482
 /define      # writes implementation plan to #482
 # later, after confusion:
-/discovery   # re-loads entire skill to "re-check the spec"
+/discover   # re-loads entire skill to "re-check the spec"
 ```
 
 Fix: read the issue body or NOTES.md instead. The skill body has nothing to add on re-read.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -6,8 +6,8 @@ Lifecycle walkthrough from discovery to closure.
 |Size|Path|Handoff|
 |-|-|-|
 |**Trivial**|`/implement`|→ PR|
-|**Medium**|`/discovery` → `/implement`|Issue Body → PR|
-|**Large**|`/discovery` → `/define` → `/implement`|Issue Body → Issue Body → PR|
+|**Medium**|`/discover` → `/implement`|Issue Body → PR|
+|**Large**|`/discover` → `/define` → `/implement`|Issue Body → Issue Body → PR|
 
 **State Management**:
 - **Inter-phase**: GitHub issue body (5-field structure — invoke `Read ${CLAUDE_PLUGIN_ROOT}/_shared/handoff-artifact.md`).
@@ -16,9 +16,9 @@ Lifecycle walkthrough from discovery to closure.
 
 ## Phase Details
 
-### 1. `/discovery` (Opus, High)
+### 1. `/discover` (Opus, High)
 **Goal**: Vague idea → well-specified GitHub issue.
-- **Process**: Classify Scope → Prior-Art Scout → `/describe` ( la-inline) → `/specify` (sequential subagent).
+- **Process**: Delegate to `/describe` (research, PPT, visuals) → `/specify` (AC generation).
 - **Output**: Issue with **Problem statement** + **Handoff block** (AC, Constraints, Decisions, Evidence, Questions).
 - **Gate**: Explicit user approval of issue body.
 - **Next**: `/define` (Large) or `/implement` (Medium).

--- a/skills/define/SKILL.md
+++ b/skills/define/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: define
 description: Lead definition phase. Resolves architecture and design technical decisions.
-when_to_use: Use after /discovery produces an approved issue with AC. Precedes /implement.
+when_to_use: Use after /discover produces an approved issue with AC. Precedes /implement.
 argument-hint: "[issue#]"
 model: opus
 effort: high
@@ -13,7 +13,7 @@ Phase Lead. Transform an approved issue into a concrete implementation plan (arc
 Adopt `Skill("orchestrator-rules")` for checkpoint, NOTES.md, and seed-brief conventions.
 
 ## Input
-Issue number with acceptance criteria from /discovery. Read body at entry; reference-read issue on demand throughout.
+Issue number with acceptance criteria from /discover. Read body at entry; reference-read issue on demand throughout.
 
 ## Team Shape
 Invoke `Skill("scope-assessment")` with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.

--- a/skills/describe/references/scope-ppt.md
+++ b/skills/describe/references/scope-ppt.md
@@ -1,21 +1,4 @@
-# Scope Assessment and Product Pressure Test
-
-## Scope Assessment
-
-|Scope|Criteria|Action|
-|-|-|-|
-|**Narrow/single-area**|Trivial fix, clear requirements, ≤ 1 file|Skip sub-agents. Single-pass problem statement. Skip PPT.|
-|**Multi-area or complex**|Typical feature/fix with some unknowns|Spawn team + visuals. Run PPT.|
-
-**Decision**: 1 file + 1 sentence → Narrow/single-area; complex/cross-cutting → Multi-area or complex; else default to full process.
-
-### Spawn Rubric
-
-Read `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md`.
-- **Multi-area or complex**: Domain researcher (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
-- **With extra complexity**: Domain researcher + Failure-mode analyst (`sonnet`) → lead analyst (`opus`) via `/grill-me`.
-
-## Product Pressure Test (PPT)
+# Product Pressure Test (PPT)
 
 Run between exploration and synthesis for multi-area or complex problems. Invoke `Skill('grill-me')` with the user on:
 

--- a/skills/epic-autopilot/SKILL.md
+++ b/skills/epic-autopilot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: epic-autopilot
-description: Autonomous epic-to-PR pipeline. Chains /discovery → /define → /implement end-to-end for each sub-issue, opening draft PRs.
+description: Autonomous epic-to-PR pipeline. Chains /discover → /define → /implement end-to-end for each sub-issue, opening draft PRs.
 when_to_use: Use when you have an epic issue number or a free-text description and want the full cycle automated.
 argument-hint: "[epic# | description]"
 model: opus
@@ -12,7 +12,7 @@ Autonomous epic-to-PR orchestrator. Takes an epic issue or description and produ
 ## Input
 
 - **Positive integer** → existing GitHub epic issue
-- **Any other string** → free-text description (triggers `/discovery` to create epic)
+- **Any other string** → free-text description (triggers `/discover` to create epic)
 
 ## Team Shape
 
@@ -26,7 +26,7 @@ Always multi-layer fan-out — dispatches one sub-agent per topological layer of
 4. **Stage 5 — Exit**: Print exit summary to stdout. Run is complete when all sub-PRs are open and epic PR is open. Merging is left to humans.
 
 **Key behaviors:**
-- Skip /discovery if epic has ≥3 acceptance criteria
+- Skip /discover if epic has ≥3 acceptance criteria
 - Skip /define if epic has implementation plan
 - Topologically sort sub-issues via Kahn's algorithm (with cycle breaking)
 - Dispatch tiers in parallel via Task sub-agents

--- a/skills/epic-autopilot/references/gates.md
+++ b/skills/epic-autopilot/references/gates.md
@@ -2,10 +2,10 @@
 
 ## Stage 1 — Discovery gate
 
-If input is a positive integer and the epic issue has a well-formed `## Requirements` section (≥3 acceptance criteria), skip /discovery and go to Stage 2.
+If input is a positive integer and the epic issue has a well-formed `## Requirements` section (≥3 acceptance criteria), skip /discover and go to Stage 2.
 
 Otherwise:
-1. Run `/discovery` on the epic (or free-text description). This is interactive.
+1. Run `/discover` on the epic (or free-text description). This is interactive.
 2. **Pause for explicit user approval.** Present: "Discovery complete. Review the issue body above. Approve to continue to /define, or provide feedback."
 3. Wait for explicit approval before proceeding.
 

--- a/skills/new-skill/references/interview-steps.md
+++ b/skills/new-skill/references/interview-steps.md
@@ -22,7 +22,7 @@ This file details the 12-step interview sequence that new-skill conducts with th
 **`AskUserQuestion`** with `header: "Mis-routing"`, question: "Could another skill be invoked instead of this one?"
 
 **Options:**
-- **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discovery'). This becomes the `when_to_use` frontmatter."
+- **Yes** — mis-routing is plausible; follow up with a free-text prompt: "Describe what this skill does NOT do and which skill handles it instead (e.g. 'Does NOT audit plugin files — use /prune for that'), and any sequence precondition (e.g. 'Use after /discover'). This becomes the `when_to_use` frontmatter."
 - **No / Skip** — omit `when_to_use` frontmatter.
 
 Only generate `when_to_use` frontmatter when the author answers Yes; omit otherwise.
@@ -32,7 +32,7 @@ Only generate `when_to_use` frontmatter when the author answers Yes; omit otherw
 **`AskUserQuestion`** with `header: "Role"`, question: "Which role does this skill fill?"
 
 **Options** (4-option limit — if the author is unsure between the two orchestrator variants, pick **Orchestrator** here and clarify in the follow-up):
-- **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discovery`, `/define`, `/implement`)
+- **Orchestrator** — leads a phase; spawns sub-skills or specialists; may write a handoff artifact (e.g. `/discover`, `/define`, `/implement`)
 - **Specialist** — executes a bounded task; receives a seed brief from an orchestrator (e.g. `/build`, `/review`, `/architecture`)
 - **Interactive primitive** — reusable inline behavior; invoked by specialists; no team, no handoff (e.g. `/grill-me`)
 - **Utility** — user-invocable maintenance/post-work skill; no seed brief, no handoff artifact (e.g. `/compound`, `/prune`, `/resolve-pr-feedback`)
@@ -40,7 +40,7 @@ Only generate `when_to_use` frontmatter when the author answers Yes; omit otherw
 **If Orchestrator:** Ask one follow-up `AskUserQuestion` with `header: "Orchestrator type"`, question: "Does this orchestrator do its own deep reasoning, or sequence already-designed sub-skills?"
 
 **Options:**
-- **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator layer (e.g. `/discovery`, `/define`). Defaults model to `opus` and `effort: high`.
+- **Research-leading** — spawns a research team before the main team; deep reasoning at the orchestrator layer (e.g. `/discover`, `/define`). Defaults model to `opus` and `effort: high`.
 - **Coordinator** — sequences sub-skills in a loop; research happens upstream or in the sub-skills (e.g. `/implement`). Defaults model to `sonnet`, no `effort`.
 
 This answer determines which template to use in step 3 and pre-fills the model/effort defaults (which the author can still override in steps e/f).

--- a/skills/specify/SKILL.md
+++ b/skills/specify/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: specify
 description: Turn a problem statement into precise, testable acceptance criteria.
-when_to_use: Use after /describe. Invoked by /discovery; can run standalone.
+when_to_use: Use after /describe. Invoked by /discover; can run standalone.
 model: sonnet
 user-invocable: true
 ---


### PR DESCRIPTION
## What

Final cleanup pass after PR #186 (discovery → discover rename + discover/describe boundary redesign). 

## Changes

### /discovery → /discover (all active docs)
- **README.md**: skill table, workflow paths, mermaid subgraph label + removed D_Scout node
- **AGENTS.md**: workflow path table, exploration note (preserved rename doc on line 58)
- **docs/workflow.md**: phase table, phase heading
- **docs/token-budgets.md**: budget table, anti-pattern example
- **skills/define/SKILL.md**: when_to_use, preamble
- **skills/specify/SKILL.md**: when_to_use
- **skills/epic-autopilot/SKILL.md**: description, input, key behavior
- **skills/epic-autopilot/references/gates.md**: stage 1 gate logic
- **skills/new-skill/references/interview-steps.md**: example values in mis-routing, role, orchestrator-type

### Post-redesign leftovers
- **docs/workflow.md**: Updated discover process from `Classify Scope → Prior-Art Scout` to match current flow (describe owns research)
- **skills/describe/references/scope-ppt.md**: Removed redundant Scope Assessment section (duplicated scope.md + SKILL.md process). File now contains only the PPT checklist.

### Preserved
- CHANGELOG.md (historical record)
- AGENTS.md rename documentation line
- AUTHORING.md breaking-change notice