### PR TITLE
ci: point install-smoke trigger at renamed epic branch

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -2,7 +2,7 @@ name: Test install
 
 on:
   pull_request:
-    branches: [main, claude/opencode-native-rebuild]
+    branches: [main, epic/opencode-native-rebuild]
 
 jobs:
   smoke-test:


### PR DESCRIPTION
## What

Updates the `pull_request` branch filter in `.github/workflows/test-install.yml` from the old integration-branch name to the renamed one:

```diff
-    branches: [main, claude/opencode-native-rebuild]
+    branches: [main, epic/opencode-native-rebuild]
```

## Why

The integration branch `claude/opencode-native-rebuild` was renamed to `epic/opencode-native-rebuild`. Without this change, the Install smoke test would no longer trigger on PRs into the epic branch.

## Scope

Single-line CI config change; no behavior change to the install script or tests themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XFYjjd2FAtiktp8CM9Z4BV

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFYjjd2FAtiktp8CM9Z4BV)_