### PR TITLE
feat: adopt Opencode-Workflows authoring patterns

### DIFF
--- a/_shared/AUTHORING.md
+++ b/_shared/AUTHORING.md
@@ -198,6 +198,10 @@ When an orchestrator must decide how to fan out work across agents, use `/scope-
 
 Document the orchestrator's specific definition of "work unit" (what counts as an input, what its `resources` list must contain) in a dedicated `references/` doc. That doc must also cite `/scope-assessment` as the canonical decomposition algorithm. The protocol skill encodes the algorithm only; per-caller variation lives at the call site.
 
+## External Style & Config References
+
+See `_shared/rfc-xml-style-guide.md` for RFC 2119 + XML tag conventions and `_shared/opencode-config-reference.md` for opencode config/permission fields. These are the adopted external best-practice patterns for artifact authoring.
+
 ## `_shared/` File Catalogue
 
 Reference on-demand via `Read \`_shared/<file>.md\``:

--- a/_shared/frontmatter-reference.md
+++ b/_shared/frontmatter-reference.md
@@ -100,7 +100,7 @@ Default frontmatter values for each skill role. `/new-skill` uses these when gen
 |`allowed-tools`|omit|omit|omit|omit|omit|
 |`user-invocable`|omit (defaults true)|omit|omit|omit|`false`|
 
-See `_shared/AUTHORING.md` § Body Assembly by Role/Tier for the full role-to-template mapping.
+See `_shared/AUTHORING.md` § Body Assembly by Role/Tier for the full role-to-template mapping. See `_shared/opencode-config-reference.md` for how these opencode frontmatter fields map to workflow conventions.
 
 ## Field Mapping: Claude Code → OpenCode
 

--- a/_shared/opencode-config-reference.md
+++ b/_shared/opencode-config-reference.md
@@ -1,0 +1,61 @@
+# Opencode Config & Permission Reference
+
+## Permission Levels
+
+Every `permission` key in opencode agent frontmatter accepts one of three values:
+
+|Value|Meaning|
+|-|-|
+|`"allow"`|Allow without asking|
+|`"ask"`|Ask user for approval|
+|`"deny"`|Deny outright|
+
+Permission keys and their gated tools are documented in `_shared/frontmatter-reference.md` (§ Permission Keys).
+
+## Agent Frontmatter Fields
+
+|Field|Required|Values|Description|
+|-|-|-|-|
+|`mode`|no|`primary`, `subagent`, `all`|`primary` = Tab-switchable; `subagent` = Task/@-invoke only; `all` = both. Default `all`.|
+|`model`|no|`provider/model-id`|Model override (cross-reference `_shared/frontmatter-reference.md` for Claude Code model syntax).|
+|`permission`|no|object|Tool permission overrides per the Permission Keys table in `frontmatter-reference.md`.|
+|`tools`|no|list of tool names|Tool allowlist (opencode equivalent of Claude Code's `allowed-tools`).|
+|`template`|no|file path|Prompt template file path.|
+|`prompt`|no|string|Inline system prompt override.|
+|`temperature`|no|0.0–1.0|Response randomness. Omit for model default.|
+|`maxSteps`|no|number|Max agentic iterations before forced text response.|
+|`hidden`|no|`true`, `false`|Hide from `@` autocomplete. Only for `mode: subagent`.|
+|`disable`|no|`true`, `false`|Disable the agent entirely.|
+|`color`|no|hex or theme color|UI appearance.|
+|`top_p`|no|0.0–1.0|Response diversity (alternative to temperature).|
+
+## Command Frontmatter Fields
+
+|Field|Required|Values|Description|
+|-|-|-|-|
+|`name`|yes|lowercase kebab-case|Command name (slug used in `/` invocation).|
+|`description`|yes|string|Short description shown in command palette.|
+|`model`|no|`provider/model-id`|Model override for the command.|
+|`prompt`|no|string|Inline system prompt.|
+|`template`|no|file path|Prompt template file.|
+|`permission`|no|object|Tool permission overrides for command execution.|
+|`temperature`|no|0.0–1.0|Response randomness.|
+|`maxSteps`|no|number|Max iterations.|
+|`hidden`|no|`true`, `false`|Hide from command palette.|
+|`disable`|no|`true`, `false`|Disable command.|
+
+## Naming Reconciliation
+
+The IgorWarzocha/Opencode-Workflows repo uses different names for some fields. Cross-reference when working with both sources:
+
+|Our field|Their field|Notes|
+|-|-|-|
+|`maxSteps`|`steps`|Same semantics — max iterations before forced response|
+|`edit` (permission key)|`write`/`patch`|Their permission system splits write and patch; ours uses `edit` for both (`write`, `edit`, `apply_patch` tools)|
+
+## Cross-Reference
+
+See `_shared/frontmatter-reference.md` for:
+- The full permission key table with tool mappings
+- Claude Code ↔ OpenCode field mapping table
+- Per-role default values by field

--- a/_shared/rfc-xml-style-guide.md
+++ b/_shared/rfc-xml-style-guide.md
@@ -1,0 +1,53 @@
+# RFC 2119 + XML Tag Style Guide
+
+## Purpose
+
+RFC 2119 keywords + XML tags structure agent artifact prompts so the model parses role boundaries, rules, and output formats reliably — at zero tooling cost. Tags shape how an agent behaves; they must never leak into what it says to the user.
+
+## Tag Palette (6 Families)
+
+|Family|Tags|Purpose|
+|-|-|-|
+|`<rules>`|`<rules>`, `<constraint>`, `<critical>`|MUST-level requirements — hard stops, invariants, non-negotiables|
+|`<constraints>`|`<constraints>`, `<limitation>`, `<boundary>`|MUST NOT / scope boundaries — what the agent must not do|
+|`<guidelines>`|`<guidelines>`, `<recommendation>`, `<best-practice>`|SHOULD/MAY-level — recommended patterns, soft rules|
+|`<context>`|`<context>`, `<background>`, `<rationale>`, `<why>`|Prose context — the "why" behind the rules|
+|`<example>`|`<example>`, `<counterexample>`, `<template>`|Illustrative — concrete do/don't samples|
+|`<output>`|`<output>`, `<format>`, `<schema>`|Output contract — expected shape of the result|
+
+This is a recommended palette, not a closed contract. Artifacts may add purpose-specific tags as needed.
+
+## Placement Rules
+
+- **Wrap only major prose sections.** Use tags to delimit significant semantic blocks (e.g., the rules block, the constraints block, the output format). Do not tag every sentence.
+- **Never wrap frontmatter.** Frontmatter is mechanically parsed; tags belong in the prose body.
+- **Maximum 3–4 tag nesting levels.** Deeply nested tags degrade prompt quality. Flatten where possible.
+- **"Enhance, not obscure."** If a tag makes the prompt harder for a human or model to read, restructure.
+
+## RFC 2119 Mapping
+
+|Keyword|Tag family|When to use|
+|-|-|-|
+|MUST / MUST NOT|`<rules>` or `<constraints>`|Hard requirements, invariants, security boundaries|
+|SHOULD / SHOULD NOT|`<guidelines>`|Recommended but not absolute; deviation requires rationale|
+|MAY / OPTIONAL|`<guidelines>`|Permissive — agent may choose|
+
+## CAPS-is-Normative Convention
+
+Capitalized RFC 2119 keywords (MUST, MUST NOT, SHOULD, SHOULD NOT, MAY) are normative when used inside tag-delimited sections. Outside tags, CAPS carries no special semantics — write normally.
+
+## Structure Must Not Leak Into Voice
+
+The XML structure is for the model's consumption only. The artifact's user-facing output must read naturally — no tag syntax, no RFC 2119 jargon, no structural markup in delivered responses. This is the "enhance not obscure" rule applied to output: the agent uses tags to organize its own reasoning; the user sees clean prose.
+
+## Preamble (Optional)
+
+Artifacts MAY include a preamble before the first tagged section. When present it sets scope, audience, or invocation context. When absent — also valid; the tag-delimited body stands alone. Omission saves per-artifact tokens.
+
+## Token Budget Mitigation
+
+Wrapping only major prose sections (per Placement Rules above) keeps the tag overhead low. Tagged sections survive minification (`bin/minify-md`) intact because they are semantic markers, not formatting.
+
+## Opencode Integration Note
+
+opencode does not perform any tag parsing. The whole body — tags included — is opaque prompt text passed to the model. The convention is pure prompt-engineering. No tag-handling code, no parser, no schema is needed in the tool integration.

--- a/_templates/SKILL.template.md
+++ b/_templates/SKILL.template.md
@@ -9,4 +9,4 @@ description: <Does X. Use when Y.>
 # user-invocable: false  # Uncomment to hide from command menu
 compatibility: claude-code opencode
 ---
-<!-- Body sections assembled by role/tier per shared authoring guide (§ Body Assembly by Role/Tier). -->
+<!-- Body sections assembled by role/tier per shared authoring guide (§ Body Assembly by Role/Tier). For RFC 2119 + XML tag conventions see `_shared/rfc-xml-style-guide.md`; for opencode config/permission schema see `_shared/opencode-config-reference.md`. -->


### PR DESCRIPTION
## Summary

Adopt external best-practice patterns from IgorWarzocha/Opencode-Workflows per the decision record in #239.

### Changes
- **\_shared/rfc-xml-style-guide.md** — adapted RFC 2119 + XML tag style guide (6 tag families, placement rules, voice rules)
- **\_shared/opencode-config-reference.md** — opencode permission/config schema reference with naming reconciliation
- **Short pointers** added to AUTHORING.md, frontmatter-reference.md, SKILL.template.md

## Testing notes
Documentation only — no code changed.

## Notes
Closes #239. Prerequisite for S3 #230, S4 #231, S5 #232, S7 #234, S9 #237.