### PR TITLE
v2: rebuild audit-issues as Orchestrator (#133)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ During `/define` or `/discover` exploration: time-box codebase reading to 3–5 
 - **Preflight before gh/git push.** Invoke `Skill("preflight")` — verifies repo, branch, CWD. Spawned workers skip preflight.
 - **NOTES.md** at `.claude/NOTES.md` is the in-phase progress ledger (gitignored). Create on entry, checkpoint before spawn, update on return, leave for the phase-ending skill.
 - **Seed-brief** (`_shared/seed-brief.md`) packages spawn-time context as YAML in XML. Used by orchestrators when spawning agents. NOT for mid-cycle state (use NOTES.md) or phase-to-phase handoff (use issue body).
-- **SKILL.md vs agent files**: SKILL.md owns process flow and spawn instructions. Agent files own the seed-brief I/O contract (input fields, output format). Never inline the contract in SKILL.md — reference the agent file. Agent file headings use `## Seed-Brief I/O Contract`. SKILL.md uses `## Worker Agent Inventory` with per-agent subsections.
+- **SKILL.md vs agent files**: SKILL.md owns process flow and spawn instructions. Agent files own the seed-brief I/O contract (input fields, output format). Never inline the contract in SKILL.md — reference the agent file. Agent file headings use `## Input (from spawn prompt)`. SKILL.md uses `## Worker Agent Inventory` with per-agent subsections.
 - **Handoff artifact** (`_shared/handoff-artifact.md`): five-field issue body structure (AC, Constraints, Prior decisions, Evidence, Open questions) for cross-phase state transfer.
 - **No autonomous merge.** Exit cleanly at awaiting-merge. Merging is always human.
 - **No issue body updates for intra-orchestrator state.** The five-field shape is for phase boundaries only.

--- a/skills/audit-issues/SKILL.md
+++ b/skills/audit-issues/SKILL.md
@@ -6,69 +6,71 @@ argument-hint: "[owner/repo | #NN | owner/repo#NN]"
 model: sonnet
 allowed-tools: Agent Bash Read
 ---
-Audit open issues for drift. Product: Updated issues themselves (mutate on confirm).
-Read-only default: mutate only after explicit per-issue confirmation.
+Audit open issues for drift against repo state. Product: updated issues themselves (mutate on confirm). Read-only by default — mutate only after explicit per-issue confirmation.
 
-## Input
-
-Target resolution:
-- Empty → `owner/repo` from cwd.
-- `owner/repo` → Use directly.
-- `#NN` → Resolve repo from cwd (single-issue audit).
-- `owner/repo#NN` → Split on `#`.
-
-- **Sourcing**: Must find local clone at `~/Projects/<repo>`. If missing → abort.
-- **Ref**: Fetch latest default branch via `git fetch origin` (do not check out).
-
-## Team Shape
-
-Invoke `Skill("orchestrator-rules")` for CWD verification, delegation, and seed-brief contract.
-
-Dispatch one `Agent("audit-issues/agents/issue-auditor.md")` per issue with a seed-brief containing `repo`, `issue_number`, `cwd`, and `default_branch_ref`. Fan-out in parallel for ≥3 issues; run inline for 1–2.
-
-See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for spawn cost models.
+Adopt `Skill("orchestrator-rules")` for seed-brief contract, CWD verification, and NOTES.md conventions.
 
 ## Process
 
-### Phase 1 — Fetch
-- **Targeted**: `gh issue view <NN>` + `gh issue list` (filtered).
-- **All-Open**: `gh issue list --state open --limit 0`.
-- Abort if issue is `closed`.
+### 1. Ingestion
 
-### Phase 2 — Per-Issue Audit
+Resolve target:
+- Empty → `owner/repo` from CWD.
+- `owner/repo` → use directly.
+- `#NN` → resolve repo from CWD (single-issue audit).
+- `owner/repo#NN` → split on `#`.
+
+Find local clone at `~/Projects/<repo>`. If missing → abort. Fetch latest default branch via `git fetch origin` (do not check out).
+
+### 2. Init NOTES.md
+
+Create `.claude/NOTES.md` with task list, decisions log, next-action per `Skill("orchestrator-rules")`.
+
+### 3. Fetch
+
+- Targeted: `gh issue view <NN>` + `gh issue list` (filtered).
+- All-open: `gh issue list --state open --limit 0`.
+
+### 4. Audit
+
 Read `references/detectors.md` for detector logic, verdict ranking, and JSON schema — pass pertinent rules into each spawn prompt so workers do not re-read.
 
-Spawn one agent per issue:
-```
-Agent("audit-issues/agents/issue-auditor.md") with prompt containing seed-brief:
-<seed-brief>
-repo: owner/repo
-issue_number: "123"
-cwd: /path/to/clone
-default_branch_ref: abc123def
-</seed-brief>
-```
+Spawn one `Agent("audit-issues/agents/issue-auditor.md")` per issue with a `<seed-brief>` YAML block containing `repo`, `issue_number`, `cwd`, and `default_branch_ref`. Fan-out in parallel for ≥3 issues; run inline for 1–2.
 
-### Phase 3 — Aggregate & Print
+Each `Agent()` spawn includes a `<seed-brief>` YAML block per `_shared/seed-brief.md`.
+
+See `${CLAUDE_PLUGIN_ROOT}/_shared/composition.md` for spawn cost models.
+
+### 5. Aggregate
+
 Concatenate JSON reports. Per-issue block: `─── #NN — <title> — verdict: <v> ───` → URL → findings → proposed edit.
 
-### Phase 4 — Interactive Mutation
-Walk blocks in order. Prompt based on verdict:
-- `valid` → `[s]kip ?`
-- `stale`/`contradicted`/`unverifiable` → `[e]dit / [s]kip ?`
-- `premise-shifted`/`superseded` → `[e]dit / [c]lose / [s]kip ?`
+### 6. Interactive Mutation
 
-**Mutation Rules**:
+Walk blocks in order. Prompt based on verdict:
+- `valid` → `[s]kip`
+- `stale`/`contradicted`/`unverifiable` → `[e]dit / [s]kip`
+- `premise-shifted`/`superseded` → `[e]dit / [c]lose / [s]kip`
+
+Mutation rules:
 - `e` → Show diff → `gh issue edit`.
 - `c` → Post closing comment → `gh issue close`.
 - `s` → Advance.
 
-## Output
+Require explicit user approval per mutation.
 
-Updated GitHub issues (mutated on confirm). No durable handoff artifact — this phase is terminal.
+### 7. Sign-off
+
+Require explicit user approval before applying mutations. No unconfirmed mutations.
+
+### 8. Compound on exit
+
+Read `${CLAUDE_PLUGIN_ROOT}/_shared/compound-on-exit.md`. Invoke `Skill("compound")` exactly once on clean completion.
 
 ## Rules
+
 - **No Auto-Clone**: Do not clone missing repos.
 - **No Invention**: No counter → `unverifiable`.
 - **Surgical**: One LLM extraction pass per issue max.
-- **Point-of-need reads**: Read `_shared/handoff-artifact.md` only when parsing handoff targets. Read `references/detectors.md` before Phase 2 only.
+- **Point-of-need reads**: Read `references/detectors.md` before step 4 only.
+- **NOTES.md**: Checkpoint before every spawn. See `Skill("orchestrator-rules")` § Progress tracking.

--- a/skills/audit-issues/agents/issue-auditor.md
+++ b/skills/audit-issues/agents/issue-auditor.md
@@ -9,7 +9,7 @@ memory: project
 ---
 Single-issue auditor. Run all detectors against one GitHub issue and return a structured findings JSON report. Spawned in parallel by `/audit-issues` — one per issue.
 
-## Seed-Brief I/O Contract
+## Input (from spawn prompt)
 
 The orchestrator passes context as a `<seed-brief>` YAML block in the spawn prompt:
 


### PR DESCRIPTION
Closes #133

## Context

Rebuild `/audit-issues` as a v2-conformant Orchestrator — delegation-only, ≤150 lines, `### N. Title` Process format, NOTES.md lifecycle, and proper agent I/O contracts. Removes legacy `## Input`/`## Team Shape`/`## Output` sections.

Also updates stale convention documentation in AGENTS.md (`## Seed-Brief I/O Contract` → `## Input (from spawn prompt)`).

## Acceptance Criteria

1. All `Agent()` spawns include comprehensive seed-brief — inline in Process step 4, cross-ref to `_shared/seed-brief.md`
2. SKILL.md ≤150 lines (77) — orchestration only, no domain work
3. Behavioral conventions via `Skill()` — `Skill(\"orchestrator-rules\")`, `Skill(\"compound\")`
4. Sub-skill linked — `audit-issues/agents/issue-auditor.md` in step 4
5. Agent I/O contract documented — `## Input (from spawn prompt)` with field table + `## Output` with JSON schema
6. Point-of-need reads — rule references `references/detectors.md` before step 4 only
7. Name/description preserved — frontmatter unchanged
8. `disallowedTools: Agent` prevents recursive spawning