### PR TITLE
fix: remove stale specialist-mode reference in README protocol table

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Shared protocols at `_shared/`:
 |`interviewing-rules.md`|One-question-at-a-time interview protocol|
 |`notes-md-protocol.md`|In-phase NOTES.md memory layer|
 |`orchestrator-rules.md`|Shared rules for pipeline orchestrators: CWD verification, delegation, no-autonomous-merge, seed-brief contract|
-|`seed-brief.md`|Spawn-time context packaging (YAML-in-XML) for orchestrator→specialist handoff; payload types defined in `specialist-mode`|
+|`seed-brief.md`|Spawn-time context packaging (YAML-in-XML) for orchestrator→specialist handoff|
 
 ## Releasing
 


### PR DESCRIPTION
## Context

The `seed-brief.md` row in the shared protocols table referenced `specialist-mode` for payload type definitions — that directory was removed during the v2 rebuild (the CHANGELOG shows it was relocated, then later dropped entirely). `_shared/seed-brief.md` now describes `payload` as a generic object whose shape is context-dependent.

## Changes

`README.md:164` — removed the trailing clause referencing the deleted `specialist-mode` directory.

## Testing

N/A — documentation only.