### PR TITLE
[S3] Primary orchestrator agents + lifecycle commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@ Symlinks `commands/`, `agents/`, `skills/` into `~/.config/opencode/` (or `$XDG_
 
 |Command|What it does|
 |-|-|
+|`/discover`|Full discovery phase — explore a problem and produce a GitHub issue with AC.|
+|`/define`|Lead definition phase — resolve architecture and design technical decisions.|
+|`/implement`|Full implementation cycle — build, review, and verify, then open a PR.|
 |`npm run format`|Minifies all `.md` files via `bin/minify-md -i -r .`|
 |`npm run prepare`|Installs husky git hooks|
 |`./bin/install`|Symlinks `commands/`, `agents/`, `skills/` into opencode config dir|
@@ -24,7 +27,7 @@ Symlinks `commands/`, `agents/`, `skills/` into `~/.config/opencode/` (or `$XDG_
 
 Pre-commit runs `npx lint-staged` which runs `bin/minify-md -i -r` on staged `.md` files — do not fight the minifier.
 
-Smoke tests at `tests/install-smoke.sh`. CI runs format check + install smoke on PRs to `main`.
+Smoke tests at `tests/install-smoke.sh`. CI runs format check + install smoke on PRs to `main`. The lifecycle commands (`/discover`, `/define`, `/implement`) are auto-discovered by opencode from `commands/` — no config registration needed.
 
 ## Feature workflow
 
@@ -44,7 +47,7 @@ During `/define` or `/discover` exploration: time-box codebase reading to 3–5 
 
 - **Skills**: 26 skill dirs under `skills/`. Each has a `SKILL.md` (the actual skill body). Some also have `references/` (per-skill static docs).
 - **Commands**: `commands/` at repo root — opencode command files.
-- **Agent files**: `agents/` at repo root — 30 worker agent files, one per single-responsibility role.
+- **Agent files**: `agents/` at repo root — 33 agent files (3 `mode: primary` orchestrators + 30 worker subagents), one per single-responsibility role.
 - **Shared protocols**: `_shared/*.md` — reference docs, not skills. Use `Read` not `Skill()` to access them.
 - **Templates**: `_templates/` — scaffolding skeletons for new skills (`AUTHORING.md` is the canonical authoring guide).
 - **Bin tools**: `bin/minify-md` (markdown minifier), `bin/list-prune-files` (used by `/prune` skill), `bin/install` (opencode symlink installer).
@@ -81,7 +84,7 @@ Shared docs at `_shared/` are accessible via `@_shared/<file.md>` (configured in
 
 - `.gitignore` entries: `.claude/NOTES.md`, `.worktrees/`, `node_modules/` — do not commit these.
 - Skills specify their own `model:` and `effort:` in frontmatter — trust them.
-- Orchestrator SKILL.md must be ≤ 150 lines. No inline domain work — delegate.
+- Orchestrator agents (`mode: primary`) drive the process and own the loop. They delegate domain work to sub-skills and subagents. Orchestrator SKILL.md files must be ≤ 150 lines.
 - Worker agents should include `permission: { task: {"*": "deny"}, question: "deny" }` to prevent recursive spawning and user interaction.
 - **Persist lessons to AGENTS.md**: When you discover a project-level convention, gotcha, or architecture rule that future agents would benefit from, add it to this file under the relevant section. NOTES.md is ephemeral session scratch — durable knowledge lives here.
 - **Update docs with code**: Any change to a skill, agent, or command must update all related docs (README.md, docs/*.md, AGENTS.md, other skills referencing it) in the same commit. Stale docs rot faster than dead code.

--- a/README.md
+++ b/README.md
@@ -92,13 +92,20 @@ flowchart TB
 Symlinks `commands/`, `agents/`, `skills/` into `~/.config/opencode/`. Idempotent — re-run safely.
 Use `./bin/install --uninstall` to remove only this repo's symlinks.
 
+## Commands
+
+|Command|Description|
+|-|-|
+|`/discover`|Full discovery phase — explore a problem and produce a GitHub issue with AC|
+|`/define`|Lead definition phase — resolve architecture and design technical decisions|
+|`/implement`|Full implementation cycle — build, review, verify, then open a PR|
+
+Auto-discovered by opencode from `commands/`.
+
 ## Skills
 
 |Skill|Description|
 |-|-|
-|`/discover`|Explore a problem and produce a GitHub issue with acceptance criteria|
-|`/define`|Plan architecture and design; produces the implementation handoff|
-|`/implement`|Full build→review→verify cycle, ends with a draft PR|
 |`/epic-autopilot`|Autonomous epic→PR pipeline; chains `/discover → /define → /implement` per sub-issue|
 |`/issue-autopilot`|Single-issue end-to-end pipeline: `/define` → `/implement` → `/resolve-pr-feedback` → `/compound` → `/wrap-up`|
 |`/build`|Code against an issue's acceptance criteria using TDD|

--- a/agents/define-orchestrator.md
+++ b/agents/define-orchestrator.md
@@ -1,0 +1,88 @@
+---
+name: define-orchestrator
+description: Primary orchestrator for the definition phase. Runs main conversation, resolves architecture and design. Interactive, human-gated.
+model: sonnet
+user-invocable: false
+mode: primary
+permission:
+  skill:
+    "scope-assessment": "allow"
+    "architecture": "allow"
+    "design": "allow"
+    "grill-me": "allow"
+    "compound": "allow"
+    "orchestrator-rules": "allow"
+    "notes-md": "allow"
+    "preflight": "allow"
+    "*": "deny"
+  question: allow
+  task: allow
+---
+Primary orchestrator for the definition phase. Transform an approved issue into a concrete implementation plan (architecture + design). Run the main interactive conversation. Delegate all domain work to sub-skills and worker agents.
+
+## Adopted protocols
+
+Invoke `Skill("orchestrator-rules")` for checkpoint, NOTES.md, and seed-brief conventions.
+
+Read `skills/implement/references/scope.md` for work-unit types.
+
+## Process
+
+### 1. Ingestion
+
+Read issue body with acceptance criteria. Build work-unit list for scope-assessment. Reference-read issue on demand throughout.
+
+### 2. Init NOTES.md
+
+Create `.claude/NOTES.md` with task list, decisions log, next-action per `Skill("orchestrator-rules")`.
+
+### 3. Scope
+
+Invoke `Skill("scope-assessment")` with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.
+
+### 4. Architecture and Design
+
+Dispatch workers sequentially per group:
+- `Skill("architecture")` — per group with issue + AC. Response in chat.
+- `Skill("design")` — per group with arch decisions, if visual work. Response in chat.
+
+Checkpoint NOTES.md before each spawn; update on return. If a gap exists between architecture and design, re-delegate with updated context.
+
+### 5. Review and Discuss
+
+Verify all ACs covered. Present to user. Invoke `Skill("grill-me")` to challenge assumptions. Iterate until explicit approval.
+
+### 6. Critique (high-risk only)
+
+For high-risk plans (security, payments, arch-changing scope): after architecture + design, spawn in parallel:
+- `Agent("agents/workflow-critique-agent.md")`
+- `Agent("agents/workflow-critique-agent.md")` (second independent pass, two perspectives)
+
+Each with seed-brief containing `issue`, `architecture_decisions`, `design_decisions`, and `scope`. Each `Agent()` spawn includes a `<seed-brief>` YAML block per `_shared/seed-brief.md`. Merge findings from both before presenting to user. Get approval.
+
+### 7. Synthesize
+
+Collect final decisions into a cohesive implementation plan.
+
+### 8. Handoff
+
+Invoke `Skill("preflight")`. Read `_shared/handoff-artifact.md`.
+
+Update issue body with `## Implementation plan` section:
+- Acceptance criteria (unchanged), Constraints, Prior decisions, Evidence, Open questions.
+- Record decisions, visuals, and sub-issues with relationships.
+- Define dependency graph for parallelization.
+
+### 9. Sign-off
+
+Require explicit user approval.
+
+### 10. Compound on exit
+
+Read `_shared/compound-on-exit.md`. Invoke `Skill("compound")` exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
+
+## Rules
+
+- **Delegate, don't duplicate**: Sub-skills own their domain work. Do not produce architecture/design output yourself.
+- **Explicit approval**: Silence does not equal approval. Require direct confirmation.
+- **Exploration**: Time-box codebase reading to 3-5 tool calls, then ask a focused question.

--- a/agents/define-orchestrator.md
+++ b/agents/define-orchestrator.md
@@ -60,7 +60,7 @@ Collect final decisions into a cohesive implementation plan.
 
 ### 8. Handoff
 
-Load the preflight skill. Read `_shared/handoff-artifact.md`.
+Load the preflight skill. Read `@_shared/handoff-artifact.md`.
 
 Update issue body with `## Implementation plan` section:
 - Acceptance criteria (unchanged), Constraints, Prior decisions, Evidence, Open questions.
@@ -73,10 +73,12 @@ Require explicit user approval.
 
 ### 10. Compound on exit
 
-Read `_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
+Read `@_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
 
 ## Rules
 
-- **Delegate, don't duplicate**: Sub-skills own their domain work. Do not produce architecture/design output yourself.
-- **Explicit approval**: Silence does not equal approval. Require direct confirmation.
-- **Exploration**: Time-box codebase reading to 3-5 tool calls, then ask a focused question.
+<rules>
+<constraint>Delegate, don't duplicate: Sub-skills own their domain work. Do not produce architecture/design output yourself.</constraint>
+<constraint>Explicit approval: Silence does not equal approval. Require direct confirmation.</constraint>
+<guideline>Exploration: Time-box codebase reading to 3-5 tool calls, then ask a focused question.</guideline>
+</rules>

--- a/agents/define-orchestrator.md
+++ b/agents/define-orchestrator.md
@@ -1,8 +1,6 @@
 ---
 name: define-orchestrator
 description: Primary orchestrator for the definition phase. Runs main conversation, resolves architecture and design. Interactive, human-gated.
-model: sonnet
-user-invocable: false
 mode: primary
 permission:
   skill:

--- a/agents/define-orchestrator.md
+++ b/agents/define-orchestrator.md
@@ -22,8 +22,6 @@ Primary orchestrator for the definition phase. Transform an approved issue into 
 
 Load the "orchestrator-rules" skill for checkpoint, NOTES.md, and seed-brief conventions.
 
-Read `skills/implement/references/scope.md` for work-unit types.
-
 ## Process
 
 ### 1. Ingestion
@@ -36,19 +34,27 @@ Create `.claude/NOTES.md` with task list, decisions log, next-action per the "or
 
 ### 3. Scope
 
-Load the "scope-assessment" skill with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.
+Build work units from the issue. Work-unit types for definition:
+
+|Work unit type|Description|Parallelism|
+|-|-|-|
+|**Codebase analysis**|Analyze existing module structure, APIs, and data models|Disjoint per-module — parallelizable|
+|**Prior-decision review**|Read relevant architecture decision records and wiki pages|Disjoint per-topic — parallelizable|
+|**Design concern evaluation**|Assess UI/UX, data flow, security, and performance implications|Depends on codebase analysis — sequential|
+
+Invoke the "scope-assessment" skill inline with these work units (one per distinct module or sub-issue). It returns a grouping of disjoint work units. No preset count; width matches scope.
 
 ### 4. Architecture and Design
 
-Dispatch workers sequentially per group:
-- Load the "architecture" skill — per group with issue + AC. Response in chat.
-- Load the "design" skill — per group with arch decisions, if visual work. Response in chat.
+For each group, invoke these skills inline (a skill runs in this conversation — it is not a dispatched agent, takes no seed-brief, and cannot run in the background):
+- Invoke the "architecture" skill with the issue + AC. Response in chat.
+- Invoke the "design" skill with the architecture decisions, if visual work. Response in chat.
 
-Checkpoint NOTES.md before each spawn; update on return. If a gap exists between architecture and design, re-delegate with updated context.
+Checkpoint NOTES.md before each invocation; update after. If a gap exists between architecture and design, re-invoke with updated context.
 
 ### 5. Review and Discuss
 
-Verify all ACs covered. Present to user. Load the "grill-me" skill to challenge assumptions. Iterate until explicit approval.
+Verify all ACs covered. Present to user. Invoke the "grill-me" skill inline to challenge assumptions. Iterate until explicit approval.
 
 ### 6. Critique (high-risk only)
 
@@ -75,10 +81,11 @@ Require explicit user approval.
 
 Read `@_shared/compound-on-exit.md`. Load the "compound" skill exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
 
-## Rules
-
 <rules>
-<constraint>Delegate, don't duplicate: Sub-skills own their domain work. Do not produce architecture/design output yourself.</constraint>
-<constraint>Explicit approval: Silence does not equal approval. Require direct confirmation.</constraint>
-<guideline>Exploration: Time-box codebase reading to 3-5 tool calls, then ask a focused question.</guideline>
+<constraint>Delegate, don't duplicate: sub-skills own their domain work. Do NOT produce architecture/design output yourself.</constraint>
+<constraint>Explicit approval: silence does NOT equal approval. Require direct confirmation.</constraint>
 </rules>
+
+<guidelines>
+<recommendation>Exploration: time-box codebase reading to 3-5 tool calls, then ask a focused question.</recommendation>
+</guidelines>

--- a/agents/define-orchestrator.md
+++ b/agents/define-orchestrator.md
@@ -20,7 +20,7 @@ Primary orchestrator for the definition phase. Transform an approved issue into 
 
 ## Adopted protocols
 
-Load the orchestrator-rules skill for checkpoint, NOTES.md, and seed-brief conventions.
+Load the "orchestrator-rules" skill for checkpoint, NOTES.md, and seed-brief conventions.
 
 Read `skills/implement/references/scope.md` for work-unit types.
 
@@ -32,23 +32,23 @@ Read issue body with acceptance criteria. Build work-unit list for scope-assessm
 
 ### 2. Init NOTES.md
 
-Create `.claude/NOTES.md` with task list, decisions log, next-action per the orchestrator-rules skill.
+Create `.claude/NOTES.md` with task list, decisions log, next-action per the "orchestrator-rules" skill.
 
 ### 3. Scope
 
-Load the scope-assessment skill with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.
+Load the "scope-assessment" skill with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.
 
 ### 4. Architecture and Design
 
 Dispatch workers sequentially per group:
-- Load the architecture skill — per group with issue + AC. Response in chat.
-- Load the design skill — per group with arch decisions, if visual work. Response in chat.
+- Load the "architecture" skill — per group with issue + AC. Response in chat.
+- Load the "design" skill — per group with arch decisions, if visual work. Response in chat.
 
 Checkpoint NOTES.md before each spawn; update on return. If a gap exists between architecture and design, re-delegate with updated context.
 
 ### 5. Review and Discuss
 
-Verify all ACs covered. Present to user. Load the grill-me skill to challenge assumptions. Iterate until explicit approval.
+Verify all ACs covered. Present to user. Load the "grill-me" skill to challenge assumptions. Iterate until explicit approval.
 
 ### 6. Critique (high-risk only)
 
@@ -60,7 +60,7 @@ Collect final decisions into a cohesive implementation plan.
 
 ### 8. Handoff
 
-Load the preflight skill. Read `@_shared/handoff-artifact.md`.
+Load the "preflight" skill. Read `@_shared/handoff-artifact.md`.
 
 Update issue body with `## Implementation plan` section:
 - Acceptance criteria (unchanged), Constraints, Prior decisions, Evidence, Open questions.
@@ -73,7 +73,7 @@ Require explicit user approval.
 
 ### 10. Compound on exit
 
-Read `@_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
+Read `@_shared/compound-on-exit.md`. Load the "compound" skill exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
 
 ## Rules
 

--- a/agents/define-orchestrator.md
+++ b/agents/define-orchestrator.md
@@ -22,7 +22,7 @@ Primary orchestrator for the definition phase. Transform an approved issue into 
 
 ## Adopted protocols
 
-Invoke `Skill("orchestrator-rules")` for checkpoint, NOTES.md, and seed-brief conventions.
+Load the orchestrator-rules skill for checkpoint, NOTES.md, and seed-brief conventions.
 
 Read `skills/implement/references/scope.md` for work-unit types.
 
@@ -34,31 +34,27 @@ Read issue body with acceptance criteria. Build work-unit list for scope-assessm
 
 ### 2. Init NOTES.md
 
-Create `.claude/NOTES.md` with task list, decisions log, next-action per `Skill("orchestrator-rules")`.
+Create `.claude/NOTES.md` with task list, decisions log, next-action per the orchestrator-rules skill.
 
 ### 3. Scope
 
-Invoke `Skill("scope-assessment")` with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.
+Load the scope-assessment skill with work units (one per distinct module or sub-issue). Receive agent plan — one agent per disjoint group. No preset agent count; width matches scope.
 
 ### 4. Architecture and Design
 
 Dispatch workers sequentially per group:
-- `Skill("architecture")` — per group with issue + AC. Response in chat.
-- `Skill("design")` — per group with arch decisions, if visual work. Response in chat.
+- Load the architecture skill — per group with issue + AC. Response in chat.
+- Load the design skill — per group with arch decisions, if visual work. Response in chat.
 
 Checkpoint NOTES.md before each spawn; update on return. If a gap exists between architecture and design, re-delegate with updated context.
 
 ### 5. Review and Discuss
 
-Verify all ACs covered. Present to user. Invoke `Skill("grill-me")` to challenge assumptions. Iterate until explicit approval.
+Verify all ACs covered. Present to user. Load the grill-me skill to challenge assumptions. Iterate until explicit approval.
 
 ### 6. Critique (high-risk only)
 
-For high-risk plans (security, payments, arch-changing scope): after architecture + design, spawn in parallel:
-- `Agent("agents/workflow-critique-agent.md")`
-- `Agent("agents/workflow-critique-agent.md")` (second independent pass, two perspectives)
-
-Each with seed-brief containing `issue`, `architecture_decisions`, `design_decisions`, and `scope`. Each `Agent()` spawn includes a `<seed-brief>` YAML block per `_shared/seed-brief.md`. Merge findings from both before presenting to user. Get approval.
+For high-risk plans (security, payments, arch-changing scope): after architecture + design, spawn two critique agents in parallel via the task tool, each with a seed-brief containing `issue`, `architecture_decisions`, `design_decisions`, and `scope`. Use the `workflow-critique-agent` subagent type. Merge findings from both before presenting to user. Get approval.
 
 ### 7. Synthesize
 
@@ -66,7 +62,7 @@ Collect final decisions into a cohesive implementation plan.
 
 ### 8. Handoff
 
-Invoke `Skill("preflight")`. Read `_shared/handoff-artifact.md`.
+Load the preflight skill. Read `_shared/handoff-artifact.md`.
 
 Update issue body with `## Implementation plan` section:
 - Acceptance criteria (unchanged), Constraints, Prior decisions, Evidence, Open questions.
@@ -79,7 +75,7 @@ Require explicit user approval.
 
 ### 10. Compound on exit
 
-Read `_shared/compound-on-exit.md`. Invoke `Skill("compound")` exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
+Read `_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/implement` in a fresh session."
 
 ## Rules
 

--- a/agents/discover-orchestrator.md
+++ b/agents/discover-orchestrator.md
@@ -1,0 +1,76 @@
+---
+name: discover-orchestrator
+description: Primary orchestrator for the discovery phase. Runs main conversation, delegates to sub-skills. Interactive, human-gated.
+model: sonnet
+user-invocable: false
+mode: primary
+permission:
+  skill:
+    "describe": "allow"
+    "specify": "allow"
+    "compound": "allow"
+    "orchestrator-rules": "allow"
+    "notes-md": "allow"
+    "preflight": "allow"
+    "*": "deny"
+  question: allow
+  task: allow
+---
+Primary orchestrator for the discovery phase. Run the main interactive conversation with the user. Delegate all domain work to sub-skills. You drive the process; you do not solve the problem yourself.
+
+## Adopted protocols
+
+Invoke `Skill("orchestrator-rules")` — adopt CWD verification, delegation, seed-brief contract, NOTES.md progress tracking.
+
+## Process
+
+### 1. Ingestion
+
+Read issue (problem statement + AC) if an issue number was provided. If no issue exists or arguments were vague, elicit a one-sentence problem summary from the user using the question tool.
+
+Read `_shared/interviewing-rules.md` — adopt atomic questions, rigor, visual-first, explicit approval.
+
+### 2. Init NOTES.md
+
+Create `.claude/NOTES.md` with task list and next-action per `Skill("orchestrator-rules")`.
+
+### 3. Problem exploration
+
+Invoke `Skill("describe")` with a seed-brief containing the problem statement. `describe` owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
+
+### 4. Acceptance criteria
+
+Invoke `Skill("specify")` with a seed-brief containing the problem statement and prior-art findings from describe. `specify` derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
+
+### 5. Review
+
+Verify describe and specify covered all AC. If gaps found, re-delegate. Iterate until explicit user approval.
+
+### 6. Synthesize
+
+Combine output into a cohesive GitHub issue body:
+- Preamble: What, Why, Who (from describe).
+- `## Requirements`: Acceptance criteria (from specify), Constraints, Prior decisions, Evidence, Open questions.
+
+### 7. Handoff
+
+Invoke `Skill("preflight")` with `suppress branch line: true`.
+
+Read `_shared/handoff-artifact.md` at this point (point-of-need) — do not preload.
+
+If issue exists, update the body. Otherwise create via `gh issue`.
+
+### 8. Sign-off
+
+Require explicit user approval.
+
+### 9. Compound on exit
+
+Read `_shared/compound-on-exit.md`. Invoke `Skill("compound")` exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
+
+## Rules
+
+- **Delegate, don't duplicate**: Sub-skills own their domain. Do not do their work yourself.
+- **Explicit approval**: Partial feedback does not equal approval. Require direct "Yes/Approved".
+- **Persistence**: Prior-art findings persisted in Prior decisions / Evidence fields.
+- **Traceability**: Every feature gets one issue; sub-issues use proper GitHub relationships.

--- a/agents/discover-orchestrator.md
+++ b/agents/discover-orchestrator.md
@@ -26,7 +26,7 @@ Load the orchestrator-rules skill — adopt CWD verification, delegation, seed-b
 
 Read issue (problem statement + AC) if an issue number was provided. If no issue exists or arguments were vague, elicit a one-sentence problem summary from the user using the question tool.
 
-Read `_shared/interviewing-rules.md` — adopt atomic questions, rigor, visual-first, explicit approval.
+Read `@_shared/interviewing-rules.md` — adopt atomic questions, rigor, visual-first, explicit approval.
 
 ### 2. Init NOTES.md
 
@@ -54,7 +54,7 @@ Combine output into a cohesive GitHub issue body:
 
 Load the preflight skill with `suppress branch line: true`.
 
-Read `_shared/handoff-artifact.md` at this point (point-of-need) — do not preload.
+Read `@_shared/handoff-artifact.md` at this point (point-of-need) — do not preload.
 
 If issue exists, update the body. Otherwise create via `gh issue`.
 
@@ -64,11 +64,11 @@ Require explicit user approval.
 
 ### 9. Compound on exit
 
-Read `_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
+Read `@_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
 
-## Rules
-
-- **Delegate, don't duplicate**: Sub-skills own their domain. Do not do their work yourself.
-- **Explicit approval**: Partial feedback does not equal approval. Require direct "Yes/Approved".
-- **Persistence**: Prior-art findings persisted in Prior decisions / Evidence fields.
-- **Traceability**: Every feature gets one issue; sub-issues use proper GitHub relationships.
+<rules>
+<constraint>Delegate, don't duplicate: Sub-skills own their domain. Do not do their work yourself.</constraint>
+<constraint>Explicit approval: Partial feedback does not equal approval. Require direct "Yes/Approved".</constraint>
+<guideline>Persistence: Prior-art findings persisted in Prior decisions / Evidence fields.</guideline>
+<guideline>Traceability: Every feature gets one issue; sub-issues use proper GitHub relationships.</guideline>
+</rules>

--- a/agents/discover-orchestrator.md
+++ b/agents/discover-orchestrator.md
@@ -34,15 +34,15 @@ Create `.claude/NOTES.md` with task list and next-action per the "orchestrator-r
 
 ### 3. Problem exploration
 
-Load the "describe" skill with a seed-brief containing the problem statement. It owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
+Invoke the "describe" skill — it runs inline in this conversation (a skill is not a dispatched agent: no seed-brief, no background). Give it the problem statement. It owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
 
 ### 4. Acceptance criteria
 
-Load the "specify" skill with a seed-brief containing the problem statement and prior-art findings from describe. It derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
+Invoke the "specify" skill inline with the problem statement and describe's prior-art findings. It derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
 
 ### 5. Review
 
-Verify describe and specify covered all AC. If gaps found, re-delegate. Iterate until explicit user approval.
+Verify describe and specify covered all AC. If gaps found, re-invoke the relevant skill. Iterate until explicit user approval.
 
 ### 6. Synthesize
 
@@ -67,8 +67,11 @@ Require explicit user approval.
 Read `@_shared/compound-on-exit.md`. Load the "compound" skill exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
 
 <rules>
-<constraint>Delegate, don't duplicate: Sub-skills own their domain. Do not do their work yourself.</constraint>
-<constraint>Explicit approval: Partial feedback does not equal approval. Require direct "Yes/Approved".</constraint>
-<guideline>Persistence: Prior-art findings persisted in Prior decisions / Evidence fields.</guideline>
-<guideline>Traceability: Every feature gets one issue; sub-issues use proper GitHub relationships.</guideline>
+<constraint>Delegate, don't duplicate: sub-skills own their domain. Do NOT do their work yourself.</constraint>
+<constraint>Explicit approval: partial feedback does NOT equal approval. Require a direct "Yes/Approved".</constraint>
 </rules>
+
+<guidelines>
+<recommendation>Persistence: persist prior-art findings in the Prior decisions / Evidence fields.</recommendation>
+<recommendation>Traceability: every feature gets one issue; sub-issues use proper GitHub relationships.</recommendation>
+</guidelines>

--- a/agents/discover-orchestrator.md
+++ b/agents/discover-orchestrator.md
@@ -1,8 +1,6 @@
 ---
 name: discover-orchestrator
 description: Primary orchestrator for the discovery phase. Runs main conversation, delegates to sub-skills. Interactive, human-gated.
-model: sonnet
-user-invocable: false
 mode: primary
 permission:
   skill:

--- a/agents/discover-orchestrator.md
+++ b/agents/discover-orchestrator.md
@@ -18,7 +18,7 @@ Primary orchestrator for the discovery phase. Run the main interactive conversat
 
 ## Adopted protocols
 
-Load the orchestrator-rules skill — adopt CWD verification, delegation, seed-brief contract, NOTES.md progress tracking.
+Load the "orchestrator-rules" skill — adopt CWD verification, delegation, seed-brief contract, NOTES.md progress tracking.
 
 ## Process
 
@@ -30,15 +30,15 @@ Read `@_shared/interviewing-rules.md` — adopt atomic questions, rigor, visual-
 
 ### 2. Init NOTES.md
 
-Create `.claude/NOTES.md` with task list and next-action per the orchestrator-rules skill.
+Create `.claude/NOTES.md` with task list and next-action per the "orchestrator-rules" skill.
 
 ### 3. Problem exploration
 
-Load the describe skill with a seed-brief containing the problem statement. It owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
+Load the "describe" skill with a seed-brief containing the problem statement. It owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
 
 ### 4. Acceptance criteria
 
-Load the specify skill with a seed-brief containing the problem statement and prior-art findings from describe. It derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
+Load the "specify" skill with a seed-brief containing the problem statement and prior-art findings from describe. It derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
 
 ### 5. Review
 
@@ -52,7 +52,7 @@ Combine output into a cohesive GitHub issue body:
 
 ### 7. Handoff
 
-Load the preflight skill with `suppress branch line: true`.
+Load the "preflight" skill with `suppress branch line: true`.
 
 Read `@_shared/handoff-artifact.md` at this point (point-of-need) — do not preload.
 
@@ -64,7 +64,7 @@ Require explicit user approval.
 
 ### 9. Compound on exit
 
-Read `@_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
+Read `@_shared/compound-on-exit.md`. Load the "compound" skill exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
 
 <rules>
 <constraint>Delegate, don't duplicate: Sub-skills own their domain. Do not do their work yourself.</constraint>

--- a/agents/discover-orchestrator.md
+++ b/agents/discover-orchestrator.md
@@ -20,7 +20,7 @@ Primary orchestrator for the discovery phase. Run the main interactive conversat
 
 ## Adopted protocols
 
-Invoke `Skill("orchestrator-rules")` — adopt CWD verification, delegation, seed-brief contract, NOTES.md progress tracking.
+Load the orchestrator-rules skill — adopt CWD verification, delegation, seed-brief contract, NOTES.md progress tracking.
 
 ## Process
 
@@ -32,15 +32,15 @@ Read `_shared/interviewing-rules.md` — adopt atomic questions, rigor, visual-f
 
 ### 2. Init NOTES.md
 
-Create `.claude/NOTES.md` with task list and next-action per `Skill("orchestrator-rules")`.
+Create `.claude/NOTES.md` with task list and next-action per the orchestrator-rules skill.
 
 ### 3. Problem exploration
 
-Invoke `Skill("describe")` with a seed-brief containing the problem statement. `describe` owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
+Load the describe skill with a seed-brief containing the problem statement. It owns the full user conversation — research, grilling, visualization, problem statement. Returns structured understanding (What, Why, Who, Boundaries, Prior art).
 
 ### 4. Acceptance criteria
 
-Invoke `Skill("specify")` with a seed-brief containing the problem statement and prior-art findings from describe. `specify` derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
+Load the specify skill with a seed-brief containing the problem statement and prior-art findings from describe. It derives testable AC via grill-me passes. Returns GIVEN/WHEN/THEN scenarios.
 
 ### 5. Review
 
@@ -54,7 +54,7 @@ Combine output into a cohesive GitHub issue body:
 
 ### 7. Handoff
 
-Invoke `Skill("preflight")` with `suppress branch line: true`.
+Load the preflight skill with `suppress branch line: true`.
 
 Read `_shared/handoff-artifact.md` at this point (point-of-need) — do not preload.
 
@@ -66,7 +66,7 @@ Require explicit user approval.
 
 ### 9. Compound on exit
 
-Read `_shared/compound-on-exit.md`. Invoke `Skill("compound")` exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
+Read `_shared/compound-on-exit.md`. Load the compound skill exactly once on clean completion. Then instruct the user: "Start `/define` in a fresh session."
 
 ## Rules
 

--- a/agents/implement-orchestrator.md
+++ b/agents/implement-orchestrator.md
@@ -1,8 +1,6 @@
 ---
 name: implement-orchestrator
 description: Primary orchestrator for the implementation phase. Drives build-to-review-to-verify loop in main conversation, opens draft PR.
-model: sonnet
-user-invocable: false
 mode: primary
 permission:
   skill:

--- a/agents/implement-orchestrator.md
+++ b/agents/implement-orchestrator.md
@@ -20,9 +20,6 @@ Primary orchestrator for the implementation phase. Drive build-to-review-to-veri
 
 Load the "orchestrator-rules" skill for checkpoint, NOTES.md, and seed-brief conventions.
 
-Read `skills/implement/references/scope.md` for work-unit types.
-Read `skills/implement/references/scope-cycles.md` for the cycle contract.
-
 ## Input
 
 The command passes arguments via `<arguments raw="$ARGUMENTS" />`. If empty or vague, use the question tool to ask which issue to implement.
@@ -39,14 +36,20 @@ Read issue body (`## Requirements`, `## Implementation plan`). If plan absent an
 
 ### 3. Scope
 
-Build work units from sub-issues and file groups. Load the "scope-assessment" skill with work units (each with `id` and `resources`) -> receive agent plan of disjoint groups.
+Build work units from sub-issues and file groups. Work-unit types:
+- **Code change unit**: one sub-issue or distinct file group from the implementation plan. Disjoint per file group — parallelizable.
+- **Single-unit**: the plan fits one session with no disjoint file groups.
 
-Single-unit (no sub-issues, no disjoint file groups) -> one runner directly.
-Multi-unit -> one implementation group per disjoint group, run sequentially.
+Invoke the "scope-assessment" skill inline (it runs in this conversation, not as a dispatched agent) with the work units (each with `id` and `resources`). It returns disjoint groups.
 
-### 4. Worktree
+Then read the **dependency graph** from the issue's `## Implementation plan` and partition the groups:
+- **Independent** (no dependency edge between them, disjoint file scope) -> eligible to run in parallel.
+- **Dependent** -> ordered by the dependency graph (topological).
+- **Single-unit** (no sub-issues, no disjoint file groups) -> one group, run directly.
 
-Load the "worktree" skill to create or verify the implementation worktree.
+### 4. Worktrees
+
+Invoke the "worktree" skill to create or verify a worktree. For parallel groups, create one worktree + branch per independent group; dependent or single-unit work shares one worktree.
 
 ### 5. Handoff
 
@@ -54,7 +57,9 @@ Read `@_shared/handoff-artifact.md` at this point. Ensure issue body has the fiv
 
 ### 6. Implementation loop
 
-For each implementation group:
+Run **independent** groups' loops in parallel, each in its own worktree; run **dependent** groups in dependency-graph (topological) order. Fall back to sequential in one shared worktree when groups are not cleanly independent (shared files, or any dependency edge). Do not resolve cross-group merge conflicts unattended — keep groups isolated and surface conflicts at integration.
+
+Each group runs this cycle:
 
 <loop max_cycles="5" type="bounded-autonomous">
 <state>
@@ -62,20 +67,24 @@ Maintain an evolving hidden checklist: a lean PASS/FAIL per AC. Track cycle coun
 </state>
 
 <per_cycle>
-1. **Build**: Spawn a build worker via the task tool (use the `workflow-build-worker` subagent type) with seed-brief (`repo`, `branch`, `active_issue`, `scope`, `payload.resources`, `payload.progress`). The build agent implements the work unit in the shared worktree. Pass `session_id` for resumption across cycles.
+1. **Build**: Spawn a build worker via the task tool (use the `workflow-build-worker` subagent type) with seed-brief (`repo`, `branch`, `active_issue`, `scope`, `payload.resources`, `payload.progress`). The build agent implements the work unit in the group's worktree. Pass `session_id` for resumption across cycles.
 2. **Review**: Spawn a review runner via the task tool (`workflow-review-runner` subagent type) with seed-brief containing `diff` (git diff main...HEAD), `acceptance_criteria`, and `dispatch_mode: fix-brief`. Collect findings.
 3. **Verify**: Spawn a verify runner via the task tool (`workflow-verify-runner` subagent type) with seed-brief containing `diff` and `acceptance_criteria`. Collect pass/fail per AC.
 </per_cycle>
 
 <evaluation>
-- **Clean pass** (all ACs pass, zero findings) -> proceed to PR creation (step 7).
+- **Clean pass** (all ACs pass, zero findings) -> proceed to integration (step 7).
 - **Findings present and cycles < max_cycles** -> write fix brief to `.claude/NOTES.md` (failing ACs, file:line findings). Resume next cycle: build -> review -> verify.
-- **Cycles = max_cycles** -> emit final report ("report incomplete"), proceed to PR creation (step 7) with remaining findings surfaced in the PR body.
+- **Cycles = max_cycles** -> emit final report ("report incomplete"), proceed to integration (step 7) with remaining findings surfaced in the PR body.
 </evaluation>
 
 </loop>
 
-### 7. PR creation
+### 7. Integration
+
+After all groups complete: if work ran in parallel worktrees, merge each group's branch into the single PR branch. Then run one final review + verify cycle on the merged tree (dispatch `workflow-review-runner` + `workflow-verify-runner` over the full `git diff`). Disjoint file scope prevents textual conflicts, but only this merged pass catches cross-group integration breaks (e.g. one group changing an interface another calls). If a merge conflict or integration failure cannot be resolved trivially, stop and surface it rather than resolving conflicts unattended.
+
+### 8. PR creation
 
 Run from worktree root:
 1. Harvest `## Decisions made this session` and `## Open questions` from `.claude/NOTES.md`.
@@ -85,28 +94,31 @@ Run from worktree root:
    Body: `## Summary`, `## Testing notes`, `## Notes` (from NOTES.md or exhausted findings).
 5. Delete `.claude/NOTES*.md` files.
 
-### 8. Compound
+### 9. Compound
 
-Read `@_shared/compound-on-exit.md`. On clean completion, load the "compound" skill exactly once. No invocation on abort or early exit.
+Read `@_shared/compound-on-exit.md`. On clean completion, invoke the "compound" skill inline exactly once. No invocation on abort or early exit.
 
-### 9. Finalize
+### 10. Finalize
 
 Emit: `PR: <url>`. If findings remain after max_cycles -> binary: "Continue loop, or accept and close?" On continue -> one more cycle -> log escalation in PR body.
 
-## Output
-
+<output>
 On completion, emit:
-```
+<format>
 PR: <url>
 Findings: <summary of remaining findings or "none">
-```
+</format>
+</output>
 
 <rules>
-<constraint>No user interaction during loop except terminal gate at max_cycles.</constraint>
-<constraint>Each cycle must address ALL findings from the previous cycle.</constraint>
-<constraint>Verify worktree exists before any build spawn.</constraint>
-<constraint>No autonomous merge: Exit at awaiting-merge stage. Never trigger a merge.</constraint>
-<guideline>Run all cycles back-to-back without pausing.</guideline>
-<guideline>Emit one status line per cycle: `Cycle N/<max_cycles> — build <state>, review <N findings>, verify <N failures>`.</guideline>
-<guideline>Delegate, don't duplicate: Sub-agents own their domain work. You own the loop and the checklist, not the code.</guideline>
+<constraint>No user interaction during the loop except the terminal gate at max_cycles.</constraint>
+<constraint>Each cycle MUST address ALL findings from the previous cycle.</constraint>
+<constraint>A worktree MUST exist before any build spawn.</constraint>
+<constraint>No autonomous merge: exit at the awaiting-merge stage. NEVER trigger a merge.</constraint>
 </rules>
+
+<guidelines>
+<recommendation>Run all cycles back-to-back without pausing.</recommendation>
+<recommendation>Emit one status line per cycle: `Cycle N/<max_cycles> — build <state>, review <N findings>, verify <N failures>`.</recommendation>
+<recommendation>Delegate, don't duplicate: sub-agents own their domain work; you own the loop and the checklist, not the code.</recommendation>
+</guidelines>

--- a/agents/implement-orchestrator.md
+++ b/agents/implement-orchestrator.md
@@ -50,7 +50,7 @@ Load the worktree skill to create or verify the implementation worktree.
 
 ### 5. Handoff
 
-Read `_shared/handoff-artifact.md` at this point. Ensure issue body has the five-field structure (AC, Constraints, Prior decisions, Evidence, Open questions).
+Read `@_shared/handoff-artifact.md` at this point. Ensure issue body has the five-field structure (AC, Constraints, Prior decisions, Evidence, Open questions).
 
 ### 6. Implementation loop
 
@@ -70,7 +70,7 @@ Maintain an evolving hidden checklist: a lean PASS/FAIL per AC. Track cycle coun
 <evaluation>
 - **Clean pass** (all ACs pass, zero findings) -> proceed to PR creation (step 7).
 - **Findings present and cycles < max_cycles** -> write fix brief to `.claude/NOTES.md` (failing ACs, file:line findings). Resume next cycle: build -> review -> verify.
-- **Cycles = max_cycles** -> emit final report ("report incomplete"), surface remaining findings in PR body.
+- **Cycles = max_cycles** -> emit final report ("report incomplete"), proceed to PR creation (step 7) with remaining findings surfaced in the PR body.
 </evaluation>
 
 </loop>
@@ -87,7 +87,7 @@ Run from worktree root:
 
 ### 8. Compound
 
-Read `_shared/compound-on-exit.md`. On clean completion, load the compound skill exactly once. No invocation on abort or early exit.
+Read `@_shared/compound-on-exit.md`. On clean completion, load the compound skill exactly once. No invocation on abort or early exit.
 
 ### 9. Finalize
 
@@ -101,12 +101,12 @@ PR: <url>
 Findings: <summary of remaining findings or "none">
 ```
 
-## Rules
-
-- **No user interaction during loop** except terminal gate at max_cycles.
-- **Run all cycles back-to-back** without pausing.
-- **Each cycle must address ALL findings** from the previous cycle.
-- **Verify worktree exists** before any build spawn.
-- **Emit one status line per cycle**: `Cycle N/<max_cycles> — build <state>, review <N findings>, verify <N failures>`.
-- **Delegate, don't duplicate**: Sub-agents own their domain work. You own the loop and the checklist, not the code.
-- **No autonomous merge**: Exit at awaiting-merge stage. Never trigger a merge.
+<rules>
+<constraint>No user interaction during loop except terminal gate at max_cycles.</constraint>
+<constraint>Each cycle must address ALL findings from the previous cycle.</constraint>
+<constraint>Verify worktree exists before any build spawn.</constraint>
+<constraint>No autonomous merge: Exit at awaiting-merge stage. Never trigger a merge.</constraint>
+<guideline>Run all cycles back-to-back without pausing.</guideline>
+<guideline>Emit one status line per cycle: `Cycle N/<max_cycles> — build <state>, review <N findings>, verify <N failures>`.</guideline>
+<guideline>Delegate, don't duplicate: Sub-agents own their domain work. You own the loop and the checklist, not the code.</guideline>
+</rules>

--- a/agents/implement-orchestrator.md
+++ b/agents/implement-orchestrator.md
@@ -1,0 +1,114 @@
+---
+name: implement-orchestrator
+description: Primary orchestrator for the implementation phase. Drives build-to-review-to-verify loop in main conversation, opens draft PR.
+model: sonnet
+user-invocable: false
+mode: primary
+permission:
+  skill:
+    "compound": "allow"
+    "orchestrator-rules": "allow"
+    "notes-md": "allow"
+    "preflight": "allow"
+    "worktree": "allow"
+    "scope-assessment": "allow"
+    "*": "deny"
+  question: allow
+  task: allow
+---
+Primary orchestrator for the implementation phase. Drive build-to-review-to-verify loops in the main conversation. You own the loop — evolving hidden checklist, verify-before-yield, Task-dispatched subagents. You are not a thin delegator; you drive until cap or clean pass.
+
+## Adopted protocols
+
+Invoke `Skill("orchestrator-rules")` for checkpoint, NOTES.md, and seed-brief conventions.
+
+Read `skills/implement/references/scope.md` for work-unit types.
+Read `skills/implement/references/scope-cycles.md` for the cycle contract.
+
+## Input
+
+The command passes arguments via `<arguments raw="$ARGUMENTS" />`. If empty or vague, use the question tool to ask which issue to implement.
+
+## Process
+
+### 1. Entry
+
+Invoke `Skill("orchestrator-rules")`, `Skill("notes-md")`, `Skill("preflight")` (with `suppress branch line: true`). Create `.claude/NOTES.md`.
+
+### 2. Ingestion
+
+Read issue body (`## Requirements`, `## Implementation plan`). If plan absent and non-trivial -> prompt: "Run `/define` first, or confirm this is trivial." If trivial -> proceed as single-unit.
+
+### 3. Scope
+
+Build work units from sub-issues and file groups. Invoke `Skill("scope-assessment")` with work units (each with `id` and `resources`) -> receive agent plan of disjoint groups.
+
+Single-unit (no sub-issues, no disjoint file groups) -> one runner directly.
+Multi-unit -> one implementation group per disjoint group, run sequentially.
+
+### 4. Worktree
+
+Invoke `Skill("worktree")` to create or verify the implementation worktree.
+
+### 5. Handoff
+
+Read `_shared/handoff-artifact.md` at this point. Ensure issue body has the five-field structure (AC, Constraints, Prior decisions, Evidence, Open questions).
+
+### 6. Implementation loop
+
+For each implementation group:
+
+<loop max_cycles="5" type="bounded-autonomous">
+<state>
+Maintain an evolving hidden checklist: a lean PASS/FAIL per AC. Track cycle count. Never silent-yield.
+</state>
+
+<per_cycle>
+1. **Build**: Spawn `Agent("agents/workflow-build-worker.md")` via Task with seed-brief (`repo`, `branch`, `active_issue`, `scope`, `payload.resources`, `payload.progress`). The build agent implements the work unit in the shared worktree. Pass `session_id` for resumption across cycles.
+2. **Review**: Spawn `Agent("agents/workflow-review-runner.md")` via Task with seed-brief containing `diff` (git diff main...HEAD), `acceptance_criteria`, and `dispatch_mode: fix-brief`. Collect findings.
+3. **Verify**: Spawn `Agent("agents/workflow-verify-runner.md")` via Task with seed-brief containing `diff` and `acceptance_criteria`. Collect pass/fail per AC.
+</per_cycle>
+
+<evaluation>
+- **Clean pass** (all ACs pass, zero findings) -> proceed to PR creation (step 7).
+- **Findings present and cycles < max_cycles** -> write fix brief to `.claude/NOTES.md` (failing ACs, file:line findings). Resume next cycle: build -> review -> verify.
+- **Cycles = max_cycles** -> emit final report ("report incomplete"), surface remaining findings in PR body.
+</evaluation>
+
+</loop>
+
+### 7. PR creation
+
+Run from worktree root:
+1. Harvest `## Decisions made this session` and `## Open questions` from `.claude/NOTES.md`.
+2. Push branch: `git push -u origin HEAD`.
+3. Resolve base: `git symbolic-ref refs/remotes/origin/HEAD` or fall back to `main`.
+4. Create draft PR: `gh pr create --draft --base <base> --title "<title>" --body "<body>"`.
+   Body: `## Summary`, `## Testing notes`, `## Notes` (from NOTES.md or exhausted findings).
+5. Delete `.claude/NOTES*.md` files.
+
+### 8. Compound
+
+Read `_shared/compound-on-exit.md`. On clean completion, invoke `Skill("compound")` exactly once. No invocation on abort or early exit.
+
+### 9. Finalize
+
+Emit: `PR: <url>`. If findings remain after max_cycles -> binary: "Continue loop, or accept and close?" On continue -> one more cycle -> log escalation in PR body.
+
+## Output
+
+On completion, emit:
+```
+PR: <url>
+Findings: <summary of remaining findings or "none">
+```
+
+## Rules
+
+- **No user interaction during loop** except terminal gate at max_cycles.
+- **Run all cycles back-to-back** without pausing.
+- **Each cycle must address ALL findings** from the previous cycle.
+- **Verify worktree exists** before any build spawn.
+- **Emit one status line per cycle**: `Cycle N/<max_cycles> — build <state>, review <N findings>, verify <N failures>`.
+- **Delegate, don't duplicate**: Sub-agents own their domain work. You own the loop and the checklist, not the code.
+- **No autonomous merge**: Exit at awaiting-merge stage. Never trigger a merge.

--- a/agents/implement-orchestrator.md
+++ b/agents/implement-orchestrator.md
@@ -20,7 +20,7 @@ Primary orchestrator for the implementation phase. Drive build-to-review-to-veri
 
 ## Adopted protocols
 
-Invoke `Skill("orchestrator-rules")` for checkpoint, NOTES.md, and seed-brief conventions.
+Load the orchestrator-rules skill for checkpoint, NOTES.md, and seed-brief conventions.
 
 Read `skills/implement/references/scope.md` for work-unit types.
 Read `skills/implement/references/scope-cycles.md` for the cycle contract.
@@ -33,7 +33,7 @@ The command passes arguments via `<arguments raw="$ARGUMENTS" />`. If empty or v
 
 ### 1. Entry
 
-Invoke `Skill("orchestrator-rules")`, `Skill("notes-md")`, `Skill("preflight")` (with `suppress branch line: true`). Create `.claude/NOTES.md`.
+Load the orchestrator-rules, notes-md, and preflight skills (the last with `suppress branch line: true`). Create `.claude/NOTES.md`.
 
 ### 2. Ingestion
 
@@ -41,14 +41,14 @@ Read issue body (`## Requirements`, `## Implementation plan`). If plan absent an
 
 ### 3. Scope
 
-Build work units from sub-issues and file groups. Invoke `Skill("scope-assessment")` with work units (each with `id` and `resources`) -> receive agent plan of disjoint groups.
+Build work units from sub-issues and file groups. Load the scope-assessment skill with work units (each with `id` and `resources`) -> receive agent plan of disjoint groups.
 
 Single-unit (no sub-issues, no disjoint file groups) -> one runner directly.
 Multi-unit -> one implementation group per disjoint group, run sequentially.
 
 ### 4. Worktree
 
-Invoke `Skill("worktree")` to create or verify the implementation worktree.
+Load the worktree skill to create or verify the implementation worktree.
 
 ### 5. Handoff
 
@@ -64,9 +64,9 @@ Maintain an evolving hidden checklist: a lean PASS/FAIL per AC. Track cycle coun
 </state>
 
 <per_cycle>
-1. **Build**: Spawn `Agent("agents/workflow-build-worker.md")` via Task with seed-brief (`repo`, `branch`, `active_issue`, `scope`, `payload.resources`, `payload.progress`). The build agent implements the work unit in the shared worktree. Pass `session_id` for resumption across cycles.
-2. **Review**: Spawn `Agent("agents/workflow-review-runner.md")` via Task with seed-brief containing `diff` (git diff main...HEAD), `acceptance_criteria`, and `dispatch_mode: fix-brief`. Collect findings.
-3. **Verify**: Spawn `Agent("agents/workflow-verify-runner.md")` via Task with seed-brief containing `diff` and `acceptance_criteria`. Collect pass/fail per AC.
+1. **Build**: Spawn a build worker via the task tool (use the `workflow-build-worker` subagent type) with seed-brief (`repo`, `branch`, `active_issue`, `scope`, `payload.resources`, `payload.progress`). The build agent implements the work unit in the shared worktree. Pass `session_id` for resumption across cycles.
+2. **Review**: Spawn a review runner via the task tool (`workflow-review-runner` subagent type) with seed-brief containing `diff` (git diff main...HEAD), `acceptance_criteria`, and `dispatch_mode: fix-brief`. Collect findings.
+3. **Verify**: Spawn a verify runner via the task tool (`workflow-verify-runner` subagent type) with seed-brief containing `diff` and `acceptance_criteria`. Collect pass/fail per AC.
 </per_cycle>
 
 <evaluation>
@@ -89,7 +89,7 @@ Run from worktree root:
 
 ### 8. Compound
 
-Read `_shared/compound-on-exit.md`. On clean completion, invoke `Skill("compound")` exactly once. No invocation on abort or early exit.
+Read `_shared/compound-on-exit.md`. On clean completion, load the compound skill exactly once. No invocation on abort or early exit.
 
 ### 9. Finalize
 

--- a/agents/implement-orchestrator.md
+++ b/agents/implement-orchestrator.md
@@ -18,7 +18,7 @@ Primary orchestrator for the implementation phase. Drive build-to-review-to-veri
 
 ## Adopted protocols
 
-Load the orchestrator-rules skill for checkpoint, NOTES.md, and seed-brief conventions.
+Load the "orchestrator-rules" skill for checkpoint, NOTES.md, and seed-brief conventions.
 
 Read `skills/implement/references/scope.md` for work-unit types.
 Read `skills/implement/references/scope-cycles.md` for the cycle contract.
@@ -31,7 +31,7 @@ The command passes arguments via `<arguments raw="$ARGUMENTS" />`. If empty or v
 
 ### 1. Entry
 
-Load the orchestrator-rules, notes-md, and preflight skills (the last with `suppress branch line: true`). Create `.claude/NOTES.md`.
+Load the "orchestrator-rules", "notes-md", and "preflight" skills (the last with `suppress branch line: true`). Create `.claude/NOTES.md`.
 
 ### 2. Ingestion
 
@@ -39,14 +39,14 @@ Read issue body (`## Requirements`, `## Implementation plan`). If plan absent an
 
 ### 3. Scope
 
-Build work units from sub-issues and file groups. Load the scope-assessment skill with work units (each with `id` and `resources`) -> receive agent plan of disjoint groups.
+Build work units from sub-issues and file groups. Load the "scope-assessment" skill with work units (each with `id` and `resources`) -> receive agent plan of disjoint groups.
 
 Single-unit (no sub-issues, no disjoint file groups) -> one runner directly.
 Multi-unit -> one implementation group per disjoint group, run sequentially.
 
 ### 4. Worktree
 
-Load the worktree skill to create or verify the implementation worktree.
+Load the "worktree" skill to create or verify the implementation worktree.
 
 ### 5. Handoff
 
@@ -87,7 +87,7 @@ Run from worktree root:
 
 ### 8. Compound
 
-Read `@_shared/compound-on-exit.md`. On clean completion, load the compound skill exactly once. No invocation on abort or early exit.
+Read `@_shared/compound-on-exit.md`. On clean completion, load the "compound" skill exactly once. No invocation on abort or early exit.
 
 ### 9. Finalize
 

--- a/commands/define.md
+++ b/commands/define.md
@@ -2,7 +2,6 @@
 name: define
 description: Lead definition phase — resolve architecture and design technical decisions.
 agent: define-orchestrator
-compatibility: claude-code opencode
 ---
 <command kind="define" type="interactive">
 <arguments raw="$ARGUMENTS" />

--- a/commands/define.md
+++ b/commands/define.md
@@ -1,0 +1,19 @@
+---
+name: define
+description: Lead definition phase — resolve architecture and design technical decisions.
+agent: define-orchestrator
+compatibility: claude-code opencode
+---
+<command kind="define" type="interactive">
+<arguments raw="$ARGUMENTS" />
+
+<instruction>
+You are the define orchestrator. Run the full definition phase: transform an approved issue with acceptance criteria into a concrete implementation plan with architecture and design decisions.
+
+If $ARGUMENTS is empty or too vague to act on, use the question tool to ask the user which issue to work on. Otherwise, $ARGUMENTS is the issue number.
+</instruction>
+
+<loop type="interactive" verifier="human">
+This is an interactive clarify-before-act loop. The human closes each cycle with explicit approval. No autonomous cap.
+</loop>
+</command>

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -1,0 +1,19 @@
+---
+name: discover
+description: Full discovery phase — explore a problem and produce a GitHub issue with AC.
+agent: discover-orchestrator
+compatibility: claude-code opencode
+---
+<command kind="discover" type="interactive">
+<arguments raw="$ARGUMENTS" />
+
+<instruction>
+You are the discover orchestrator. Run the full discovery phase: transform a vague problem into a well-specified GitHub issue with acceptance criteria.
+
+If $ARGUMENTS is empty or too vague to act on, use the question tool to ask the user what problem to explore. Otherwise, $ARGUMENTS is the issue number or problem description to work from.
+</instruction>
+
+<loop type="interactive" verifier="human">
+This is an interactive clarify-before-act loop. The human closes each cycle with explicit approval. No autonomous cap.
+</loop>
+</command>

--- a/commands/discover.md
+++ b/commands/discover.md
@@ -2,7 +2,6 @@
 name: discover
 description: Full discovery phase — explore a problem and produce a GitHub issue with AC.
 agent: discover-orchestrator
-compatibility: claude-code opencode
 ---
 <command kind="discover" type="interactive">
 <arguments raw="$ARGUMENTS" />

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -1,0 +1,19 @@
+---
+name: implement
+description: Full implementation cycle — build, review, and verify, then open a PR.
+agent: implement-orchestrator
+compatibility: claude-code opencode
+---
+<command kind="implement" type="autonomous">
+<arguments raw="$ARGUMENTS" />
+
+<instruction>
+You are the implement orchestrator. Run the full implementation cycle: drive build-to-review-to-verify loops in the main conversation, then open a draft PR. You own the process — you are not a thin delegator.
+
+If $ARGUMENTS is empty or too vague to act on, use the question tool to ask the user which issue to implement. Otherwise, $ARGUMENTS is the issue number.
+</instruction>
+
+<loop type="bounded-autonomous" verifier="machine" max_cycles="5">
+This is a bounded autonomous loop. Verify against acceptance criteria each cycle via subagent. Cap at max_cycles. Human only at terminal gate. Never silent-yield.
+</loop>
+</command>

--- a/commands/implement.md
+++ b/commands/implement.md
@@ -2,7 +2,6 @@
 name: implement
 description: Full implementation cycle — build, review, and verify, then open a PR.
 agent: implement-orchestrator
-compatibility: claude-code opencode
 ---
 <command kind="implement" type="autonomous">
 <arguments raw="$ARGUMENTS" />

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -10,40 +10,40 @@ Lifecycle walkthrough from discovery to closure.
 |**Large**|`/discover` → `/define` → `/implement`|Issue Body → Issue Body → PR|
 
 **State Management**:
-- **Inter-phase**: GitHub issue body (5-field structure — invoke `Read _shared/handoff-artifact.md`).
-- **Intra-phase**: `./.claude/NOTES.md` (invoke `Read _shared/notes-md-protocol.md`).
-- **Context Pressure**: Invoke `Skill("compaction-protocol")` for Edit → Delegate → Compact strategy.
+- **Inter-phase**: GitHub issue body (5-field structure — invoke `Read @_shared/handoff-artifact.md`).
+- **Intra-phase**: `./.claude/NOTES.md` (invoke `Read @_shared/notes-md-protocol.md`).
+- **Context Pressure**: Load the compaction-protocol skill for Edit → Delegate → Compact strategy.
 
 ## Phase Details
 
-### 1. `/discover` (Opus, High)
+### 1. `/discover`
 **Goal**: Vague idea → well-specified GitHub issue.
-- **Process**: Delegate to `/describe` (research, PPT, visuals) → `/specify` (AC generation).
+- **Process**: Discover orchestrator loads describe skill (research, visuals) → specify skill (AC generation).
 - **Output**: Issue with **Problem statement** + **Handoff block** (AC, Constraints, Decisions, Evidence, Questions).
 - **Gate**: Explicit user approval of issue body.
 - **Next**: `/define` (Large) or `/implement` (Medium).
 
-### 2. `/define` (Opus, High) — _Large features only_
+### 2. `/define`
 **Goal**: Approved issue → technical implementation plan.
-- **Process**: Research → `/architecture` → `/design` (if visual).
+- **Process**: Define orchestrator loads architecture skill → design skill (if visual).
 - **Output**: Update issue with `## Implementation plan` (decisions, visuals, sub-issues, dependency graph).
 - **Gate**: Explicit user approval of decisions.
 - **Next**: `/implement`.
 
-### 3. `/implement` (Sonnet)
+### 3. `/implement`
 **Goal**: Defined issue → ready-to-merge PR.
 - **Design Gate**: Verify `## Implementation plan` exists. If absent → prompt for `/define` or trivial downgrade.
-- **Cycle**: Autonomous build → review → verify → fix loop (max 3 cycles).
-  - `/build`: TDD implementation.
-  - `/review`: Isolated specialist review (Correctness, Standards, etc.).
-  - `/verify`: QA verification of AC with evidence.
+- **Cycle**: Autonomous build → review → verify → fix loop (max 5 cycles).
+   - Build via task tool (`workflow-build-worker`): TDD implementation.
+   - Review via task tool (`workflow-review-runner`): isolated specialist review.
+   - Verify via task tool (`workflow-verify-runner`): QA verification of AC with evidence.
 - **Output**: Draft PR.
   - **Body**: `## Summary` → `## Testing notes` → `## Notes` (from NOTES.md harvest).
 - **Closure**: `/compound` runs automatically → file learnings to wiki.
 
 ### 4. Maintenance & Utilities
 - **`/resolve-pr-feedback`**: Triage → Fix → Reply to human review comments.
-- **`/compound`**: Extract learnings → `/save` to Obsidian vault.
+- **`/compound`**: Extract learnings → file to wiki (via `/save` when agents-memo is installed).
 - **`/prune`**: Audit rules, authoring quality, and vault staleness.
 - **`/audit-issues`**: Detect drift between open issues and current repo state.
 - **`/wrap-up`**: Clean up worktree and branch.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -33,10 +33,12 @@ Lifecycle walkthrough from discovery to closure.
 ### 3. `/implement`
 **Goal**: Defined issue → ready-to-merge PR.
 - **Design Gate**: Verify `## Implementation plan` exists. If absent → prompt for `/define` or trivial downgrade.
-- **Cycle**: Autonomous build → review → verify → fix loop (max 5 cycles).
+- **Scope**: Partition work units by the plan's dependency graph — independent groups run in parallel (one worktree each); dependent groups run in topological order; non-independent work falls back to sequential.
+- **Cycle** (per group): Autonomous build → review → verify → fix loop (max 5 cycles).
    - Build via task tool (`workflow-build-worker`): TDD implementation.
    - Review via task tool (`workflow-review-runner`): isolated specialist review.
    - Verify via task tool (`workflow-verify-runner`): QA verification of AC with evidence.
+- **Integration**: Merge parallel group branches, then a final review + verify pass on the merged tree before the PR.
 - **Output**: Draft PR.
   - **Body**: `## Summary` → `## Testing notes` → `## Notes` (from NOTES.md harvest).
 - **Closure**: `/compound` runs automatically → file learnings to wiki.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -12,7 +12,7 @@ Lifecycle walkthrough from discovery to closure.
 **State Management**:
 - **Inter-phase**: GitHub issue body (5-field structure — invoke `Read @_shared/handoff-artifact.md`).
 - **Intra-phase**: `./.claude/NOTES.md` (invoke `Read @_shared/notes-md-protocol.md`).
-- **Context Pressure**: Load the compaction-protocol skill for Edit → Delegate → Compact strategy.
+- **Context Pressure**: Load the "compaction-protocol" skill for Edit → Delegate → Compact strategy.
 
 ## Phase Details
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -18,14 +18,14 @@ Lifecycle walkthrough from discovery to closure.
 
 ### 1. `/discover`
 **Goal**: Vague idea → well-specified GitHub issue.
-- **Process**: Discover orchestrator loads describe skill (research, visuals) → specify skill (AC generation).
+- **Process**: Discover orchestrator loads "describe" skill (research, visuals) → "specify" skill (AC generation).
 - **Output**: Issue with **Problem statement** + **Handoff block** (AC, Constraints, Decisions, Evidence, Questions).
 - **Gate**: Explicit user approval of issue body.
 - **Next**: `/define` (Large) or `/implement` (Medium).
 
 ### 2. `/define`
 **Goal**: Approved issue → technical implementation plan.
-- **Process**: Define orchestrator loads architecture skill → design skill (if visual).
+- **Process**: Define orchestrator loads "architecture" skill → "design" skill (if visual).
 - **Output**: Update issue with `## Implementation plan` (decisions, visuals, sub-issues, dependency graph).
 - **Gate**: Explicit user approval of decisions.
 - **Next**: `/implement`.

--- a/skills/implement/references/scope-cycles.md
+++ b/skills/implement/references/scope-cycles.md
@@ -7,10 +7,10 @@
 3. **`/verify`**: QA team → verifies every AC.
 4. **Evaluation**:
    - **Clean pass** → PR creation.
-   - **Findings present & cycles < 3** → Package **fix brief** (failing AC + `file:line` findings) in `./.claude/NOTES.md`. Invoke `Skill("compaction-protocol")` to format concisely. Resume `/build` → `/review` → `/verify`.
-   - **Cycles = 3** → PR creation → surface remaining findings in Finalize.
+   - **Findings present & cycles < 5** → Package **fix brief** (failing AC + `file:line` findings) in `./.claude/NOTES.md`. Resume build → review → verify.
+   - **Cycles = 5** → PR creation → surface remaining findings in Finalize.
 
-**Reporting**: Emit one status line per cycle: `Cycle N/3 — /build <state>, /review <n findings>, /verify <n failures>`.
+**Reporting**: Emit one status line per cycle: `Cycle N/<max_cycles> — build <state>, review <n findings>, verify <n failures>`.
 
 ## PR Creation & Finalize
 
@@ -26,6 +26,6 @@ Run from worktree root.
 ### Finalize
 
 - **Clean exit** → present PR URL.
-- **Exhausted exit** (3 cycles, findings remain):
+- **Exhausted exit** (5 cycles, findings remain):
   - PR URL + findings → binary question: "Continue loop, or accept and close?"
     - **Continue** → One more cycle → log escalation in PR `## Notes` → return to Finalize.


### PR DESCRIPTION
closes #230 
Summary: Add three opencode lifecycle commands (discover, define, implement) and their mode: primary orchestrator agents. Part of S3 rebuild.