### PR TITLE
chore: rebrand claude-workflow → agents-flow

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-workflow",
+  "name": "agents-flow",
   "owner": {
     "name": "Michal Konopski",
     "url": "https://github.com/misiekhardcore"
@@ -10,7 +10,7 @@
   },
   "plugins": [
     {
-      "name": "claude-workflow",
+      "name": "agents-flow",
       "source": "./",
       "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discover → /define → /implement. 26 skills, shared protocols, authoring standard, /new-skill scaffolder.",
       "version": "2.0.1",
@@ -18,8 +18,8 @@
         "name": "Michal Konopski",
         "url": "https://github.com/misiekhardcore"
       },
-      "homepage": "https://github.com/misiekhardcore/claude-workflow",
-      "repository": "https://github.com/misiekhardcore/claude-workflow",
+      "homepage": "https://github.com/misiekhardcore/agents-flow",
+      "repository": "https://github.com/misiekhardcore/agents-flow",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-workflow",
+  "name": "agents-flow",
   "version": "2.0.1",
   "description": "Workflow skills for Claude Code — standardized feature lifecycle: /discover → /define → /implement. Ships a family of lifecycle skills, shared protocols, an authoring standard, and the /new-skill scaffolder.",
   "author": {
@@ -7,8 +7,8 @@
     "url": "https://github.com/misiekhardcore"
   },
   "license": "MIT",
-  "homepage": "https://github.com/misiekhardcore/claude-workflow",
-  "repository": "https://github.com/misiekhardcore/claude-workflow",
+  "homepage": "https://github.com/misiekhardcore/agents-flow",
+  "repository": "https://github.com/misiekhardcore/agents-flow",
   "keywords": [
     "workflow",
     "skills",

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .claude/NOTES.md
 .worktrees/
 node_modules/
+opencode.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
-# AGENTS.md — claude-workflow plugin
+# AGENTS.md — agents-flow plugin
 
 ## Repository type
 
-This is a **Claude Code skills plugin** installed via `claude plugin marketplace add misiekhardcore/claude-workflow`. It is not a standalone app — skills live at `skills/<name>/SKILL.md` and are loaded by Claude Code at invocation time.
+This is a **Claude Code skills plugin** installed via `claude plugin marketplace add misiekhardcore/agents-flow`. It is not a standalone app — skills live at `skills/<name>/SKILL.md` and are loaded by Claude Code at invocation time.
 
 ## Commands
 
@@ -67,7 +67,7 @@ Token budgets per artifact/phase, CLAUDE.md placement rules, `@`-imports: `${CLA
 ## Plugin path variables
 
 - `${CLAUDE_PLUGIN_ROOT}` — plugin install dir. Skills reference `_shared/` via `${CLAUDE_PLUGIN_ROOT}/_shared/<file.md>`. Fallback: if not expanded inline, skills use `_shared/<file.md>` and Claude resolves via glob against `~/.claude/plugins/cache/<marketplace>/<version>/`.
-- `${CLAUDE_PLUGIN_DATA}` — `~/.claude/plugins/data/claude-workflow/` for persistent cached state.
+- `${CLAUDE_PLUGIN_DATA}` — `~/.claude/plugins/data/agents-flow/` for persistent cached state.
 
 ## Existing instruction files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the **claude-workflow** plugin are recorded here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+All notable changes to the **agents-flow** plugin are recorded here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [2.0.1] - 2026-06-16
 ### Fixed
@@ -75,9 +75,9 @@ All notable changes to the **claude-workflow** plugin are recorded here. The for
 - Complete v2 terminology cleanup and documentation update
 # Changelog
 
-All notable changes to the **claude-workflow** plugin are recorded here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+All notable changes to the **agents-flow** plugin are recorded here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-GitHub Releases (with auto-generated notes and source tarballs) remain the canonical artifact: <https://github.com/misiekhardcore/claude-workflow/releases>. This file mirrors them in repo so changes are visible without leaving the source tree.
+GitHub Releases (with auto-generated notes and source tarballs) remain the canonical artifact: <https://github.com/misiekhardcore/agents-flow/releases>. This file mirrors them in repo so changes are visible without leaving the source tree.
 
 ## [1.6.2] - 2026-05-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-workflow
+# agents-flow
 
 Workflow skills plugin for Claude Code — a standardized lifecycle for feature development.
 
@@ -86,8 +86,8 @@ flowchart TB
 ## Install
 
 ```bash
-claude plugin marketplace add misiekhardcore/claude-workflow
-claude plugin install claude-workflow@claude-workflow
+claude plugin marketplace add misiekhardcore/agents-flow
+claude plugin install agents-flow@agents-flow
 ```
 
 Then enable it in your project or globally in Claude Code settings.
@@ -167,7 +167,7 @@ Shared protocols at `_shared/`:
 
 Versions in `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (both `metadata.version` and `plugins[0].version`) must agree. Trigger the **Release** workflow via `workflow_dispatch` to bump all three in lockstep, commit, tag, and publish.
 
-Per-release notes with full diffs: [GitHub Releases](https://github.com/misiekhardcore/claude-workflow/releases). In-repo summary: [`CHANGELOG.md`](CHANGELOG.md).
+Per-release notes with full diffs: [GitHub Releases](https://github.com/misiekhardcore/agents-flow/releases). In-repo summary: [`CHANGELOG.md`](CHANGELOG.md).
 
 ## License
 

--- a/_shared/AUTHORING.md
+++ b/_shared/AUTHORING.md
@@ -1,6 +1,6 @@
 # Skill Authoring Guide
 
-This document defines the structural and behavioral conventions for building skills in `claude-workflow`.
+This document defines the structural and behavioral conventions for building skills in `agents-flow`.
 
 ## Role Taxonomy
 
@@ -43,7 +43,7 @@ user-invocable: false
 - Divide into sections: **Contract**, **Behavior**, **Verification** (as appropriate).
 - Document entry conditions, exit behaviors, and any state mutations.
 
-### Protocol Skills in `claude-workflow`
+### Protocol Skills in `agents-flow`
 
 The current Protocol skill catalog lives in `skills/`. Consult `ls skills/` for a list of available protocols. Each skill directory contains a `SKILL.md` with the authoritative protocol definition.
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,7 +2,7 @@
 header = """
 # Changelog
 
-All notable changes to the **claude-workflow** plugin are recorded here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+All notable changes to the **agents-flow** plugin are recorded here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
 """
 body = """

--- a/docs/cross-plugin.md
+++ b/docs/cross-plugin.md
@@ -1,26 +1,26 @@
 # Cross-plugin Coordination
 
-Plugin-specific decisions for `claude-workflow` and how it coexists with other Claude Code plugins. For general CLAUDE.md layering, `plugin.json.dependencies`, and MCP namespacing, see Anthropic's Claude Code plugin documentation and the [MCP specification](https://modelcontextprotocol.io/).
+Plugin-specific decisions for `agents-flow` and how it coexists with other Claude Code plugins. For general CLAUDE.md layering, `plugin.json.dependencies`, and MCP namespacing, see Anthropic's Claude Code plugin documentation and the [MCP specification](https://modelcontextprotocol.io/).
 
 ## MCP scope
 
-`claude-workflow` bundles no MCP servers. When a plugin needs an MCP that another plugin already provides, install it once at user scope (`~/.claude/`) rather than bundling a duplicate.
+`agents-flow` bundles no MCP servers. When a plugin needs an MCP that another plugin already provides, install it once at user scope (`~/.claude/`) rather than bundling a duplicate.
 
 Why: overlapping servers load under different identifiers (`<name>` vs `plugin:<plugin>:<name>`), forcing every consumer to branch on which is live.
 
-**Worked example**: both `claude-workflow` and `claude-obsidian` ship an `obsidian-vault` MCP server.
+**Worked example**: both `agents-flow` and `claude-obsidian` ship an `obsidian-vault` MCP server.
 
 |Source|Tool identifier|
 |-|-|
 |User scope (`~/.claude/`)|`mcp__obsidian-vault__obsidian_get_file_contents`|
-|`claude-workflow` plugin|`mcp__plugin_claude-workflow_obsidian-vault__obsidian_get_file_contents`|
+|`agents-flow` plugin|`mcp__plugin_agents-flow_obsidian-vault__obsidian_get_file_contents`|
 |`claude-obsidian` plugin|`mcp__plugin_claude-obsidian_obsidian-vault__obsidian_get_file_contents`|
 
 Both plugins boot separate server processes pointed at the same vault, doubling resource use and racing on writes. Skills written against one identifier silently no-op when only the other is installed. Installing the server once at user scope collapses all three rows to a single identifier.
 
 ## Optional `claude-obsidian` integration
 
-`claude-workflow` integrates with `claude-obsidian` via **runtime detection**, not `plugin.json.dependencies`. A hard dependency would block install for users who don't want the vault; runtime detection lets it degrade gracefully.
+`agents-flow` integrates with `claude-obsidian` via **runtime detection**, not `plugin.json.dependencies`. A hard dependency would block install for users who don't want the vault; runtime detection lets it degrade gracefully.
 
 Skills probe for these commands; vault-aware path activates if present, otherwise fall back inline:
 

--- a/docs/dispatch-primitives.md
+++ b/docs/dispatch-primitives.md
@@ -1,6 +1,6 @@
 # Dispatch Primitives — Decision Framework
 
-This document establishes when to use each dispatch mechanism in `claude-workflow` (`Skill`, `Agent`, `context: fork`, `agent:`, `isolation: worktree`) and defines the canonical role taxonomy (Orchestrator, Interaction, Worker, Protocol). It replaces the layer-number terminology in `AUTHORING.md` as the human-facing classification system.
+This document establishes when to use each dispatch mechanism in `agents-flow` (`Skill`, `Agent`, `context: fork`, `agent:`, `isolation: worktree`) and defines the canonical role taxonomy (Orchestrator, Interaction, Worker, Protocol). It replaces the layer-number terminology in `AUTHORING.md` as the human-facing classification system.
 
 ## Core Principle
 

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "skills": {
+    "paths": ["./skills"]
+  },
+  "instructions": ["./AGENTS.md"],
+  "references": {
+    "memory": {
+      "path": "~/Projects/claude-memory",
+      "description": "Obsidian wiki vault containing all project knowledge"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "claude-workflow",
+  "name": "agents-flow",
   "version": "0.0.1",
   "private": true,
   "engines": {


### PR DESCRIPTION
Renames repo from claude-workflow to agents-flow. Updates all references in package.json, plugin metadata, docs, changelog, and config files. Repo has been renamed at GitHub level, remote updated accordingly.