### PR TITLE
feat: add git-cliff changelog handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -58,14 +66,26 @@ jobs:
           jq --arg v "$v" '.metadata.version = $v | .plugins[0].version = $v' .claude-plugin/marketplace.json > "$tmp"
           mv "$tmp" .claude-plugin/marketplace.json
 
+      - name: Update CHANGELOG
+        run: |
+          set -euo pipefail
+          tag="${{ steps.bump.outputs.tag }}"
+          sed -i '/^## \[Unreleased\]/,/^## \[/{/^## \[Unreleased\]/d;/^## \[/!d}' CHANGELOG.md
+          npx git-cliff --tag "$tag" --prepend CHANGELOG.md
+
       - name: Commit, tag, push
         run: |
           set -euo pipefail
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json CHANGELOG.md
           git commit -m "chore: release ${{ steps.bump.outputs.tag }}"
           git tag -a "${{ steps.bump.outputs.tag }}" -m "${{ steps.bump.outputs.tag }}"
           git push origin HEAD
           git push origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Generate release body
+        run: |
+          set -euo pipefail
+          npx git-cliff --latest --strip header --output /tmp/release-body.md
 
       - name: Package source tarball
         run: |
@@ -86,5 +106,5 @@ jobs:
         run: |
           gh release create "${{ steps.bump.outputs.tag }}" \
             --title "${{ steps.bump.outputs.tag }}" \
-            --generate-notes \
-            "$artifact"
+            --notes-file /tmp/release-body.md \
+            "${{ env.artifact }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,235 +1,202 @@
 # Changelog
 
-All notable changes to the **claude-workflow** plugin are recorded here. The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project follows [Semantic Versioning](https://semver.org/).
+All notable changes to the **claude-workflow** plugin are recorded here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 GitHub Releases (with auto-generated notes and source tarballs) remain the canonical artifact: <https://github.com/misiekhardcore/claude-workflow/releases>. This file mirrors them in repo so changes are visible without leaving the source tree.
 
 ## [Unreleased]
-
-### Changed
-
-- **Shared docs refactored** -- per-skill details moved out of `_shared/` protocol docs into the skills that own them:
-
-  - **`_shared/handoff-artifact.md`** trimmed to the general five-field protocol (purpose, shape, precedence, rules). Section-heading names (`## Requirements` for `/discovery`, `## Implementation plan` for `/define`) and the final-pass checklist inlined into their respective skill files.
-
-  - **`_shared/seed-brief.md`** trimmed to the universal protocol spec (purpose, format, required fields, orchestrator duties, specialist behavior, failure mode). Payload type definitions (`type: research`, `type: fix`, `type: prior-art`) and the canonical example moved to `skills/specialist-mode/SKILL.md`.
-
-  - **Per-skill handoff instructions added**: `/discovery` now declares its `## Requirements` section heading and final-pass checklist inline; `/define` declares its `## Implementation plan` heading and field requirements.
-
-  - **README**: Added `seed-brief.md` to the `_shared/` protocol table; updated `handoff-artifact.md` description to reflect the protocol-only scope.
-
-- **NOTES.md protocol broadened** -- ownership model shifted from "orchestrator-only" to ownership-transfer (orchestrator owns before spawn / after return, sub-skill owns during execution). Standalone L2 skills now use NOTES.md for their own multi-step tracking. Adds Orchestrator Checkpoint pattern (create on entry, checkpoint before spawn, update on return) and Seed-brief Slice pattern (progress field in seed-brief payload).
-- **Terminology standardized** -- all "tier" references in shared docs renamed to "layer" for consistency with the three-layer taxonomy. Affected files: _shared/notes-md-protocol.md (memory tier -> memory layer), README.md.
-
-- **Shared docs decoupled from skill names** -- removed hardcoded /build, /review, /verify, /implement, etc. references from 7 shared/protocol files. Skills are now referenced generically by role rather than by command name.
-
-- **Layer-3 boundary realignment** - five skills demoted from layer-3 (`Skill()` invocation) to `_shared/` reference docs (`Read`):
-  - `seed-brief` -> `_shared/seed-brief.md` - spawn-time context packaging format (data structure spec, not behavioral protocol)
-  - `worktree` -> `_shared/worktree-protocol.md` - `wt` CLI command reference (command cheat sheet, not behavioral protocol)
-  - `interviewing-rules` -> `_shared/interviewing-rules.md` - one-question-at-a-time user-interaction rules (interaction pattern, not cross-skill behavioral contract)
-  - `handoff-artifact` -> `_shared/handoff-artifact.md` - cross-phase handoff protocol for GitHub issue body (reference doc, not invoked skill)
-  - `notes-md` -> `_shared/notes-md-protocol.md` - in-phase memory layer lifecycle and structure (reference doc, not invoked skill)
-  - All callers updated from `Invoke \`Skill("name")\`` to `Read \`${CLAUDE_PLUGIN_ROOT}/_shared/<name>.md\``.
-  - `_shared/AUTHORING.md` decision rule refined with concrete examples; `_shared/` catalogue expanded.
-  - `skills/scope-assessment/SKILL.md` gained missing `layer: 3` frontmatter.
-
 ### Added
 
-- **`_shared/orchestrator-rules.md`** - new shared protocol extracting rules common to all pipeline orchestrators: CWD verification, delegation (no reimplemented sub-skill logic), no-autonomous-merge, and seed-brief contract. Replaces duplicated rules in `/issue-autopilot` and `/epic-autopilot`.
-
-- **`/issue-autopilot` skill** - new single-issue end-to-end pipeline that chains `/define` -> `/implement` -> `/resolve-pr-feedback` (looped to zero unresolved threads) -> `/compound` -> `/wrap-up`. State-based resume on re-invocation: each `/issue-autopilot <N>` call reads current issue/PR state and runs only the next applicable phase. Introduced as a new sibling skill rather than extending `/epic-autopilot` to keep the linear single-issue state machine separate from epic fanout logic. (#92)
-
-- **`agents/` directory** - new top-level directory for reusable agent definitions, mirroring the claude-obsidian pattern. Seeded with `agents/prune-lane.md`: a single-lane audit worker for `/prune` that documents the spawn-prompt contract (CWD verification, pre-enumerated file list, structured report output). (#76)
-
-### Renamed
-
-- **`/discovery` → `/discover`** — **breaking change**: existing `CLAUDE.md` references to `/discovery` will stop working. Update all occurrences manually; no compatibility shim is provided.
-
-### Changed
-
-- **`/prune` dispatches one Task sub-agent per lane** — rules, authoring, and vault lanes now run as parallel Task sub-agents. The main thread enumerates files and dispatches once, then aggregates the three lane reports. Prevents inline overrun on large skill plugin directories. Every spawn prompt includes `cd <abs-path> && pwd` CWD verification. (#76)
-
-- **`/resolve-pr-feedback` fix-dispatch threshold lowered to ≥2 file groups** — previously TeamCreate was gated at ≥3 groups; parallel subagents now trigger at ≥2 non-overlapping file groups. Reply drafting is always delegated (one sub-agent per thread) — pure I/O with no synthesis on the main thread. Spawn prompts include CWD verification. (#76)
-
-- **`/find-skills` delegates search to a research sub-agent** — the leaderboard check + CLI search pass is delegated to a haiku-model Task sub-agent; the main thread receives a list of candidate skills with one-line summaries and handles install confirmation and execution. Prevents verbose web-fetch results from bloating the main context. (#76)
-
-- **`/wrap-up`, `/grill-me`, `/specify` stay inline** — one-line rationale comments added to each SKILL.md: wrap-up (destructive sequential / low context cost), grill-me (interactive primitive), specify (interactive). No behavior change. (#76)
-
-- **`_shared/composition.md` — "Main-thread overrun" sub-section added** — counter-rule to "default to single-agent" for three trigger shapes: multi-file read sweep (≥5 files), N-way fan-out over independent items, and verbose-I/O with thin synthesis. Includes concrete spawn-prompt requirements (CWD verification, pre-enumerated paths, prior findings). References the existing `Inline overrun` failure-mode row. (#76)
-
-- **`_templates/AUTHORING.md` — inline-overrun smell checklist added** — four smells (file-sweep, fan-out, thin-synthesis, verbose-tool-output) with a remediation note. Placed in the Parallelism decision section so new skills are reviewed for delegation gaps at authoring time. (#76)
-
-- **`_templates/SKILL.orchestrator.template.md` — Spawn justification stub updated** — "inline overrun" listed as a valid dispatch trigger alongside cost-based parallelism, with a reference to the new composition.md sub-section. (#76)
-
-- **`effortLevel` → `effort` migration** — all 6 skills that declared `effortLevel: high` (architecture, define, describe, discovery, epic-autopilot, review) now use the correct harness field `effort: high`. Templates (`SKILL.specialist.template.md`, `SKILL.orchestrator.template.md`) and plugin guidance (`CLAUDE.md`, `AUTHORING.md`) updated in lockstep. Previously `effortLevel: high` was silently ignored; `effort: high` now enables the intended higher-effort execution.
-
-- **`AUTHORING.md` frontmatter table expanded** — `effortLevel` row replaced by `effort` (`low|medium|high|xhigh|max`); new rows added for `when_to_use`, `argument-hint`, `user-invocable`, and `disable-model-invocation`. Notes added for the 1,536-char combined `description + when_to_use` cap and the upstream `argument-hint` autocomplete bug ([anthropics/claude-code#46626](https://github.com/anthropics/claude-code/issues/46626)). Canonical frontmatter field order documented.
-
-- **`argument-hint` added** to 8 positional-argument skills: build (`[issue#]`), implement (`[issue#]`), review (`[PR# or URL]`), resolve-pr-feedback (`[thread-URL]`), audit-issues (`[owner/repo | #NN | owner/repo#NN]`), epic-autopilot (`[epic# | description]`), discovery (`[issue# | description]`), define (`[issue#]`).
-
-- **Descriptions trimmed to ≤150 chars** across 13 skills (prune, review, new-skill, grill-me, define, epic-autopilot, resolve-pr-feedback, verify, build, describe, wrap-up, architecture, design). Trigger-phrase content relocated to `when_to_use`; other overflow moved to skill body. No information discarded.
-
-- **`when_to_use` field added** to describe, discovery, specify, define (disambiguation guidance), and additionally to build, epic-autopilot, grill-me, prune, resolve-pr-feedback, wrap-up (trigger-phrase overflow from trimmed descriptions).
-
-- **`/new-skill` scaffolder updated** — step (e) renamed to `effort`, two new interview questions added: (f) `argument-hint` (free-text positional-arg hint; asked after description) and user-invocable follow-up in step (c) for Specialist/Primitive roles. Generation step updated to emit all four new fields in canonical order.
-
-- **Frontmatter field order normalized** across all SKILL.md files to canonical order: `name → description → when_to_use → argument-hint → model → effort → allowed-tools → user-invocable → disable-model-invocation`.
-
-## [1.0.2] — 2026-05-04
-
-### Fixed
-
-- **`marketplace.json` source format** — switched the single plugin entry from a github-ref object (`{ "source": "github", "repo": "misiekhardcore/claude-workflow", "ref": "main" }`) to the canonical self-reference form (`"source": "./"`). The github-ref form forced the plugin loader to perform a second clone (separate from the marketplace clone) into a versioned cache directory, and that step was failing silently across version bumps — `installed_plugins.json` would record the new version and a fresh `lastUpdated` timestamp, but the cache directory under `~/.claude/plugins/cache/claude-workflow/` would not exist on disk and `gitCommitSha` never advanced past the v0.7.0 commit. Existing broken installs may need to remove the `claude-workflow@claude-workflow` entry from `installed_plugins.json` and reinstall once. (#65)
-
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v1.0.1...v1.0.2)
-
-## [1.0.1] — 2026-05-03
-
-### Fixed
-
-- **`/implement` preflight branch display** refined; orchestrator template carves out a terminal-phase exception so `/implement` is correctly treated as the terminal step in the seed-brief contract introduced in 1.0.0. (#64)
-
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v1.0.0...v1.0.1)
-
-## [1.0.0] — 2026-05-03
-
-First major release. Locks in the specialist-mode contract that lets orchestrators drive the build → review → verify loop autonomously, repurposes `/wrap-up` from an audit step into a worktree-cleanup utility, and adds two new skills: `/epic-autopilot` (autonomous epic-to-PR pipeline) and `/audit-issues` (drift-check for open GitHub issues).
-
-### Added
-
-- **`/audit-issues`** skill — drift-checks open GitHub issues in a target repo against the current local working tree. Five detectors (file-path-existence, numeric-claim-drift, version-reference-staleness, resolved-open-question, cross-issue-contradiction), a verdict taxonomy (`unverifiable` > `premise-shifted` > `superseded by #N` > `contradicted` > `stale` > `valid`), and per-issue interactive `[e]dit / [c]lose / [s]kip` actions. Mutates only after explicit confirmation. Requires a local clone at `~/Projects/<repo>`. (#61)
-- **`/epic-autopilot`** skill — five-stage orchestrator that chains `/discovery → /define → /implement` end-to-end for each sub-issue of an epic. Human gates after `/discovery`, after the epic-level `/define`, and after each per-sub-issue `/define`; afterwards the autonomous phase opens the epic branch, computes a Kahn topological sort of dependencies, dispatches per-tier `Task` subagents in parallel, retries-once on failure, and opens draft sub-PRs plus a top-level epic PR. Resumable from any stage via markers in the epic issue body. (#60)
-- **`/review`** can now accept a PR number or URL as input (in addition to the existing branch-only mode) and post findings as inline GitHub comments + summary review, idempotent via fingerprint markers. Two new conditional personas: docs consistency and architecture / scope-creep. The fix-brief path inside `/implement` is unchanged. (#59)
-- **`autonomous: true`** seed-brief flag — when an orchestrator passes it, `/implement` skips the exhausted-exit prompt and accepts unconditionally, surfacing findings into the PR body's `## Notes`. Used by `/epic-autopilot`'s autonomous phase. (#60)
-
-### Changed — breaking
-
-- **`/wrap-up` repurposed** as a user-invoked cleanup utility: removes the feature worktree, deletes the branch, clears NOTES.md. State machine refuses outright on the default branch or out-of-tree paths; on a dirty worktree, surfaces unpushed/uncommitted state and requires a proceed-anyway confirmation. **No longer drafts an audit block** — that responsibility moved into `/implement`'s PR-body harvest. (#58)
-- **`_shared/handoff-artifact.md`** trimmed to two phase-boundary skills (`/discovery`, `/define`); `/implement` and `/wrap-up` are no longer phase-boundary skills. (#58)
+- Rebuild define
+- Clarify SKILL.md and agent file responsibilities, and document knowledge persistence in AGENTS.md
+- Add formatter test workflow and minify markdown tests
+- Enhance SKILL.md for clarity and detail in process descriptions
+- Rebuild audit-issues
+- Update SKILL.md for clarity and consistency - refine description, adjust model type, and streamline process steps
+- Rebuild new-skill as Orchestrator- Rewrite SKILL.md as thin Orchestrator with interview flow- Read _shared/AUTHORING.md and references/interview-steps.md at point of need- Consolidate to single minimal template approach- Remove layer: field from frontmatter (handled in #177)Co-authored-by: openhands <openhands@all-hands.dev>
+- Add AGENTS.md documentation for plugin commands and conventions
+- Create missing agent files for discovery and define
+- Add layer declarations to remaining v2 skills
+- Split interactive skills by consumption contract (autonomous research + interactive deliberation)
+- Rebuild verify and build as v2 L2 sub-skills
+- Rebuild find-skills and review as v2 L2 sub-skills
+- Rebuild describe and specify as v2 L2 sub-skills
+- Create worktree and notes-md L3 skills, update wrap-up and compound
+- Enhance SKILL.md files with detailed descriptions and user-invocable flags
+- Update SKILL.md files to clarify output and handoff processes
+- Add user-invocable frontmatter and caller contracts to simple L2 skills
+- Decouple shared docs by moving per-skill details into owning skills- _shared/handoff-artifact.md: Trimmed to protocol-only (five-field format,  shape, precedence, rules). Removed phase-specific heading rules and  final-pass checklist — these are now inline in each producing skill.- _shared/seed-brief.md: Trimmed to universal protocol spec. Payload type  definitions (research, fix, prior-art) and canonical example moved to  skills/specialist-mode/SKILL.md.- skills/discovery/SKILL.md: Added ## Requirements section heading and  final-pass checklist inline.- skills/define/SKILL.md: Cleaned handoff instructions to reference the  five-field format and ## Implementation plan heading.- skills/implement/SKILL.md: Clarified section heading origins (Requirements  from discovery, Implementation plan from define).- skills/specialist-mode/SKILL.md: Added Payload Types section (moved from  seed-brief) and Execution Delta table (seeded vs standalone behavior).- README.md: Added seed-brief.md to the _shared/ protocol table.Co-authored-by: openhands <openhands@all-hands.dev>
+- Add compound-on-exit protocol and assessment gate
+- Rebuild as L2 specialist with dual-mode seed-brief
+- Replace Lightweight/Standard/Deep scope labels with two-mechanism pattern
+- Promote behavioral _shared/ files to layer-3 skills
+- Author /scope-assessment as shared tier-3 skill
 
 ### Changed
 
-- **`/implement` end-to-end refactor** — introduced the `_shared/specialist-mode.md` contract (seed-brief detection, transport format, required fields, per-specialist skip-list) so orchestrators can drive `/build`, `/review`, `/verify`, `/describe`, `/specify`, `/architecture`, `/design` autonomously without re-running preflight per specialist. Audit content (assumptions, uncertainties, follow-ups, outstanding findings) is now harvested from `./.claude/NOTES.md` into the PR body's `## Notes` section before the PR opens — `/implement` is the terminal phase, its output is the PR, not an issue body update. (#58)
+- Remove outdated version references from AUTHORING.md
+- Rebuild epic-autopilot
+- Rebuild issue-autopilot
+- Rebuild /new-skill as Orchestrator
+- Rebuild /new-skill as Orchestrator
+- Rebuild audit-issues as Orchestrator
+- Feat/132 implement v2
+- Rebuild define
+- Remove stale /discovery references and post-redesign leftovers
+- Rebuild discover
+- Rebuild resolve-pr-feedback
+- Rebuild grill-me
+- Update bin/list-prune-files to remove dependency on layer: frontmatter field
+- Apply dispatch primitives framework — taxonomy, skill reclassification, issue audit
+- NOTES.md as orchestrator progress ledger with checkpoint/slice pattern
+- Layer-3 boundary realignment: demote seed-brief, worktree, interviewing-rules to _shared/
+- Switch license from MIT to PolyForm Noncommercial 1.0.0
+- V2 F1: bootstrap v2 branch and AUTHORING.md for tier-3 hierarchy
 
 ### Documentation
 
-- README skill table refreshed with `/audit-issues` and `/epic-autopilot`; `/wrap-up` description updated; flowchart adjusted (epic-autopilot in Other tools, audit-issues alongside it).
-- `docs/workflow.md` Step 6 rewritten for the new `/wrap-up` shape; added Maintenance section for `/audit-issues` and an Autonomous-variant section for `/epic-autopilot`; PR-body wording table now documents the `## Summary / ## Testing notes / ## Notes` template and the NOTES.md harvest.
-- New `CHANGELOG.md` mirroring GitHub Releases history in-repo.
+- Expand AGENTS.md with commit message formatting rules
+- Add AGENTS.md with PR formatting conventions
+- Update CHANGELOG with handoff-artifact and notes-md demotion
 
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.7.0...v1.0.0)
+### Fixed
 
-## [0.7.0] — 2026-04-27
-
+- Update argument-hint in SKILL.md to include PR-URL option
+- Correct AGENTS.md path in CLAUDE.md
+- Update skill count in marketplace.json description
+- Clarify filing step in compound skill process
+- Replace stale specialist-mode reference with implement-runner agent
+- Complete v2 terminology cleanup and documentation update
+## [1.6.2] - 2026-05-15
 ### Added
 
-- **`_shared/repo-preflight.md`** extracted from inline 4-step stanzas in `/build` and `/resolve-pr-feedback`; wired into `/discovery` (before `gh issue create`) and `/define` (before issue body update / sub-issue creation), closing the wrong-repo-mutation gap. (#55)
-- **`_shared/scope-preflight.md`** with trigger conditions (≥3 files or audit/refactor/normalize/sweep/propagate/extract/rename verbs) and file-list confirmation/refusal templates; wired into `/build` and `/resolve-pr-feedback`. (#55)
+- Run /compound at end of stage 4 for epic-level learnings
 
 ### Changed
 
-- **`/resolve-pr-feedback`** now resolves PR review threads via GraphQL `resolveReviewThread` for `fixed`, `fixed-differently`, and `not-addressing` verdicts; leaves `needs-human` and `replied` unresolved. (#56)
-- **`/specify`** requires fetch-and-confirm before treating any URL or external claim as authoritative; prohibits pasting unverified citations into spec/issue bodies. (#56)
+- Release v1.6.2
+## [1.6.1] - 2026-05-15
+### Changed
 
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.6.0...v0.7.0)
+- Release v1.6.1
 
-## [0.6.0] — 2026-04-26
+### Fixed
 
+- Move /compound review-time pass from stage 5 to stage 3
+## [1.6.0] - 2026-05-15
+### Changed
+
+- Release v1.6.0
+- Extract procedure to references/procedure.md
+
+### Documentation
+
+- Establish lazy-loading standard for skill reference files
+
+### Fixed
+
+- Enforce worktree creation for all build scopes
+## [1.5.1] - 2026-05-15
+### Changed
+
+- Release v1.5.1
+- Reduce issue-autopilot skill to 50-line cap
+- Reduce 9 over-cap skills to 50-line limit
+- Reduce build skill to 50-line cap
+- Reduce new-skill to 44-line cap, extract Process section
+- Reduce epic-autopilot skill to 50-line cap
+- Reduce find-skills skill to 50-line cap
+
+### Fixed
+
+- Update dispatch command to use ${PLUGIN_ROOT} for file listing
+- Replace [Ref:] shorthand with explicit read instructions across skills
+## [1.5.0] - 2026-05-14
+### Changed
+
+- Release v1.5.0
+- Redesign /prune: drop Rules+Vault lanes, add Dead-state audit
+## [1.4.0] - 2026-05-14
 ### Added
 
-- **`docs/token-budgets.md`** — per-artifact and per-phase token budgets, the context-rot threshold (~12% of window), CLAUDE.md placement and `@`-import syntax, and the skill-invocation duplication anti-pattern. Cross-referenced from `README.md`, `CLAUDE.md`, `_shared/composition.md`, `_shared/notes-md-protocol.md`, `docs/context-hygiene.md`, and `docs/cross-plugin.md`. (#52)
-- **`docs/cross-plugin.md`** — ecosystem coordination guide covering MCP scope (shared vs. plugin-bundled), inter-plugin dependency declarations, and CLAUDE.md layering across `~/.claude/CLAUDE.md`, `./CLAUDE.md`, and `./CLAUDE.local.md`. Documents the decision to keep `claude-obsidian` optional via runtime detection. (#50)
-- **`${CLAUDE_PLUGIN_DATA}`** documented in `_templates/AUTHORING.md` for persistent plugin state that survives updates, with the diff-then-install pattern for dependency caching. (#48)
+- Add /ship skill — single-issue end-to-end pipeline
+- Time-box codebase reading during /define and /discovery
 
 ### Changed
 
-- **Spawn-site audit** across all skills against the TeamCreate rubric in `_shared/composition.md`. Most spawn sites collapsed from `TeamCreate` to subagent fan-out where mid-task communication wasn't needed; remaining `TeamCreate` invocations now carry explicit justifications. (#47)
-- **Specialist spawn-site model tiers** — `/describe`, `/architecture`, `/design`, `/verify`, `/review` now name explicit `model:` per spawn site (sonnet for research/analysis, haiku for structured QA, opus reserved for lead-interactive and critical work). (#49)
-- **`_templates/AUTHORING.md`** — added "Parallelism decision" section linking to the composition rubric; orchestrator and specialist templates now require a Scope Assessment + Parallelism choice / spawn justification block. `/new-skill` interview asks an explicit parallelism question (no-parallelism / subagents / TeamCreate) before writing the skill. Added "Progressive disclosure via `references/`" section with a worked split rule. (#51)
-- **`/find-skills`** and **`/compound`** split out reference material into `references/` subdirectories per the new progressive-disclosure pattern, reducing main SKILL.md footprints by ~30%. (#51)
+- Release v1.4.0
+- Add explicit verification step to resolve-pr-feedback
 
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.5.0...v0.6.0)
+### Documentation
 
-## [0.5.0] — 2026-04-25
-
+- Add external-audience writing rule
+## [1.3.0] - 2026-05-12
 ### Added
 
-- **TeamCreate decision rubric** in `_shared/composition.md` — cost model (~7× tokens per Anthropic /en/costs), criteria for choosing `TeamCreate` over sub-agents (≥3 genuinely parallel sub-tasks with disjoint files and ≥3× wall-clock payoff), and worked examples. (#46)
+- Extend Authoring Lane to scan _shared/*.md and .claude/**/*.md
 
 ### Changed
 
-- **Skill descriptions trimmed to ≤150 chars** across the plugin so they fit in `claude plugin list` output without truncation. (#45)
-- **Release workflow** — version lockstep documented: `.claude-plugin/plugin.json` and both `metadata.version` + `plugins[0].version` in `.claude-plugin/marketplace.json` must agree, bumped together by the `Release` workflow. (#44)
-
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.4.0...v0.5.0)
-
-## [0.4.0] — 2026-04-23
-
+- Release v1.3.0
+- Improve skill authoring quality: conditional when_to_use, modularity, paired prohibitions
+## [1.2.0] - 2026-05-07
 ### Added
 
-- **Release workflow** (`.github/workflows/release.yml`) — `workflow_dispatch` with `patch | minor | major` bump; computes version, updates `plugin.json` + `marketplace.json` in lockstep, commits, tags, and creates a GitHub release with auto-generated notes and a source tarball. (#38)
-- **`/implement` design-before-build gate** — for `Standard` and `Deep` scope, `/implement` requires architecture decisions to be cross-phase verified before `/build` runs; design gate stays live even in specialist mode. (#20)
-- **`/build` and `/resolve-pr-feedback` repo pre-flight echo** — explicit confirmation step before any `git` or `gh` mutation, gating against wrong-repo writes. (#21)
-- **Final-pass checklist** in `_shared/handoff-artifact.md` — last-mile checklist for the handoff author. (#22)
+- Enrich skill/agent frontmatter — allowed-tools, when_to_use, effort, disable-model-invocation
 
 ### Changed
 
-- **Issue/PR sections use human-readable headings** (e.g. "Acceptance criteria") instead of machine-style placeholders. (#32)
-- **Empty handoff sections omitted** rather than rendered with `None` placeholders, keeping bodies clean. (#28)
-
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.3.0...v0.4.0)
-
-## [0.3.0] — 2026-04-20
-
+- Release v1.2.0
+## [1.1.0] - 2026-05-07
 ### Added
 
-- **`_shared/composition.md`** — four composition patterns (linear / branch / loop / parallel), three skill roles (orchestrator / specialist / primitive), and three structured briefs (research / prior-art / fix) with contracts and failure modes.
-- **Role-specific templates** — `SKILL.template.md` split into `SKILL.orchestrator.template.md`, `SKILL.specialist.template.md`, `SKILL.primitive.template.md`, each under 50 lines.
-- **`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`** prerequisite documented in `README.md` and `CLAUDE.md` for parallel composition.
+- Dispatch sub-agents in utility skills + main-thread-overrun guidance
+- Add GitHub Actions workflow for linting and formatting
+- Initialize project with package.json and package-lock.json
+- Extend /prune with empirical AGENTS.md authoring heuristics
 
 ### Changed
 
-- **`/specify`** and **`/design`** document optional prior-art and research brief inputs.
-- **`/new-skill`** asks about role and routes to the appropriate role-specific template.
-- **`AUTHORING.md`** gains a skill-types table and composition-patterns subsection.
-- **`docs/workflow.md`** cross-links to `composition.md`.
-- Stale references fixed in `docs/workflow.md`, `SKILL.template.md` frontmatter, and several skill files. (#12)
+- Release v1.1.0
+- Update SKILL.md files to improve formatting and clarity
 
-Closes #13, #11.
+### Documentation
 
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.2.0...v0.3.0)
+- Backfill 1.0.1 and 1.0.2 entries
 
-## [0.2.0] — 2026-04-17
+### Fixed
 
-### Changed — breaking
+- EffortLevel→effort migration, argument-hint, description trim, when_to_use
+- Require PR creation commands to run from worktree root
+- Compact context between build→review→verify cycles
+## [1.0.2] - 2026-05-04
+### Changed
 
-- **Decoupled from the vault path.** All 36 hardcoded `memory/wiki/` references removed across 9 files. Skills now speak `claude-obsidian`'s vocabulary (vault, hot cache, log, concept/entity/source notes, session archive) instead of filesystem paths.
-- **`/compound`** drafts a structured note and files it via `claude-obsidian:save` when the plugin is available; otherwise emits the note inline.
-- **`/prune`** splits into a CLAUDE.md+auto-memory lane that always runs, and a vault lane delegated to `wiki-lint` when `claude-obsidian` is installed.
-- **`/architecture`** and **`/define`** query the vault for prior patterns via `wiki-query` when available.
+- Release v1.0.2
 
+### Fixed
+
+- Use self-reference source instead of github+ref
+## [1.0.1] - 2026-05-03
+### Changed
+
+- Release v1.0.1
+
+### Documentation
+
+- Refresh skill table, /wrap-up shape, and add CHANGELOG
+
+### Fixed
+
+- Refine /implement preflight branch display + orchestrator template terminal-phase carve-out
+## [1.0.0] - 2026-05-03
 ### Added
 
-- **`docs/context-hygiene.md`** — the "Context Hygiene Between Workflow Phases" rationale moved into the plugin so it travels with the workflow regardless of whether any vault is installed.
-- **README**: "Optional: claude-obsidian integration" section.
+- /audit-issues skill — detect stale GitHub issues vs. current repo
+- Epic-autopilot skill — autonomous epic-to-PR pipeline
+- /implement end-to-end refactor — specialist-mode contract, PR-body audit, /wrap-up cleanup utility
 
-### Migration
+### Changed
 
-No migration is needed if you don't have `claude-obsidian` — skills just skip the vault lanes. To opt in, install `claude-obsidian` and run `/wiki` once to bootstrap a vault; the delegation kicks in automatically.
-
-Closes #9.
-
-[Full diff](https://github.com/misiekhardcore/claude-workflow/compare/v0.1.0...v0.2.0)
-
-## [0.1.0] — 2026-04-17
-
-First tagged public release.
-
-### Added
-
-- **17 workflow skills**: `/discovery`, `/define`, `/architecture`, `/design`, `/describe`, `/specify`, `/implement`, `/build`, `/review`, `/verify`, `/wrap-up`, `/compound`, `/prune`, `/find-skills`, `/grill-me`, `/resolve-pr-feedback`, `/new-skill`.
-- **4 shared protocols** under `_shared/`: `handoff-artifact.md`, `interviewing-rules.md`, `notes-md-protocol.md`, `compaction-protocol.md`.
-- **Authoring standard**: `_templates/SKILL.template.md`, `_templates/AUTHORING.md`, and the interactive `/new-skill` scaffolder.
-- **Self-marketplace**: `.claude-plugin/marketplace.json` + `plugin.json` shipped in-repo so the repo installs via a single `marketplace add`.
-
-[v0.1.0 release tag](https://github.com/misiekhardcore/claude-workflow/releases/tag/v0.1.0)
+- Release v1.0.0
+- Extend /review to accept external PRs + add docs and architecture personas

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: changelog
+
+changelog:
+	sed -i '/^## \[Unreleased\]/,/^## \[/{/^## \[Unreleased\]/d;/^## \[/!d}' CHANGELOG.md
+	npx git-cliff --unreleased --prepend CHANGELOG.md

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to the **claude-workflow** plugin are recorded here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+"""
+body = """
+{%- if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- else %}\
+## [Unreleased]
+{%- endif %}\
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first() }}
+{% for commit in commits %}
+- {{ commit.message | upper_first() }}
+{%- endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = [
+  { pattern = "\n[\\s\\S]*", replace = "" },
+  { pattern = " *\\(#\\d+\\)", replace = "" },
+  { pattern = "^Initial commit.*", replace = "chore: initial commit" },
+]
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^ci", group = "Infrastructure" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^bump", group = "Changed" },
+  { message = "^chore", group = "Changed" },
+  { message = "^perf", group = "Performance" },
+  { message = ".*", group = "Changed" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+skip_tags = "v0\\."
+topo_order = false
+sort_commits = "newest"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,32 @@
       "name": "claude-workflow",
       "version": "0.0.1",
       "devDependencies": {
+        "git-cliff": "^2.13.1",
         "husky": "^9.1",
         "lint-staged": "^15.5"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ansi-escapes": {
@@ -217,6 +238,22 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -251,6 +288,224 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff/-/git-cliff-2.13.1.tgz",
+      "integrity": "sha512-2BzXwrom+SMHeNA5Ut+MtzqXejg0wbVwmzj3k7e9w62UQoyCDrM9UIcvtl6hnT3jocEQ1zLRQBaXXx97Gmnk7A==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "execa": "^9.6.0"
+      },
+      "bin": {
+        "git-cliff": "lib/cli/cli.js"
+      },
+      "engines": {
+        "node": "^18.19 || >=20.6"
+      },
+      "optionalDependencies": {
+        "git-cliff-darwin-arm64": "2.13.1",
+        "git-cliff-darwin-x64": "2.13.1",
+        "git-cliff-linux-arm64": "2.13.1",
+        "git-cliff-linux-x64": "2.13.1",
+        "git-cliff-windows-arm64": "2.13.1",
+        "git-cliff-windows-x64": "2.13.1"
+      }
+    },
+    "node_modules/git-cliff-darwin-arm64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-darwin-arm64/-/git-cliff-darwin-arm64-2.13.1.tgz",
+      "integrity": "sha512-3ebPUnUlLmrSZDHknSZQmyZV7DEJVtKse8I25Am0cENET5Py9u9Hg9k8IRXdiDtHtPDs6MYZx7BOi11WtcfqSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/git-cliff-darwin-x64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-darwin-x64/-/git-cliff-darwin-x64-2.13.1.tgz",
+      "integrity": "sha512-KZfggGAiw1EvZH3BOUclEU4eGCP2+Z+lH/N2Ni3FH9L2M1U7FYJqqaMhqgO8azTj67betvDshH8WBUkIkSsVxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/git-cliff-linux-arm64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-linux-arm64/-/git-cliff-linux-arm64-2.13.1.tgz",
+      "integrity": "sha512-clNRcNzdvk4GKyTt3ZhhWqcrjVRghcUcGNSV/Y87YJf3Mc/zl9ajUAhnXPOBSX/KWBr2od5SmkCt0qGYagY07g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/git-cliff-linux-x64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-linux-x64/-/git-cliff-linux-x64-2.13.1.tgz",
+      "integrity": "sha512-gZcIQhIQ1lDUMD8UieUSEZAYoyZN7nPd8O3VQoj1Ddhqll4UAS1Zxms1SU3U8pb0UTdc2m3ia/wtOnyhvbjdjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/git-cliff-windows-arm64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-windows-arm64/-/git-cliff-windows-arm64-2.13.1.tgz",
+      "integrity": "sha512-+XubuQv68DuDwF0u6Af5d889MEf/RD48VBQS7ZmPi4sUSCXAZqRm1/ApCsStLqxMDCf1+7s05B/kNbm9wjV80A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/git-cliff-windows-x64": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/git-cliff-windows-x64/-/git-cliff-windows-x64-2.13.1.tgz",
+      "integrity": "sha512-Bi8ehp1VMkomY7M/356PgovKQ8CBRiuOOkq+aWC2evQuMFfXWjG0GBlPED9QkZoUJ4iQ5ygB5DYdK3BjhaOyPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/git-cliff/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/git-cliff/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/git-cliff/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/git-cliff/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -305,6 +560,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -313,6 +581,19 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -536,6 +817,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -570,6 +864,22 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -735,6 +1045,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -783,6 +1106,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format:fix": "bin/minify-md --write"
   },
   "devDependencies": {
+    "git-cliff": "^2.13.1",
     "husky": "^9.1",
     "lint-staged": "^15.5"
   },


### PR DESCRIPTION
## Summary

Add automated changelog generation using git-cliff, matching the pattern established in whisper-anywhere. Drops hand-maintained CHANGELOG.md in favor of tag-based regeneration.

## Testing notes

1. Run `make changelog` to prepend new unreleased entries to CHANGELOG.md
2. Verify `npx git-cliff` generates correct sections from conventional commits
3. Manually dispatch the Release workflow with patch/minor/major to verify full pipeline

## Notes

Closes #200

- Binary name is `git-cliff` (not `git cliff`) — `npx git-cliff` resolves from node_modules after npm ci
- Release.yml updated: adds npm ci, git-cliff changelog update with commit, and --notes-file for release body (strips top-level header via --strip header)
- Tags v0.* excluded per skip_tags pattern (too early to include)