### PR TITLE
fix: add --unreleased flag to git-cliff in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           set -euo pipefail
           tag="${{ steps.bump.outputs.tag }}"
           sed -i '/^## \[Unreleased\]/,/^## \[/{/^## \[Unreleased\]/d;/^## \[/!d}' CHANGELOG.md
-          npx git-cliff --tag "$tag" --prepend CHANGELOG.md
+          npx git-cliff --tag "$tag" --unreleased --prepend CHANGELOG.md
 
       - name: Commit, tag, push
         run: |


### PR DESCRIPTION
## Context

[Release #17](https://github.com/misiekhardcore/claude-workflow/actions/runs/27615828264) failed at the **Update CHANGELOG** step.

## Root cause

The `npx git-cliff --tag "$tag" --prepend CHANGELOG.md` command requires either `--unreleased` (`-u`) or `--latest` (`-l`) to determine the commit scope. Without it, git-cliff exits with:

> Error: ArgumentError("'-u' or '-l' is not specified")

Since the tag doesn't exist yet when the CHANGELOG step runs (it's created in the subsequent **Commit, tag, push** step), `--unreleased` is the correct flag.

## Fix

Added `--unreleased` to the git-cliff invocation.

## Verification

Tested locally: `npx git-cliff --tag v1.7.0 --unreleased --prepend CHANGELOG.md` succeeds and correctly prepends the new version section.